### PR TITLE
GET/POST with value as body

### DIFF
--- a/api/setting.go
+++ b/api/setting.go
@@ -38,7 +38,7 @@ func (h SettingHandler) AddRoutes(e *gin.Engine) {
 // @description Get a setting by its key.
 // @tags get, setting
 // @produce json
-// @success 200 {object} api.Setting
+// @success 200 {object}
 // @router /settings/{key} [get]
 // @param key path string true "Key"
 func (h SettingHandler) Get(ctx *gin.Context) {
@@ -52,7 +52,7 @@ func (h SettingHandler) Get(ctx *gin.Context) {
 	r := Setting{}
 	r.With(setting)
 
-	ctx.JSON(http.StatusOK, r)
+	ctx.JSON(http.StatusOK, r.Value)
 }
 
 // List godoc
@@ -138,13 +138,13 @@ func (h SettingHandler) Update(ctx *gin.Context) {
 		return
 	}
 
-	updates := &Setting{}
-	err := ctx.BindJSON(updates)
+	updates := Setting{}
+	updates.Key = key
+	err := ctx.BindJSON(&updates.Value)
 	if err != nil {
 		h.bindFailed(ctx, err)
 		return
 	}
-	updates.Key = key
 
 	m := updates.Model()
 	db := h.DB.Model(&model.Setting{})


### PR DESCRIPTION
Small change to support GET and PUT body begin the setting value.

Example:
```
curl -s -X PUT localhost:8080/settings/git.insecure.enabled -d "true"
curl -s -X GET localhost:8080/settings/git.insecure.enabled
true
```

The POST (create) body will continue to be `api.Setting`.
The GET (list) result will continue to be `[]api.Setting`.