### PR TITLE
Fix PUT on application.

### DIFF
--- a/api/application.go
+++ b/api/application.go
@@ -189,11 +189,13 @@ func (h ApplicationHandler) Update(ctx *gin.Context) {
 		h.updateFailed(ctx, result.Error)
 		return
 	}
+	db = h.DB.Model(m)
 	err = db.Association("Identities").Replace(m.Identities)
 	if err != nil {
 		h.updateFailed(ctx, err)
 		return
 	}
+	db = h.DB.Model(m)
 	err = db.Association("Tags").Replace(m.Tags)
 	if err != nil {
 		h.updateFailed(ctx, err)

--- a/api/stakeholder.go
+++ b/api/stakeholder.go
@@ -159,6 +159,7 @@ func (h StakeholderHandler) Update(ctx *gin.Context) {
 		h.updateFailed(ctx, result.Error)
 		return
 	}
+	db = h.DB.Model(m)
 	err = db.Association("Groups").Replace(m.Groups)
 	if err != nil {
 		h.updateFailed(ctx, err)

--- a/hack/update/application.sh
+++ b/hack/update/application.sh
@@ -4,8 +4,8 @@ host="${HOST:-localhost:8080}"
 
 curl -X PUT ${host}/applications/1 -d \
 '{
-    "name":"Cat",
-    "description": "Cat application.",
+    "name":"Dog2",
+    "description": "Dog2 application.",
     "businessService": {"id":1},
     "identities": [
       {"id":1},


### PR DESCRIPTION
I have been bitten by this before.  Even though the DB object is designed to be chained, you cannot do more than 1 _finisher_ method. Subsequent uses can do weird things due to the DB having inconsistent state.  For example, the DB.table and DB.model may not match.  I have observed this.

fixes #42