### PR TITLE
Better support managing app-identity associations.

### DIFF
--- a/api/base.go
+++ b/api/base.go
@@ -222,3 +222,17 @@ func (r *Resource) With(m *model.Model) {
 	r.UpdateUser = m.UpdateUser
 	r.CreateTime = m.CreateTime
 }
+
+//
+// Ref represents a FK.
+// Contains the PK and (name) natural key.
+// The name is read-only.
+type Ref struct {
+	ID   uint   `json:"id" binding:"required"`
+	Name string `json:"name"`
+}
+
+func (r *Ref) With(id uint, name string) {
+	r.ID = id
+	r.Name = name
+}

--- a/hack/add/all.sh
+++ b/hack/add/all.sh
@@ -10,12 +10,12 @@ dir=`dirname $0`
 cd ${dir}
 
 ./tag.sh
+./identity.sh
 ./job-function.sh
 ./stakeholder-group.sh
 ./stakeholder.sh
 ./business-service.sh
 ./application.sh
 ./review.sh
-./identity.sh
 ./proxy.sh
 

--- a/hack/add/application.sh
+++ b/hack/add/application.sh
@@ -8,6 +8,10 @@ curl -X POST ${host}/application-inventory/application -d \
     "name":"Dog",
     "description": "Dog application.",
     "businessService": "1",
+    "identities": [
+      {"id":1},
+      {"id":2}
+    ],
     "tags":[
       "1",
       "2"

--- a/hack/add/identity.sh
+++ b/hack/add/identity.sh
@@ -4,22 +4,19 @@ host="${HOST:-localhost:8080}"
 
 curl -X POST ${host}/identities -d \
 '{
-    "createUser": "tackle",
     "kind": "git",
-    "name":"jeff",
+    "name":"test-git",
     "description": "Forklift",
     "user": "userA",
     "password": "passwordA",
     "key": "keyA",
-    "settings": "settingsA",
-    "application": 1
+    "settings": "settingsA"
 }' | jq -M .
 
-curl -X POST ${host}/application-inventory/application/1/identities -d \
+curl -X POST ${host}/identities -d \
 '{
-    "createUser": "tackle",
     "kind": "mvn",
-    "name":"jeff-mvn",
+    "name":"test-mvn",
     "description": "Forklift",
     "user": "userA",
     "password": "passwordA",

--- a/model/identity.go
+++ b/model/identity.go
@@ -8,18 +8,16 @@ import (
 
 //
 // Identity represents and identity with a set of credentials.
-// Kinds = (git|svn|mvn|proxy)
 type Identity struct {
 	Model
-	Kind          string `gorm:"not null"`
-	Name          string `gorm:"not null"`
-	Description   string
-	User          string
-	Password      string
-	Key           string
-	Settings      string
-	Encrypted     string
-	ApplicationID uint `gorm:"many2many:appIdentity"`
+	Kind        string `gorm:"not null"`
+	Name        string `gorm:"not null"`
+	Description string
+	User        string
+	Password    string
+	Key         string
+	Settings    string
+	Encrypted   string
 }
 
 //


### PR DESCRIPTION
Better support managing app-identity associations.
Identities are _many-2-many_ with applications.  They need to be managed like:

1. create identities.
2. create applications with identity FKs listed.
and/or
2. update application with updated identity FKs listed.

The association needs to be managed from the application.  Essentially, manage the association like we do for Tags.

---

Adds `Ref` for FKs.