### PR TITLE
Refactor task manager and reaper.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ PKG = ./addon/... \
       ./k8s/... \
       ./model/... \
       ./settings/... \
-      ./task/...
+      ./tasking/...
 
 BUILD = --tags json1 -o bin/hub github.com/konveyor/tackle2-hub/cmd
 

--- a/addon/adapter.go
+++ b/addon/adapter.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"github.com/konveyor/controller/pkg/logging"
 	"github.com/konveyor/tackle2-hub/settings"
-	"github.com/konveyor/tackle2-hub/task"
+	"github.com/konveyor/tackle2-hub/tasking"
 	"net/http"
 	"os"
 	"strings"
@@ -106,7 +106,7 @@ func (h *Adapter) Client() *Client {
 func newAdapter() (adapter *Adapter) {
 	//
 	// Load secret.
-	secret := &task.Secret{}
+	secret := &tasking.Secret{}
 	b, err := os.ReadFile(Settings.Addon.Path.Secret)
 	if err != nil {
 		panic(err)

--- a/addon/task.go
+++ b/addon/task.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/konveyor/tackle2-hub/api"
-	"github.com/konveyor/tackle2-hub/task"
+	"github.com/konveyor/tackle2-hub/tasking"
 )
 
 //
@@ -13,7 +13,7 @@ type Task struct {
 	// hub API client.
 	client *Client
 	// Addon Secret
-	secret *task.Secret
+	secret *tasking.Secret
 	// Task report.
 	report api.TaskReport
 }
@@ -51,7 +51,7 @@ func (h *Task) DataWith(object interface{}) (err error) {
 // Started report addon started.
 func (h *Task) Started() {
 	h.deleteReport()
-	h.report.Status = task.Running
+	h.report.Status = tasking.Running
 	h.pushReport()
 	Log.Info("Addon reported started.")
 	return
@@ -60,7 +60,7 @@ func (h *Task) Started() {
 //
 // Succeeded report addon succeeded.
 func (h *Task) Succeeded() {
-	h.report.Status = task.Succeeded
+	h.report.Status = tasking.Succeeded
 	h.report.Completed = h.report.Total
 	h.pushReport()
 	Log.Info("Addon reported: succeeded.")
@@ -71,7 +71,7 @@ func (h *Task) Succeeded() {
 // Failed report addon failed.
 // The reason can be a printf style format.
 func (h *Task) Failed(reason string, x ...interface{}) {
-	h.report.Status = task.Failed
+	h.report.Status = tasking.Failed
 	h.report.Error = fmt.Sprintf(reason, x...)
 	h.pushReport()
 	Log.Info(

--- a/api/task.go
+++ b/api/task.go
@@ -6,7 +6,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/konveyor/tackle2-hub/auth"
 	"github.com/konveyor/tackle2-hub/model"
-	tasking "github.com/konveyor/tackle2-hub/task"
+	tasking "github.com/konveyor/tackle2-hub/tasking"
 	"gorm.io/gorm/clause"
 	batch "k8s.io/api/batch/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
@@ -411,7 +411,6 @@ func (r *Task) With(m *model.Task) {
 	r.Isolated = m.Isolated
 	r.Application = r.refPtr(m.ApplicationID, m.Application)
 	r.Bucket = m.Bucket
-	r.Purged = m.Purged
 	r.State = m.State
 	r.Started = m.Started
 	r.Terminated = m.Terminated

--- a/api/taskgroup.go
+++ b/api/taskgroup.go
@@ -5,7 +5,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/konveyor/tackle2-hub/auth"
 	"github.com/konveyor/tackle2-hub/model"
-	tasking "github.com/konveyor/tackle2-hub/task"
+	tasking "github.com/konveyor/tackle2-hub/tasking"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 	"net/http"
@@ -319,7 +319,6 @@ func (r *TaskGroup) With(m *model.TaskGroup) {
 	r.Addon = m.Addon
 	r.State = m.State
 	r.Bucket = m.Bucket
-	r.Purged = m.Purged
 	r.Tasks = []Task{}
 	_ = json.Unmarshal(m.Data, &r.Data)
 	switch m.State {
@@ -340,10 +339,9 @@ func (r *TaskGroup) With(m *model.TaskGroup) {
 // Model builds a model.
 func (r *TaskGroup) Model() (m *model.TaskGroup) {
 	m = &model.TaskGroup{
-		Name:   r.Name,
-		Addon:  r.Addon,
-		Purged: r.Purged,
-		State:  r.State,
+		Name:  r.Name,
+		Addon: r.Addon,
+		State: r.State,
 	}
 	m.ID = r.ID
 	m.Bucket = r.Bucket

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -15,7 +15,7 @@ import (
 	crd "github.com/konveyor/tackle2-hub/k8s/api"
 	"github.com/konveyor/tackle2-hub/model"
 	"github.com/konveyor/tackle2-hub/settings"
-	"github.com/konveyor/tackle2-hub/task"
+	"github.com/konveyor/tackle2-hub/tasking"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
 	"gorm.io/gorm/schema"
@@ -159,7 +159,7 @@ func main() {
 		h.With(db, client, provider)
 		h.AddRoutes(router)
 	}
-	taskManager := task.Manager{
+	taskManager := tasking.Manager{
 		Client: client,
 		DB:     db,
 	}

--- a/hack/add/task.sh
+++ b/hack/add/task.sh
@@ -6,7 +6,7 @@ curl -X POST ${host}/tasks -d \
 '{
     "name":"Test",
     "locator": "app.1.test",
-    "addon": "test",
+    "addon": "sleeper",
     "application": {"id": 1},
     "data": {
       "path": "/etc"

--- a/hack/add/task.sh
+++ b/hack/add/task.sh
@@ -6,7 +6,7 @@ curl -X POST ${host}/tasks -d \
 '{
     "name":"Test",
     "locator": "app.1.test",
-    "addon": "sleeper",
+    "addon": "test",
     "application": {"id": 1},
     "data": {
       "path": "/etc"

--- a/hack/cmd/addon/main.go
+++ b/hack/cmd/addon/main.go
@@ -214,7 +214,7 @@ func tag(d *Data, application *api.Application) (err error) {
 		api.Ref{ID: tag.ID})
 	//
 	// Update application.
-	err = addon.Application.Update(application)
+	_ = addon.Application.Update(application)
 	return
 }
 

--- a/model/bucket.go
+++ b/model/bucket.go
@@ -19,7 +19,7 @@ func (m *BucketOwner) BeforeCreate(db *gorm.DB) (err error) {
 }
 
 func (m *BucketOwner) BeforeDelete(db *gorm.DB) (err error) {
-	err = m.Delete()
+	err = m.DeleteBucket()
 	return
 }
 
@@ -42,8 +42,8 @@ func (m *BucketOwner) Create() (err error) {
 }
 
 //
-// Purge associated storage.
-func (m *BucketOwner) Purge() (err error) {
+// EmptyBucket delete bucket content.
+func (m *BucketOwner) EmptyBucket() (err error) {
 	content, _ := ioutil.ReadDir(m.Bucket)
 	for _, n := range content {
 		p := path.Join(m.Bucket, n.Name())
@@ -53,8 +53,8 @@ func (m *BucketOwner) Purge() (err error) {
 }
 
 //
-// Delete associated storage.
-func (m *BucketOwner) Delete() (err error) {
+// DeleteBucket associated storage.
+func (m *BucketOwner) DeleteBucket() (err error) {
 	err = os.RemoveAll(m.Bucket)
 	return
 }

--- a/model/task.go
+++ b/model/task.go
@@ -33,7 +33,6 @@ type Task struct {
 	Error         string
 	Job           string
 	Report        *TaskReport `gorm:"constraint:OnDelete:CASCADE"`
-	Purged        bool
 	ApplicationID *uint
 	Application   *Application
 	TaskGroupID   *uint `gorm:"<-:create"`
@@ -64,13 +63,12 @@ func (m *Task) BeforeDelete(db *gorm.DB) (err error) {
 type TaskGroup struct {
 	Model
 	BucketOwner
-	Name   string
-	Addon  string
-	Data   JSON
-	Tasks  []Task `gorm:"constraint:OnDelete:CASCADE"`
-	List   JSON
-	State  string
-	Purged bool
+	Name  string
+	Addon string
+	Data  JSON
+	Tasks []Task `gorm:"constraint:OnDelete:CASCADE"`
+	List  JSON
+	State string
 }
 
 //

--- a/model/task.go
+++ b/model/task.go
@@ -31,7 +31,8 @@ type Task struct {
 	Terminated    *time.Time
 	State         string
 	Error         string
-	Job           string
+	Pod           string
+	Retries       int
 	Report        *TaskReport `gorm:"constraint:OnDelete:CASCADE"`
 	ApplicationID *uint
 	Application   *Application

--- a/settings/hub.go
+++ b/settings/hub.go
@@ -40,7 +40,7 @@ type Hub struct {
 	Task struct {
 		SA      string
 		Retries int
-		Reaper  struct {
+		Reaper  struct { // hours.
 			Created   int
 			Succeeded int
 			Failed    int
@@ -93,7 +93,7 @@ func (r *Hub) Load() (err error) {
 		n, _ := strconv.Atoi(s)
 		r.Task.Reaper.Failed = n
 	} else {
-		r.Task.Reaper.Failed = 48
+		r.Task.Reaper.Failed = 72
 	}
 	r.Task.SA, found = os.LookupEnv(EnvTaskSA)
 	if !found {

--- a/settings/hub.go
+++ b/settings/hub.go
@@ -16,6 +16,7 @@ const (
 	EnvTaskReapSucceeded = "TASK_REAP_SUCCEEDED"
 	EnvTaskReapFailed    = "TASK_REAP_FAILED"
 	EnvTaskSA            = "TASK_SA"
+	EnvTaskRetries       = "TASK_RETRIES"
 )
 
 type Hub struct {
@@ -37,7 +38,8 @@ type Hub struct {
 	}
 	// Task
 	Task struct {
-		SA     string
+		SA      string
+		Retries int
 		Reaper struct {
 			Created   int
 			Succeeded int
@@ -77,14 +79,14 @@ func (r *Hub) Load() (err error) {
 		n, _ := strconv.Atoi(s)
 		r.Task.Reaper.Created = n
 	} else {
-		r.Task.Reaper.Created = 720
+		r.Task.Reaper.Created = 72
 	}
 	s, found = os.LookupEnv(EnvTaskReapSucceeded)
 	if found {
 		n, _ := strconv.Atoi(s)
 		r.Task.Reaper.Succeeded = n
 	} else {
-		r.Task.Reaper.Succeeded = 12
+		r.Task.Reaper.Succeeded = 1
 	}
 	s, found = os.LookupEnv(EnvTaskReapFailed)
 	if found {
@@ -96,6 +98,13 @@ func (r *Hub) Load() (err error) {
 	r.Task.SA, found = os.LookupEnv(EnvTaskSA)
 	if !found {
 		r.Task.SA = "tackle-hub"
+	}
+	s, found = os.LookupEnv(EnvTaskSA)
+	if found {
+		n, _ := strconv.Atoi(s)
+		r.Task.Retries = n
+	} else {
+		r.Task.Retries= 1
 	}
 
 	return
@@ -115,7 +124,7 @@ func (r *Hub) namespace() (ns string, err error) {
 		return
 	}
 	if os.IsNotExist(err) {
-		ns = "tackle-operator"
+		ns = "konveyor-tackle"
 		err = nil
 	}
 

--- a/settings/hub.go
+++ b/settings/hub.go
@@ -40,7 +40,7 @@ type Hub struct {
 	Task struct {
 		SA      string
 		Retries int
-		Reaper struct {
+		Reaper  struct {
 			Created   int
 			Succeeded int
 			Failed    int
@@ -104,7 +104,7 @@ func (r *Hub) Load() (err error) {
 		n, _ := strconv.Atoi(s)
 		r.Task.Retries = n
 	} else {
-		r.Task.Retries= 1
+		r.Task.Retries = 1
 	}
 
 	return

--- a/tasking/manager.go
+++ b/tasking/manager.go
@@ -3,6 +3,7 @@ package tasking
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	liberr "github.com/konveyor/controller/pkg/error"
 	"github.com/konveyor/controller/pkg/logging"
 	crd "github.com/konveyor/tackle2-hub/k8s/api/tackle/v1alpha1"
@@ -306,7 +307,7 @@ func (r *Task) pod(secret *core.Secret) (pod core.Pod) {
 		Spec: r.specification(secret),
 		ObjectMeta: meta.ObjectMeta{
 			Namespace:    Settings.Hub.Namespace,
-			GenerateName: strings.ToLower(r.Name) + "-",
+			GenerateName: fmt.Sprintf("task-%d-", r.ID),
 			Labels:       r.labels(),
 		},
 	}

--- a/tasking/manager.go
+++ b/tasking/manager.go
@@ -158,9 +158,10 @@ func (m *Manager) updateRunning() {
 }
 
 //
-// postpone task based on requested isolation.
-// An isolated task must run by itself and will cause all
-// other tasks to be postponed.
+// postpone Postpones a task based on the following rules:
+//   - Tasks must be unique for an addon and application.
+//   - An isolated task must run by itself and will cause all
+//     other tasks to be postponed.
 func (m *Manager) postpone(pending *model.Task, list []model.Task) (found bool) {
 	for i := range list {
 		task := &list[i]
@@ -169,6 +170,10 @@ func (m *Manager) postpone(pending *model.Task, list []model.Task) (found bool) 
 		}
 		if pending.State != Running {
 			continue
+		}
+		if pending.Application == task.Application && pending.Addon == task.Addon {
+			found = true
+			return
 		}
 		if pending.Isolated || task.Isolated {
 			found = true

--- a/tasking/manager.go
+++ b/tasking/manager.go
@@ -112,17 +112,15 @@ func (m *Manager) startReady() {
 			Postponed:
 			if m.postpone(ready, list) {
 				ready.State = Postponed
-				result := m.DB.Save(ready)
-				Log.Trace(result.Error)
-				if result.Error == nil {
-					Log.Info("Task postponed.", "id", ready.ID)
+				Log.Info("Task postponed.", "id", ready.ID)
+			} else {
+				err := task.Run()
+				if err == nil {
+					Log.Info("Task started.", "id", ready.ID)
+				} else {
+					continue
 				}
 			}
-			err := task.Run()
-			if err != nil {
-				continue
-			}
-			Log.Info("Task started.", "id", ready.ID)
 			result := m.DB.Save(ready)
 			Log.Trace(result.Error)
 		}

--- a/tasking/reaper.go
+++ b/tasking/reaper.go
@@ -82,6 +82,7 @@ func (r *TaskReaper) delete(task *model.Task) (deleted bool, err error) {
 	err = r.DB.Delete(task).Error
 	if err == nil {
 		Log.Info("Task deleted.", "id", task.ID)
+		deleted = true
 	} else {
 		err = liberr.Wrap(err)
 	}
@@ -264,6 +265,7 @@ func (r *GroupReaper) delete(g *model.TaskGroup) (deleted bool, err error) {
 	err = r.DB.Delete(g).Error
 	if err == nil {
 		Log.Info("Group deleted.", "id", g.ID)
+		deleted = true
 	} else {
 		err = liberr.Wrap(err)
 	}

--- a/tasking/reaper.go
+++ b/tasking/reaper.go
@@ -217,6 +217,11 @@ func (r *TaskReaper) mayDeletePod(task *model.Task) (may bool) {
 		d := time.Duration(
 			Settings.Hub.Task.Reaper.Succeeded) * ReaperUnit
 		may = time.Since(mark) > d
+	case Failed:
+		mark := *task.Terminated
+		d := time.Duration(
+			Settings.Hub.Task.Reaper.Failed) * ReaperUnit
+		may = time.Since(mark) > d
 	}
 	return
 }

--- a/tasking/reaper.go
+++ b/tasking/reaper.go
@@ -1,0 +1,284 @@
+package tasking
+
+import (
+	"context"
+	"github.com/konveyor/tackle2-hub/model"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+	batch "k8s.io/api/batch/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	pathlib "path"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
+)
+
+const (
+	ReaperUnit = time.Hour
+)
+
+//
+// Reaper interface.
+type Reaper interface {
+	Run()
+}
+
+//
+// TaskReaper reaps tasks.
+type TaskReaper struct {
+	// DB
+	DB *gorm.DB
+	// k8s client.
+	Client client.Client
+}
+
+//
+// Run Executes the reaper.
+func (r *TaskReaper) Run() {
+	list := []model.Task{}
+	result := r.DB.Find(
+		&list,
+		"state IN ?",
+		[]string{
+			Created,
+			Succeeded,
+			Failed,
+		})
+	Log.Trace(result.Error)
+	if result.Error != nil {
+		return
+	}
+	for i := range list {
+		task := &list[i]
+		deleted, err := r.delete(task)
+		if deleted || err != nil {
+			continue
+		}
+		err = r.emptyBucket(task)
+		if err != nil {
+			continue
+		}
+		err = r.deleteJob(task)
+		if err != nil {
+			continue
+		}
+	}
+}
+
+//
+// delete Deletes the task as needed.
+func (r *TaskReaper) delete(task *model.Task) (deleted bool, err error) {
+	if !r.mayDelete(task) {
+		return
+	}
+	result := r.DB.Delete(task)
+	if result.Error == nil {
+		Log.Info("Task deleted.", "id", task.ID)
+	} else {
+		Log.Trace(result.Error)
+	}
+
+	return
+}
+
+//
+// emptyBucket Empties the task bucket as needed.
+func (r *TaskReaper) emptyBucket(task *model.Task) (err error) {
+	if !r.mayEmptyBucket(task) {
+		return
+	}
+	err = task.EmptyBucket()
+	if err == nil {
+		Log.Info("Task bucket emptied.", "id", task.ID)
+	} else {
+		Log.Trace(err)
+	}
+	return
+}
+
+//
+// deleteJob Deletes the associated job as needed.
+func (r *TaskReaper) deleteJob(task *model.Task) (err error) {
+	if !r.mayDeleteJob(task) {
+		return
+	}
+	job := &batch.Job{}
+	ns, name := pathlib.Split(task.Job)
+	err = r.Client.Get(
+		context.TODO(),
+		client.ObjectKey{
+			Namespace: ns,
+			Name:      name,
+		},
+		job)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			err = nil
+		} else {
+			Log.Trace(err)
+		}
+		return
+	}
+	err = r.Client.Delete(context.TODO(), job)
+	if err == nil {
+		Log.Info("Task job deleted.", "id", task.ID)
+	} else {
+		Log.Trace(err)
+	}
+	return
+}
+
+//
+// mayDelete determines if a task may be deleted.
+// May be deleted when:
+//   - Not associated with an application.
+//   - Never submitted or terminated for defined period.
+func (r *TaskReaper) mayDelete(task *model.Task) (approved bool) {
+	if task.ApplicationID != nil {
+		return
+	}
+	switch task.State {
+	case Created:
+		mark := task.CreateTime
+		d := time.Duration(
+			Settings.Hub.Task.Reaper.Created) * ReaperUnit
+		approved = time.Since(mark) > d
+	case Succeeded:
+		mark := *task.Terminated
+		d := time.Duration(
+			Settings.Hub.Task.Reaper.Succeeded) * ReaperUnit
+		approved = time.Since(mark) > d
+	case Failed:
+		mark := *task.Terminated
+		d := time.Duration(
+			Settings.Hub.Task.Reaper.Failed) * ReaperUnit
+		approved = time.Since(mark) > d
+	}
+	return
+}
+
+//
+// mayEmptyBucket Determines if a task bucket may be emptied.
+// May be purged when:
+//   - Not associated with a group.
+//   - Terminated for defined period.
+func (r *TaskReaper) mayEmptyBucket(task *model.Task) (may bool) {
+	if task.TaskGroupID != nil {
+		return
+	}
+	switch task.State {
+	case Succeeded:
+		mark := *task.Terminated
+		d := time.Duration(
+			Settings.Hub.Task.Reaper.Succeeded) * ReaperUnit
+		may = time.Since(mark) > d
+	case Failed:
+		mark := *task.Terminated
+		d := time.Duration(
+			Settings.Hub.Task.Reaper.Failed) * ReaperUnit
+		may = time.Since(mark) > d
+	}
+	return
+}
+
+//
+// mayDeleteJob Determines if a task job can be deleted.
+func (r *TaskReaper) mayDeleteJob(task *model.Task) (may bool) {
+	switch task.State {
+	case Succeeded:
+		mark := *task.Terminated
+		d := time.Duration(
+			Settings.Hub.Task.Reaper.Succeeded) * ReaperUnit
+		may = time.Since(mark) > d
+	}
+	return
+}
+
+//
+// GroupReaper reaps task groups.
+type GroupReaper struct {
+	// DB
+	DB *gorm.DB
+}
+
+//
+// Run Executes the reaper.
+func (r *GroupReaper) Run() {
+	list := []model.TaskGroup{}
+	db := r.DB.Preload(clause.Associations)
+	result := db.Find(&list)
+	if result.Error != nil {
+		return
+	}
+	for i := range list {
+		g := &list[i]
+		deleted, err := r.delete(g)
+		if deleted || err != nil {
+			continue
+		}
+		err = r.emptyBucket(g)
+		if err != nil {
+			continue
+		}
+	}
+}
+
+//
+// delete Deletes the group as needed.
+func (r *GroupReaper) delete(g *model.TaskGroup) (deleted bool, err error) {
+	if !r.mayDelete(g) {
+		return
+	}
+	result := r.DB.Delete(g)
+	if result.Error == nil {
+		Log.Info("Group deleted.", "id", g.ID)
+	} else {
+		Log.Trace(result.Error)
+	}
+	return
+}
+
+//
+// emptyBucket Empty the group bucket as needed.
+func (r *GroupReaper) emptyBucket(g *model.TaskGroup) (err error) {
+	if !r.mayDelete(g) {
+		return
+	}
+	err = g.EmptyBucket()
+	if err == nil {
+		Log.Info("Group bucket emptied.", "id", g.ID)
+	} else {
+		Log.Trace(err)
+	}
+	return
+}
+
+//
+// mayDelete Determines if a group may be deleted.
+// May be deleted when:
+//   - Empty for defined period.
+func (r *GroupReaper) mayDelete(g *model.TaskGroup) (approved bool) {
+	empty := len(g.Tasks) == 0
+	mark := g.CreateTime
+	d := time.Duration(
+		Settings.Hub.Task.Reaper.Created) * ReaperUnit
+	approved = empty && time.Since(mark) > d
+	return
+}
+
+//
+// mayEmptyBucket Determines if a group bucket may be emptied.
+// May be purged when:
+//   - All tasks buckets may be emptied.
+func (r *GroupReaper) mayEmptyBucket(g *model.TaskGroup) (approved bool) {
+	nMayPurge := 0
+	tr := TaskReaper{DB: r.DB}
+	for i := range g.Tasks {
+		task := &g.Tasks[i]
+		task.TaskGroupID = nil
+		if tr.mayEmptyBucket(task) {
+			nMayPurge++
+		}
+	}
+	approved = nMayPurge == len(g.Tasks)
+	return
+}


### PR DESCRIPTION
Added task job reaper.
Add: serialize tasks running against the same addon & application.
Refactor reapers into separate objects in a new `reaper.go`.
Replaced _purge_ terminology with _empty_ (verb).
Renamed `task` package => `tasking`.
Tasks using Pods (instead of Jobs).
Fix issue with using task _name_ for the pod name.

The operator can override here: https://github.com/konveyor/tackle2-operator/issues/47.

closes #40 
closes #63 