### PR TITLE
Wrap errors at the edge to capture stack trace.

### DIFF
--- a/addon/client.go
+++ b/addon/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	liberr "github.com/konveyor/controller/pkg/error"
 	"github.com/konveyor/tackle2-hub/auth"
 	"io"
 	"io/ioutil"
@@ -33,6 +34,7 @@ func (r *Client) Get(path string, object interface{}) (err error) {
 	request.Header.Set(auth.Header, r.token)
 	reply, err := r.http.Do(request)
 	if err != nil {
+		err = liberr.Wrap(err)
 		return
 	}
 	defer func() {
@@ -44,6 +46,7 @@ func (r *Client) Get(path string, object interface{}) (err error) {
 		var body []byte
 		body, err = io.ReadAll(reply.Body)
 		if err != nil {
+			err = liberr.Wrap(err)
 			return
 		}
 		err = json.Unmarshal(body, object)
@@ -61,6 +64,7 @@ func (r *Client) Get(path string, object interface{}) (err error) {
 func (r *Client) Post(path string, object interface{}) (err error) {
 	bfr, err := json.Marshal(object)
 	if err != nil {
+		err = liberr.Wrap(err)
 		return
 	}
 	reader := bytes.NewReader(bfr)
@@ -73,6 +77,7 @@ func (r *Client) Post(path string, object interface{}) (err error) {
 	request.Header.Set(auth.Header, r.token)
 	reply, err := r.http.Do(request)
 	if err != nil {
+		err = liberr.Wrap(err)
 		return
 	}
 	status := reply.StatusCode
@@ -82,10 +87,12 @@ func (r *Client) Post(path string, object interface{}) (err error) {
 		var body []byte
 		body, err = ioutil.ReadAll(reply.Body)
 		if err != nil {
+			err = liberr.Wrap(err)
 			return
 		}
 		err = json.Unmarshal(body, object)
 		if err != nil {
+			err = liberr.Wrap(err)
 			return
 		}
 	case http.StatusConflict:
@@ -102,6 +109,7 @@ func (r *Client) Post(path string, object interface{}) (err error) {
 func (r *Client) Put(path string, object interface{}) (err error) {
 	bfr, err := json.Marshal(object)
 	if err != nil {
+		err = liberr.Wrap(err)
 		return
 	}
 	reader := bytes.NewReader(bfr)
@@ -114,6 +122,7 @@ func (r *Client) Put(path string, object interface{}) (err error) {
 	request.Header.Set(auth.Header, r.token)
 	reply, err := r.http.Do(request)
 	if err != nil {
+		err = liberr.Wrap(err)
 		return
 	}
 	status := reply.StatusCode
@@ -123,10 +132,12 @@ func (r *Client) Put(path string, object interface{}) (err error) {
 		var body []byte
 		body, err = ioutil.ReadAll(reply.Body)
 		if err != nil {
+			err = liberr.Wrap(err)
 			return
 		}
 		err = json.Unmarshal(body, object)
 		if err != nil {
+			err = liberr.Wrap(err)
 			return
 		}
 	case http.StatusNotFound:
@@ -149,6 +160,7 @@ func (r *Client) Delete(path string) (err error) {
 	request.Header.Set(auth.Header, r.token)
 	reply, err := r.http.Do(request)
 	if err != nil {
+		err = liberr.Wrap(err)
 		return
 	}
 	defer func() {

--- a/importer/manager.go
+++ b/importer/manager.go
@@ -3,6 +3,7 @@ package importer
 import (
 	"context"
 	"fmt"
+	liberr "github.com/konveyor/controller/pkg/error"
 	"github.com/konveyor/tackle2-hub/api"
 	"github.com/konveyor/tackle2-hub/model"
 	"gorm.io/gorm"
@@ -41,7 +42,7 @@ func (m *Manager) processImports() (err error) {
 	db := m.DB.Preload("ImportTags")
 	result := db.Find(&list, "processed = ?", false)
 	if result.Error != nil {
-		err = result.Error
+		err = liberr.Wrap(result.Error)
 		return
 	}
 	for _, imp := range list {
@@ -56,7 +57,7 @@ func (m *Manager) processImports() (err error) {
 		imp.Processed = true
 		result = m.DB.Save(&imp)
 		if result.Error != nil {
-			err = result.Error
+			err = liberr.Wrap(result.Error)
 			return
 		}
 	}

--- a/k8s/client.go
+++ b/k8s/client.go
@@ -1,6 +1,7 @@
 package k8s
 
 import (
+	liberr "github.com/konveyor/controller/pkg/error"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
@@ -15,5 +16,8 @@ func NewClient() (newClient client.Client, err error) {
 		client.Options{
 			Scheme: scheme.Scheme,
 		})
+	if err != nil {
+		err = liberr.Wrap(err)
+	}
 	return
 }

--- a/model/bucket.go
+++ b/model/bucket.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"github.com/google/uuid"
+	liberr "github.com/konveyor/controller/pkg/error"
 	"gorm.io/gorm"
 	"io/ioutil"
 	"os"
@@ -31,6 +32,10 @@ func (m *BucketOwner) Create() (err error) {
 		uid.String())
 	err = os.MkdirAll(m.Bucket, 0777)
 	if err != nil {
+		err = liberr.Wrap(
+			err,
+			"path",
+			m.Bucket)
 		return
 	}
 	return

--- a/model/identity.go
+++ b/model/identity.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"encoding/json"
+	liberr "github.com/konveyor/controller/pkg/error"
 	"github.com/konveyor/tackle2-hub/encryption"
 	"gorm.io/gorm"
 )
@@ -33,6 +34,10 @@ func (r *Identity) Encrypt() (err error) {
 	encrypted.Settings = r.Settings
 	b, err := json.Marshal(encrypted)
 	if err != nil {
+		err = liberr.Wrap(
+			err,
+			"id",
+			r.ID)
 		return
 	}
 	r.Encrypted, err = aes.Encrypt(string(b))
@@ -47,10 +52,18 @@ func (r *Identity) Decrypt(passphrase string) (err error) {
 	var dj string
 	dj, err = aes.Decrypt(r.Encrypted)
 	if err != nil {
+		err = liberr.Wrap(
+			err,
+			"id",
+			r.ID)
 		return
 	}
 	err = json.Unmarshal([]byte(dj), decrypted)
 	if err != nil {
+		err = liberr.Wrap(
+			err,
+			"id",
+			r.ID)
 		return
 	}
 	r.User = decrypted.User

--- a/model/task.go
+++ b/model/task.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"encoding/json"
+	liberr "github.com/konveyor/controller/pkg/error"
 	"gorm.io/gorm"
 	"time"
 )
@@ -88,11 +89,19 @@ func (m *TaskGroup) Propagate() (err error) {
 		a := Map{}
 		err = json.Unmarshal(m.Data, &a)
 		if err != nil {
+			err = liberr.Wrap(
+				err,
+				"id",
+				m.ID)
 			return
 		}
 		b := Map{}
 		err = json.Unmarshal(task.Data, &b)
 		if err != nil {
+			err = liberr.Wrap(
+				err,
+				"id",
+				m.ID)
 			return
 		}
 		task.Data, _ = json.Marshal(m.merge(a, b))


### PR DESCRIPTION
The design pattern used on MTV and other projects has been to Wrap errors at the edge (where they occur).  The wrap method will capture the stack trace and provide for attaching additional context to the error.  The error is returned. The error is either handled or returned on up the stack by the calling code. Should the error never be handled, it will be logged with the relevant stack trace and attached context.