### PR TITLE
Fix addon identity decryption.

### DIFF
--- a/api/identity.go
+++ b/api/identity.go
@@ -239,6 +239,7 @@ func (r *Identity) Model() (m *model.Identity) {
 		Password:    r.Password,
 		Key:         r.Key,
 		Settings:    r.Settings,
+		Encrypted:   r.Encrypted,
 	}
 	m.ID = r.ID
 


### PR DESCRIPTION
The Model() method needs to populate the `Encrypted` field for decryption.  This is safe because the API handler always calls Identity.Encrypt() which overwrites the `Encrypted` field before CREATE & UPDATE.
This is a regression introduced a bit ago in the hub but not caught until I rebased the windup addon.

Background on design patterns:

The Resource.Model() method is used to build a DB model.
The Resource.With() method is used to populate the rest Resource with the DB model.