### PR TITLE
Fix identity updates.

### DIFF
--- a/api/identity.go
+++ b/api/identity.go
@@ -148,10 +148,9 @@ func (h IdentityHandler) Update(ctx *gin.Context) {
 		return
 	}
 	m := r.Model()
-	db := h.DB.Model(&Identity{})
+	db := h.DB.Model(m)
 	db = db.Where("id", id)
-	db = db.Omit("id")
-	result := db.Updates(m)
+	result := db.Updates(h.fields(m))
 	if result.Error != nil {
 		h.updateFailed(ctx, result.Error)
 		return

--- a/api/task.go
+++ b/api/task.go
@@ -242,16 +242,9 @@ func (h TaskHandler) UpdateReport(ctx *gin.Context) {
 	task, _ := strconv.Atoi(id)
 	report.TaskID = uint(task)
 	m := report.Model()
-	db := h.DB.Model(&model.TaskReport{})
+	db := h.DB.Model(m)
 	db = db.Where("taskid", task)
-	result := db.Updates(
-		map[string]interface{}{
-			"status":    m.Status,
-			"error":     m.Error,
-			"total":     m.Total,
-			"completed": m.Completed,
-			"activity":  m.Activity,
-		})
+	result := db.Updates(h.fields(m))
 	if result.Error != nil {
 		h.updateFailed(ctx, result.Error)
 	}

--- a/hack/delete/application.sh
+++ b/hack/delete/application.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+host="${HOST:-localhost:8080}"
+
+# ID to delete (default:1)
+id="${1:-1}"
+
+curl -X DELETE ${host}/application-inventory/application/${id}
+

--- a/hack/update/identity.sh
+++ b/hack/update/identity.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+host="${HOST:-localhost:8080}"
+
+curl -X PUT ${host}/identities/1 -d \
+'{
+    "kind": "git",
+    "name":"test-git",
+    "description": "Forklift",
+    "user": "userB",
+    "password": "passwordB",
+    "key": "keyA",
+    "settings": "settingsB"
+}' | jq -M .
+

--- a/model/base.go
+++ b/model/base.go
@@ -7,8 +7,8 @@ import (
 //
 // Model Base model.
 type Model struct {
-	ID         uint `gorm:"primaryKey"`
-	CreateUser string
+	ID         uint      `gorm:"<-:create;primaryKey"`
+	CreateTime time.Time `gorm:"<-:create;autoCreateTime"`
+	CreateUser string    `gorm:"<-:create"`
 	UpdateUser string
-	CreateTime time.Time `gorm:"autoCreateTime"`
 }

--- a/model/identity.go
+++ b/model/identity.go
@@ -74,6 +74,13 @@ func (r *Identity) BeforeSave(tx *gorm.DB) (err error) {
 }
 
 //
+// BeforeUpdate ensure encrypted.
+func (r *Identity) BeforeUpdate(tx *gorm.DB) (err error) {
+	err = r.Encrypt(Settings.Encryption.Passphrase)
+	return
+}
+
+//
 // encrypted returns the encrypted credentials.
 func (r *Identity) encrypted(passphrase string) (encrypted *Identity, err error) {
 	aes := encryption.New(passphrase)

--- a/model/task.go
+++ b/model/task.go
@@ -11,18 +11,18 @@ type TaskReport struct {
 	Total     int
 	Completed int
 	Activity  JSON
-	TaskID    uint `gorm:"uniqueIndex"`
+	TaskID    uint `gorm:"<-:create;uniqueIndex"`
 	Task      *Task
 }
 
 type Task struct {
 	Model
-	Name       string `gorm:"index"`
-	Addon      string `gorm:"index"`
-	Locator    string `gorm:"index"`
-	Image      string
-	Isolated   bool
-	Data       JSON
+	Name       string `gorm:"<-:create;index"`
+	Addon      string `gorm:"<-:create;index"`
+	Locator    string `gorm:"<-:create;index"`
+	Image      string `gorm:"<-:create"`
+	Isolated   bool   `gorm:"<-:create"`
+	Data       JSON   `gorm:"<-:create"`
 	Started    *time.Time
 	Terminated *time.Time
 	Status     string


### PR DESCRIPTION
When using db.Updates(), the hooks are not fired which in this case is really bad since the BeforeSave() ensures fields are encrypted.

Also revert part of https://github.com/konveyor/tackle2-hub/pull/6.  Somehow, the changed $HOME was not respected by maven.  Found a simpler approach.

Add `Handler.fields()` method using to build a _map_ of a model's fields.  Considered adding `BaseModel.Map()` but since go does not support polymorphism, The receiver IsA BaseModel not the concrete type.

Refit the TaskHandler.Update() to use fields().