### PR TITLE
Fix identity update.

### DIFF
--- a/api/identity.go
+++ b/api/identity.go
@@ -151,6 +151,11 @@ func (h IdentityHandler) Update(ctx *gin.Context) {
 	m := r.Model()
 	m.ID = id
 	db := h.DB.Model(m)
+	err = m.BeforeUpdate(db)
+	if err != nil {
+		h.updateFailed(ctx, err)
+		return
+	}
 	result := db.Updates(h.fields(m))
 	if result.Error != nil {
 		h.updateFailed(ctx, result.Error)
@@ -210,10 +215,6 @@ func (r *Identity) With(m *model.Identity) {
 	r.Kind = m.Kind
 	r.Name = m.Name
 	r.Description = m.Description
-	r.User = m.User
-	r.Password = m.Password
-	r.Key = m.Key
-	r.Settings = m.Settings
 	r.Encrypted = m.Encrypted
 }
 
@@ -228,7 +229,6 @@ func (r *Identity) Model() (m *model.Identity) {
 		Password:    r.Password,
 		Key:         r.Key,
 		Settings:    r.Settings,
-		Encrypted:   r.Encrypted,
 	}
 	m.ID = r.ID
 

--- a/api/identity.go
+++ b/api/identity.go
@@ -97,6 +97,11 @@ func (h IdentityHandler) Create(ctx *gin.Context) {
 		return
 	}
 	m := r.Model()
+	err = m.Encrypt()
+	if err != nil {
+		h.updateFailed(ctx, err)
+		return
+	}
 	result := h.DB.Create(m)
 	if result.Error != nil {
 		h.createFailed(ctx, result.Error)
@@ -151,7 +156,7 @@ func (h IdentityHandler) Update(ctx *gin.Context) {
 	m := r.Model()
 	m.ID = id
 	db := h.DB.Model(m)
-	err = m.BeforeUpdate(db)
+	err = m.Encrypt()
 	if err != nil {
 		h.updateFailed(ctx, err)
 		return

--- a/model/identity.go
+++ b/model/identity.go
@@ -23,28 +23,14 @@ type Identity struct {
 
 //
 // Encrypt sensitive fields.
-func (r *Identity) Encrypt(passphrase string) (err error) {
+func (r *Identity) Encrypt() (err error) {
+	passphrase := Settings.Encryption.Passphrase
 	aes := encryption.New(passphrase)
-	encrypted, err := r.encrypted(passphrase)
-	if err != nil {
-		return
-	}
-	if r.User != "" {
-		encrypted.User = r.User
-		r.User = ""
-	}
-	if r.Password != "" {
-		encrypted.Password = r.Password
-		r.Password = ""
-	}
-	if r.Key != "" {
-		encrypted.Key = r.Key
-		r.Key = ""
-	}
-	if r.Settings != "" {
-		encrypted.Settings = r.Settings
-		r.Settings = ""
-	}
+	encrypted := Identity{}
+	encrypted.User = r.User
+	encrypted.Password = r.Password
+	encrypted.Key = r.Key
+	encrypted.Settings = r.Settings
 	b, err := json.Marshal(encrypted)
 	if err != nil {
 		return
@@ -56,46 +42,40 @@ func (r *Identity) Encrypt(passphrase string) (err error) {
 //
 // Decrypt sensitive fields.
 func (r *Identity) Decrypt(passphrase string) (err error) {
-	encrypted, err := r.encrypted(passphrase)
+	aes := encryption.New(passphrase)
+	decrypted := &Identity{}
+	var dj string
+	dj, err = aes.Decrypt(r.Encrypted)
 	if err != nil {
 		return
 	}
-	r.User = encrypted.User
-	r.Password = encrypted.Password
-	r.Key = encrypted.Key
-	r.Settings = encrypted.Settings
+	err = json.Unmarshal([]byte(dj), decrypted)
+	if err != nil {
+		return
+	}
+	r.User = decrypted.User
+	r.Password = decrypted.Password
+	r.Key = decrypted.Key
+	r.Settings = decrypted.Settings
 	return
 }
 
 //
 // BeforeSave ensure encrypted.
 func (r *Identity) BeforeSave(tx *gorm.DB) (err error) {
-	err = r.Encrypt(Settings.Encryption.Passphrase)
+	err = r.Encrypt()
+	if err == nil {
+		r.User = ""
+		r.Password = ""
+		r.Kind = ""
+		r.Settings = ""
+	}
 	return
 }
 
 //
 // BeforeUpdate ensure encrypted.
 func (r *Identity) BeforeUpdate(tx *gorm.DB) (err error) {
-	err = r.Encrypt(Settings.Encryption.Passphrase)
-	return
-}
-
-//
-// encrypted returns the encrypted credentials.
-func (r *Identity) encrypted(passphrase string) (encrypted *Identity, err error) {
-	aes := encryption.New(passphrase)
-	encrypted = &Identity{}
-	if r.Encrypted != "" {
-		var dj string
-		dj, err = aes.Decrypt(r.Encrypted)
-		if err != nil {
-			return
-		}
-		err = json.Unmarshal([]byte(dj), encrypted)
-		if err != nil {
-			return
-		}
-	}
+	err = r.BeforeSave(tx)
 	return
 }


### PR DESCRIPTION
Encrypt() needs to be called before h.fields() because the hooks are called by db.Updates().

Simplified the idempotent behavior of both Encrypt() and Decrypt() by moving the clearing of the encrypted fields to the hooks.
Explicitly call Encrypt() in the handler Create() and Update() leaving the hooks to perform an Encrypt() as a safety net.  This will result in the Encrypt() being called twice but this is harmless.