### PR TITLE
Resource ref() and refPtr() using reflect instead of Named interface.

### DIFF
--- a/api/base.go
+++ b/api/base.go
@@ -229,24 +229,21 @@ func (r *Resource) With(m *model.Model) {
 
 //
 // ref with id and named model.
-func (r *Resource) ref(id uint, m Named) (ref Ref) {
+func (r *Resource) ref(id uint, m interface{}) (ref Ref) {
 	ref.ID = id
-	if m != nil {
-		ref.Name = m.GetName()
-	}
+	ref.Name = r.nameOf(m)
 	return
 }
 
 //
 // refPtr with id and named model.
-func (r *Resource) refPtr(id *uint, m Named) (ref *Ref) {
+func (r *Resource) refPtr(id *uint, m interface{}) (ref *Ref) {
 	if id == nil {
 		return
 	}
-	ref = &Ref{ID: *id}
-	if m != nil {
-		ref.Name = m.GetName()
-	}
+	ref = &Ref{}
+	ref.ID = *id
+	ref.Name = r.nameOf(m)
 	return
 }
 
@@ -260,9 +257,27 @@ func (r *Resource) idPtr(ref *Ref) (id *uint) {
 }
 
 //
-// Named model.
-type Named interface {
-	GetName() string
+// nameOf model.
+func (r *Resource) nameOf(m interface{}) (name string) {
+	mt := reflect.TypeOf(m)
+	mv := reflect.ValueOf(m)
+	if mv.IsNil() {
+		return
+	}
+	if mt.Kind() == reflect.Ptr {
+		mt = mt.Elem()
+		mv = mv.Elem()
+	}
+	for i := 0; i < mt.NumField(); i++ {
+		ft := mt.Field(i)
+		fv := mv.Field(i)
+		switch ft.Name {
+		case "Name":
+			name = fv.String()
+			return
+		}
+	}
+	return
 }
 
 //

--- a/model/application.go
+++ b/model/application.go
@@ -10,15 +10,11 @@ type Application struct {
 	Repository        JSON
 	Extensions        JSON
 	Comments          string
-	Buckets           []Bucket
-	Tags              []Tag      `gorm:"many2many:applicationTags"`
-	Identities        []Identity `gorm:"many2many:appIdentity"`
+	Buckets           []Bucket   `gorm:"constraint:OnDelete:CASCADE"`
+	Tags              []Tag      `gorm:"many2many:applicationTags;constraint:OnDelete:CASCADE"`
+	Identities        []Identity `gorm:"many2many:appIdentity;constraint:OnDelete:CASCADE"`
 	BusinessServiceID uint       `gorm:"index"`
 	BusinessService   *BusinessService
-}
-
-func (r *Application) GetName() string {
-	return r.Name
 }
 
 type Dependency struct {

--- a/model/identity.go
+++ b/model/identity.go
@@ -21,10 +21,6 @@ type Identity struct {
 	Encrypted   string
 }
 
-func (r *Identity) GetName() string {
-	return r.Name
-}
-
 //
 // Encrypt sensitive fields.
 func (r *Identity) Encrypt(passphrase string) (err error) {


### PR DESCRIPTION
The m == nil  will always result to false because `m` passed in as an interface.
Since one of the main values are the `nil` checks, it seemed this is the only approach that makes it worth using.  Also eliminates the annoying GetName() on all the models.