### PR TITLE
addon: use workingDir as home.

### DIFF
--- a/addon/adapter.go
+++ b/addon/adapter.go
@@ -105,6 +105,12 @@ func (h *Adapter) Client() *Client {
 // newAdapter builds a new Addon Adapter object.
 func newAdapter() (adapter *Adapter) {
 	//
+	// Working directory.
+	wDir := Settings.Path.WorkingDir
+	_ = os.MkdirAll(wDir, 0755)
+	_ = os.Setenv("HOME", wDir)
+	_ = os.Chdir(wDir)
+	//
 	// Load secret.
 	secret := &task.Secret{}
 	b, err := os.ReadFile(Settings.Addon.Path.Secret)

--- a/settings/addon.go
+++ b/settings/addon.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	EnvAddonSecretPath = "ADDON_SECRET_PATH"
-	EnvWorkingDirPath  = "ADDON_WORKINGDIR_PATH"
+	EnvAddonWorkingDir = "ADDON_WORKING_DIR"
 	EnvHubBaseURL      = "HUB_BASE_URL"
 )
 
@@ -42,7 +42,7 @@ func (r *Addon) Load() (err error) {
 	if !found {
 		r.Path.Secret = "/tmp/secret.json"
 	}
-	r.Path.WorkingDir, found = os.LookupEnv(EnvWorkingDirPath)
+	r.Path.WorkingDir, found = os.LookupEnv(EnvAddonWorkingDir)
 	if !found {
 		r.Path.WorkingDir = "/tmp"
 	}

--- a/task/manager.go
+++ b/task/manager.go
@@ -328,7 +328,7 @@ func (r *Task) container() (container core.Container) {
 				Value: Settings.Addon.Path.Secret,
 			},
 			{
-				Name:  settings.EnvWorkingDirPath,
+				Name:  settings.EnvAddonWorkingDir,
 				Value: Settings.Addon.Path.WorkingDir,
 			},
 		},


### PR DESCRIPTION
addon: use workingDir as home.
The workingDir will be a mounted volume.  We don't want to depend on the elasticity of the _tmpfs_.
This also needs to be the _home_ directory because some CLI tools write files to $HOME by default.