### PR TITLE
Support task variants.

### DIFF
--- a/addon/task.go
+++ b/addon/task.go
@@ -48,6 +48,12 @@ func (h *Task) DataWith(object interface{}) (err error) {
 }
 
 //
+// Variant returns the task variant.
+func (h *Task) Variant() string {
+	return h.secret.Hub.Variant
+}
+
+//
 // Started report addon started.
 func (h *Task) Started() {
 	h.deleteReport()

--- a/api/task.go
+++ b/api/task.go
@@ -384,8 +384,9 @@ func (h TaskHandler) DeleteReport(ctx *gin.Context) {
 type Task struct {
 	Resource
 	Name        string      `json:"name"`
-	Locator     string      `json:"locator"`
-	Isolated    bool        `json:"isolated,omitempty"`
+	Locator     string      `json:"locator,omitempty"`
+	Variant     string      `json:"variant,omitempty"`
+	Policy      string      `json:"policy,omitempty"`
 	Addon       string      `json:"addon,omitempty" binding:"required"`
 	Data        interface{} `json:"data" swaggertype:"object" binding:"required"`
 	Application *Ref        `json:"application"`
@@ -409,7 +410,8 @@ func (r *Task) With(m *model.Task) {
 	r.Image = m.Image
 	r.Addon = m.Addon
 	r.Locator = m.Locator
-	r.Isolated = m.Isolated
+	r.Policy = m.Policy
+	r.Variant = m.Variant
 	r.Application = r.refPtr(m.ApplicationID, m.Application)
 	r.Bucket = m.Bucket
 	r.State = m.State
@@ -433,7 +435,8 @@ func (r *Task) Model() (m *model.Task) {
 		Name:          r.Name,
 		Addon:         r.Addon,
 		Locator:       r.Locator,
-		Isolated:      r.Isolated,
+		Variant:       r.Variant,
+		Policy:        r.Policy,
 		State:         r.State,
 		Retries:       r.Retries,
 		ApplicationID: r.idPtr(r.Application),

--- a/model/task.go
+++ b/model/task.go
@@ -25,7 +25,8 @@ type Task struct {
 	Addon         string `gorm:"index"`
 	Locator       string `gorm:"index"`
 	Image         string
-	Isolated      bool
+	Variant       string
+	Policy        string
 	Data          JSON
 	Started       *time.Time
 	Terminated    *time.Time

--- a/tasking/manager.go
+++ b/tasking/manager.go
@@ -178,7 +178,7 @@ func (m *Manager) postpone(pending *model.Task, list []model.Task) (found bool) 
 		if task.State != Running {
 			continue
 		}
-		if pending.Application == task.Application && pending.Addon == task.Addon {
+		if pending.ApplicationID == task.ApplicationID && pending.Addon == task.Addon {
 			found = true
 			return
 		}

--- a/tasking/manager.go
+++ b/tasking/manager.go
@@ -31,6 +31,12 @@ const (
 	Postponed = "Postponed"
 )
 
+//
+// Policies
+const (
+	Isolated = "Isolated"
+)
+
 var (
 	Settings = &settings.Settings
 	Log      = logging.WithName("task")
@@ -176,7 +182,7 @@ func (m *Manager) postpone(pending *model.Task, list []model.Task) (found bool) 
 			found = true
 			return
 		}
-		if pending.Isolated || task.Isolated {
+		if pending.Policy == Isolated || task.Policy == Isolated {
 			found = true
 			return
 		}
@@ -454,6 +460,7 @@ type Secret struct {
 		Token       string
 		Application *uint
 		Task        uint
+		Variant     string
 		Encryption  struct {
 			Passphrase string
 		}


### PR DESCRIPTION
Task.isolated replaced with policy=Isolated. This will be more flexible. 
Policies:
- "" -  The (default) normal concurrent execution.
- Isolated - Must be the only task running.

Added Task.Variant.  The _variant_ signals to the addon (adapter) -_what kind of task_ .  

This will be useful for cases like: Asking the windup adapter to clear the shared maven .m2 repository (instead of run windup).  The reason the variant is a first class concept on the task is because it determines the required `Data` payload.
Perhaps something like:
```
switch addon.Variant() {
case "windup.run", "":
    runWindup()
case "maven.clean":
    maven := Maven{}
    maven.Clean()
default:
    err = &SoftError{Reason: "Variant not supported."}
}
```