### PR TITLE
Add application extensions.

### DIFF
--- a/api/application.go
+++ b/api/application.go
@@ -189,6 +189,7 @@ type Application struct {
 	Name            string      `json:"name" binding:"required"`
 	Description     string      `json:"description"`
 	Repository      *Repository `json:"repository"`
+	Extensions      Extensions  `json:"extensions"`
 	Review          *Review     `json:"review"`
 	Comments        string      `json:"comments"`
 	Tags            []string    `json:"tags"`
@@ -203,6 +204,7 @@ func (r *Application) With(m *model.Application) {
 	r.Description = m.Description
 	r.Comments = m.Comments
 	_ = json.Unmarshal(m.Repository, &r.Repository)
+	_ = json.Unmarshal(m.Extensions, &r.Extensions)
 	if m.Review != nil {
 		r.Review = &Review{Resource: Resource{ID: m.Review.ID}}
 	}
@@ -225,6 +227,9 @@ func (r *Application) Model() (m *model.Application) {
 	m.ID = r.ID
 	if r.Repository != nil {
 		m.Repository, _ = json.Marshal(r.Repository)
+	}
+	if r.Extensions != nil {
+		m.Extensions, _ = json.Marshal(r.Extensions)
 	}
 	if len(r.BusinessService) > 0 {
 		id, _ := strconv.Atoi(r.BusinessService)
@@ -253,3 +258,7 @@ type Repository struct {
 	Tag    string `json:"tag"`
 	Path   string `json:"path"`
 }
+
+//
+// Extensions of the application.
+type Extensions map[string]interface{}

--- a/hack/add/application.sh
+++ b/hack/add/application.sh
@@ -42,6 +42,9 @@ curl -X POST ${host}/application-inventory/application -d \
       "url": "https://github.com/konveyor/tackle2-pathfinder.git",
       "branch": "1.2.0"
     },
+    "extensions": {
+      "binary": "pathfinder.jar"
+    },
     "businessService": "1"
 }' | jq -M .
 

--- a/model/application.go
+++ b/model/application.go
@@ -8,6 +8,7 @@ type Application struct {
 	Description       string
 	Review            *Review
 	Repository        JSON
+	Extensions        JSON
 	Comments          string
 	Tags              []Tag      `gorm:"many2many:applicationTags"`
 	Identities        []Identity `gorm:"many2many:appIdentity"`


### PR DESCRIPTION
Add Application.Extensions to support application _type_ specific properties.
Needed for MVN coordinates for java application binaries.
Also, suggested that it would be useful for plugins to augment the application with information not suitable for buckets.