### PR TITLE
Add Task.Application as optional FK.

### DIFF
--- a/addon/task.go
+++ b/addon/task.go
@@ -19,6 +19,19 @@ type Task struct {
 }
 
 //
+// Application returns the application associated with the task.
+func (h *Task) Application() (r *api.Application, err error) {
+	id := h.secret.Hub.Application
+	if id == nil {
+		err = NotFound{}
+	}
+	r = &api.Application{}
+	path := Params{api.ID: *id}.inject(api.ApplicationRoot)
+	err = h.client.Get(path, r)
+	return
+}
+
+//
 // Data returns the addon data.
 func (h *Task) Data() (d map[string]interface{}) {
 	d = h.secret.Addon.(map[string]interface{})

--- a/api/bucket.go
+++ b/api/bucket.go
@@ -16,19 +16,19 @@ type BucketHandler struct {
 
 //
 // content at path.
-func (h *BucketHandler) content(ctx *gin.Context, bucket *model.Bucket) {
+func (h *BucketHandler) content(ctx *gin.Context, owner *model.BucketOwner) {
 	rPath := ctx.Param(Wildcard)
 	ctx.File(pathlib.Join(
-		bucket.Path,
+		owner.Bucket,
 		rPath))
 }
 
 //
 // upload file at path.
-func (h *BucketHandler) upload(ctx *gin.Context, bucket *model.Bucket) {
+func (h *BucketHandler) upload(ctx *gin.Context, owner *model.BucketOwner) {
 	rPath := ctx.Param(Wildcard)
 	path := pathlib.Join(
-		bucket.Path,
+		owner.Bucket,
 		rPath)
 	input, err := ctx.FormFile("file")
 	if err != nil {

--- a/api/task.go
+++ b/api/task.go
@@ -252,7 +252,7 @@ func (h TaskHandler) Content(ctx *gin.Context) {
 		h.getFailed(ctx, result.Error)
 		return
 	}
-	h.content(ctx, &m.Bucket)
+	h.content(ctx, &m.BucketOwner)
 }
 
 // Upload godoc
@@ -272,7 +272,7 @@ func (h TaskHandler) Upload(ctx *gin.Context) {
 		return
 	}
 
-	h.upload(ctx, &m.Bucket)
+	h.upload(ctx, &m.BucketOwner)
 }
 
 // CreateReport godoc
@@ -360,19 +360,21 @@ func (h TaskHandler) DeleteReport(ctx *gin.Context) {
 // Task REST resource.
 type Task struct {
 	Resource
-	Name       string      `json:"name"`
-	Locator    string      `json:"locator"`
-	Isolated   bool        `json:"isolated,omitempty"`
-	Addon      string      `json:"addon,omitempty"`
-	Data       interface{} `json:"data" swaggertype:"object"`
-	Status     string      `json:"status"`
-	Image      string      `json:"image,omitempty"`
-	Bucket     string      `json:"bucket"`
-	Started    *time.Time  `json:"started,omitempty"`
-	Terminated *time.Time  `json:"terminated,omitempty"`
-	Error      string      `json:"error,omitempty"`
-	Job        string      `json:"job,omitempty"`
-	Report     *TaskReport `json:"report,omitempty"`
+	Name        string      `json:"name"`
+	Locator     string      `json:"locator"`
+	Isolated    bool        `json:"isolated,omitempty"`
+	Addon       string      `json:"addon,omitempty"`
+	Data        interface{} `json:"data" swaggertype:"object"`
+	Application *Ref        `json:"application"`
+	Status      string      `json:"status"`
+	Image       string      `json:"image,omitempty"`
+	Bucket      string      `json:"bucket"`
+	Purged      bool        `json:"purged,omitempty"`
+	Started     *time.Time  `json:"started,omitempty"`
+	Terminated  *time.Time  `json:"terminated,omitempty"`
+	Error       string      `json:"error,omitempty"`
+	Job         string      `json:"job,omitempty"`
+	Report      *TaskReport `json:"report,omitempty"`
 }
 
 //
@@ -384,7 +386,9 @@ func (r *Task) With(m *model.Task) {
 	r.Addon = m.Addon
 	r.Locator = m.Locator
 	r.Isolated = m.Isolated
-	r.Bucket = m.Bucket.Path
+	r.Application = r.refPtr(m.ApplicationID, m.Application)
+	r.Bucket = m.Bucket
+	r.Purged = m.Purged
 	r.Status = m.Status
 	r.Started = m.Started
 	r.Terminated = m.Terminated
@@ -402,10 +406,11 @@ func (r *Task) With(m *model.Task) {
 // Model builds a model.
 func (r *Task) Model() (m *model.Task) {
 	m = &model.Task{
-		Name:     r.Name,
-		Addon:    r.Addon,
-		Locator:  r.Locator,
-		Isolated: r.Isolated,
+		Name:          r.Name,
+		Addon:         r.Addon,
+		Locator:       r.Locator,
+		Isolated:      r.Isolated,
+		ApplicationID: r.idPtr(r.Application),
 	}
 	m.Data, _ = json.Marshal(r.Data)
 	m.ID = r.ID

--- a/api/taskgroup.go
+++ b/api/taskgroup.go
@@ -293,7 +293,7 @@ func (h TaskGroupHandler) Content(ctx *gin.Context) {
 		h.getFailed(ctx, result.Error)
 		return
 	}
-	h.content(ctx, &m.Bucket)
+	h.content(ctx, &m.BucketOwner)
 }
 
 // Upload godoc
@@ -313,7 +313,7 @@ func (h TaskGroupHandler) Upload(ctx *gin.Context) {
 		return
 	}
 
-	h.upload(ctx, &m.Bucket)
+	h.upload(ctx, &m.BucketOwner)
 }
 
 //
@@ -324,6 +324,7 @@ type TaskGroup struct {
 	Addon  string      `json:"addon"`
 	Data   interface{} `json:"data" swaggertype:"object"`
 	Bucket string      `json:"bucket"`
+	Purged bool        `json:"purged,omitempty"`
 	Tasks  []Task      `json:"tasks"`
 }
 
@@ -333,7 +334,8 @@ func (r *TaskGroup) With(m *model.TaskGroup) {
 	r.Resource.With(&m.Model)
 	r.Name = m.Name
 	r.Addon = m.Addon
-	r.Bucket = m.Bucket.Path
+	r.Bucket = m.Bucket
+	r.Purged = m.Purged
 	r.Tasks = []Task{}
 	for _, task := range m.Tasks {
 		member := Task{}
@@ -349,8 +351,9 @@ func (r *TaskGroup) With(m *model.TaskGroup) {
 // Model builds a model.
 func (r *TaskGroup) Model() (m *model.TaskGroup) {
 	m = &model.TaskGroup{
-		Name:  r.Name,
-		Addon: r.Addon,
+		Name:   r.Name,
+		Addon:  r.Addon,
+		Purged: r.Purged,
 	}
 	for _, task := range r.Tasks {
 		member := *task.Model()

--- a/hack/add/task.sh
+++ b/hack/add/task.sh
@@ -7,8 +7,8 @@ curl -X POST ${host}/tasks -d \
     "name":"Test",
     "locator": "app.1.test",
     "addon": "test",
+    "application": {"id": 1},
     "data": {
-      "application": 1,
       "path": "/etc"
     }
 }' | jq -M .

--- a/hack/cmd/addon/main.go
+++ b/hack/cmd/addon/main.go
@@ -37,7 +37,7 @@ func main() {
 		}
 		//
 		// Get application.
-		application, err := addon.Application.Get(d.Application)
+		application, err := addon.Task.Application()
 		if err != nil {
 			return
 		}
@@ -59,7 +59,7 @@ func main() {
 		}
 		//
 		// Tag
-		err = tag(d)
+		err = tag(d, application)
 		if err != nil {
 			return
 		}
@@ -191,10 +191,7 @@ func find(path string, max int) (paths []string, err error) {
 
 //
 // Tag application.
-func tag(d *Data) (err error) {
-	//
-	// Fetch application.
-	application, _ := addon.Application.Get(d.Application)
+func tag(d *Data, application *api.Application) (err error) {
 	//
 	// Create tag.
 	tag := &api.Tag{}
@@ -222,8 +219,6 @@ func tag(d *Data) (err error) {
 //
 // Data Addon data passed in the secret.
 type Data struct {
-	// Application ID.
-	Application uint `json:"application"`
 	// Path to be listed.
 	Path string `json:"path"`
 	// Delay on error (minutes).

--- a/hack/cmd/addon/secret.json
+++ b/hack/cmd/addon/secret.json
@@ -1,1 +1,1 @@
-{"Hub":{"Task":1,"Encryption":{"Passphrase": "tackle"},"Token": "xx"},"Addon":{"application":1, "path":"/etc"}}
+{"Hub":{"Task":1,"Application": 1,"Encryption":{"Passphrase": "tackle"},"Token": "xx"},"Addon":{"path":"/etc"}}

--- a/model/application.go
+++ b/model/application.go
@@ -4,13 +4,15 @@ import "fmt"
 
 type Application struct {
 	Model
-	Bucket
+	BucketOwner
 	Name              string `gorm:"index;unique;not null"`
 	Description       string
 	Review            *Review
 	Repository        JSON
+	Binary            string
 	Facts             JSON
 	Comments          string
+	Tasks             []Task     `gorm:"constraint:OnDelete:CASCADE"`
 	Tags              []Tag      `gorm:"many2many:applicationTags"`
 	Identities        []Identity `gorm:"many2many:appIdentity"`
 	BusinessServiceID uint       `gorm:"index"`

--- a/model/pkg.go
+++ b/model/pkg.go
@@ -30,7 +30,6 @@ func All() []interface{} {
 		Stakeholder{},
 		BusinessService{},
 		Application{},
-		Bucket{},
 		Dependency{},
 		Review{},
 		Identity{},

--- a/model/task.go
+++ b/model/task.go
@@ -19,21 +19,24 @@ type TaskReport struct {
 
 type Task struct {
 	Model
-	Bucket
-	Name        string `gorm:"index"`
-	Addon       string `gorm:"index"`
-	Locator     string `gorm:"index"`
-	Image       string
-	Isolated    bool
-	Data        JSON
-	Started     *time.Time
-	Terminated  *time.Time
-	Status      string
-	Error       string
-	Job         string
-	Report      *TaskReport `gorm:"constraint:OnDelete:CASCADE"`
-	TaskGroupID *uint       `gorm:"<-:create"`
-	TaskGroup   *TaskGroup
+	BucketOwner
+	Name          string `gorm:"index"`
+	Addon         string `gorm:"index"`
+	Locator       string `gorm:"index"`
+	Image         string
+	Isolated      bool
+	Data          JSON
+	Started       *time.Time
+	Terminated    *time.Time
+	Status        string
+	Error         string
+	Job           string
+	Report        *TaskReport `gorm:"constraint:OnDelete:CASCADE"`
+	Purged        bool
+	ApplicationID *uint
+	Application   *Application
+	TaskGroupID   *uint `gorm:"<-:create"`
+	TaskGroup     *TaskGroup
 }
 
 func (m *Task) Reset() {
@@ -44,7 +47,7 @@ func (m *Task) Reset() {
 
 func (m *Task) BeforeCreate(db *gorm.DB) (err error) {
 	if m.TaskGroupID == nil {
-		err = m.Bucket.BeforeCreate(db)
+		err = m.BucketOwner.BeforeCreate(db)
 	}
 	m.Reset()
 	return
@@ -52,22 +55,23 @@ func (m *Task) BeforeCreate(db *gorm.DB) (err error) {
 
 func (m *Task) BeforeDelete(db *gorm.DB) (err error) {
 	if m.TaskGroupID == nil {
-		err = m.Bucket.BeforeDelete(db)
+		err = m.BucketOwner.BeforeDelete(db)
 	}
 	return
 }
 
 type TaskGroup struct {
 	Model
-	Bucket
-	Name  string
-	Addon string
-	Data  JSON
-	Tasks []Task `gorm:"constraint:OnDelete:CASCADE"`
+	BucketOwner
+	Name   string
+	Addon  string
+	Data   JSON
+	Tasks  []Task `gorm:"constraint:OnDelete:CASCADE"`
+	Purged bool
 }
 
 func (m *TaskGroup) BeforeCreate(db *gorm.DB) (err error) {
-	err = m.Bucket.BeforeCreate(db)
+	err = m.BucketOwner.BeforeCreate(db)
 	if err != nil {
 		return
 	}
@@ -81,7 +85,7 @@ func (m *TaskGroup) BeforeUpdate(*gorm.DB) (err error) {
 }
 
 func (m *TaskGroup) BeforeDelete(db *gorm.DB) (err error) {
-	err = m.Bucket.BeforeDelete(db)
+	err = m.BucketOwner.BeforeDelete(db)
 	if err != nil {
 		return
 	}

--- a/settings/hub.go
+++ b/settings/hub.go
@@ -2,15 +2,19 @@ package settings
 
 import (
 	"os"
+	"strconv"
 )
 
 const (
-	EnvNamespace  = "NAMESPACE"
-	EnvDbPath     = "DB_PATH"
-	EnvDbSeedPath = "DB_SEED_PATH"
-	EnvBucketPath = "BUCKET_PATH"
-	EnvBucketPVC  = "BUCKET_PVC"
-	EnvPassphrase = "ENCRYPTION_PASSPHRASE"
+	EnvNamespace         = "NAMESPACE"
+	EnvDbPath            = "DB_PATH"
+	EnvDbSeedPath        = "DB_SEED_PATH"
+	EnvBucketPath        = "BUCKET_PATH"
+	EnvBucketPVC         = "BUCKET_PVC"
+	EnvPassphrase        = "ENCRYPTION_PASSPHRASE"
+	EnvTaskReapCreated   = "TASK_REAP_CREATED"
+	EnvTaskReapSucceeded = "TASK_REAP_SUCCEEDED"
+	EnvTaskReapFailed    = "TASK_REAP_FAILED"
 )
 
 type Hub struct {
@@ -29,6 +33,14 @@ type Hub struct {
 	// Encryption settings.
 	Encryption struct {
 		Passphrase string
+	}
+	// Task
+	Task struct {
+		Reaper struct {
+			Created   int
+			Succeeded int
+			Failed    int
+		}
 	}
 }
 
@@ -57,6 +69,27 @@ func (r *Hub) Load() (err error) {
 	r.Encryption.Passphrase, found = os.LookupEnv(EnvPassphrase)
 	if !found {
 		r.Encryption.Passphrase = "tackle"
+	}
+	s, found := os.LookupEnv(EnvTaskReapCreated)
+	if found {
+		n, _ := strconv.Atoi(s)
+		r.Task.Reaper.Created = n
+	} else {
+		r.Task.Reaper.Created = 720
+	}
+	s, found = os.LookupEnv(EnvTaskReapSucceeded)
+	if found {
+		n, _ := strconv.Atoi(s)
+		r.Task.Reaper.Succeeded = n
+	} else {
+		r.Task.Reaper.Succeeded = 12
+	}
+	s, found = os.LookupEnv(EnvTaskReapFailed)
+	if found {
+		n, _ := strconv.Atoi(s)
+		r.Task.Reaper.Failed = n
+	} else {
+		r.Task.Reaper.Failed = 48
 	}
 
 	return


### PR DESCRIPTION
This PR introduces the (optional) relationship between tasks and applications as a first class concept. This includes cascade delete to delete tasks when the associated application is deleted. 

---

Adds missing Application.Binary (string) field.

---

Adjust task/group bucket reaper:

Purge task (buckets) when:
- The task not in a group.  (not shared)
- The task has been terminated for a defined period.

Delete tasks when:
- Not associated with an application.
- The task has never been submitted or terminated for a defined period.

Delete group when:
- The group is empty for a defined period.

Purge group bucket when:
- All of the tasks (buckets) would have been purged had they not been in the group.

--- 

Renamed the model _mixin_ Bucket => BucketOwner and field Path => Bucket because Path is not clear in context.  Ex:  Application.Bucket is better than Application.Path.