### PR TITLE
Identity fields encrypted instead of entire object.

### DIFF
--- a/addon/application.go
+++ b/addon/application.go
@@ -56,7 +56,7 @@ func (h *Application) FindIdentity(id uint, kind string) (r *api.Identity, found
 		if r.Kind == kind {
 			m := r.Model()
 			err = m.Decrypt(Addon.secret.Hub.Encryption.Passphrase)
-			r.With(m, false)
+			r.With(m)
 			if err != nil {
 				return
 			}

--- a/addon/identity.go
+++ b/addon/identity.go
@@ -22,7 +22,7 @@ func (h *Identity) Get(id uint) (r *api.Identity, err error) {
 	}
 	m := r.Model()
 	err = m.Decrypt(Addon.secret.Hub.Encryption.Passphrase)
-	r.With(m, false)
+	r.With(m)
 	return
 }
 
@@ -38,7 +38,7 @@ func (h *Identity) List() (list []api.Identity, err error) {
 		r := &list[i]
 		m := r.Model()
 		err = m.Decrypt(Addon.secret.Hub.Encryption.Passphrase)
-		r.With(m, false)
+		r.With(m)
 		if err != nil {
 			return
 		}

--- a/settings/auth.go
+++ b/settings/auth.go
@@ -41,7 +41,7 @@ type Auth struct {
 
 func (r *Auth) Load() (err error) {
 	var found bool
-	r.Required = getEnvBool(EnvAuthRequired, false)
+	r.Required = getEnvBool(EnvAuthRequired, true)
 	if !r.Required {
 		return
 	}


### PR DESCRIPTION
Identity fields encrypted instead of entire object.  The primary goal is to provide _natural_ round-trip of resources that reflects the true state.  For example, when edited by the UI, the populated fields can be depicted as populated either by displaying the raw encrypted values (or masked using a password widget).  Then, PUT back with a mix of encrypted (unedited) and clear-text (edited) fields.

```
[

    {
        "id": 1,
        "createUser": "",
        "updateUser": "",
        "createTime": "2022-04-28T04:15:20.625532011-07:00",
        "kind": "git",
        "name": "test-git",
        "description": "Forklift",
        "user": "userA",
        "password": "HhVQQNHxrKJLrrRWfJEqIUGdj+jq2wKidQ==",
        "key": "PAEYeqPPFKhx+Jvp4WyHZwxNKQo=",
        "settings": "ufvqyWVDeTJTuvY6Q7Sma/2HBjlA/UAQUA=="
    },
    {
        "id": 2,
        "createUser": "",
        "updateUser": "",
        "createTime": "2022-04-28T04:15:20.674021123-07:00",
        "kind": "mvn",
        "name": "test-mvn",
        "description": "Forklift",
        "user": "userA",
        "password": "T7Ea8kNXXc8qayavqOcLBeNhppq0qjA/VA==",
        "key": "+XD/g+1sC3eyMlE5plonnzy+ltk=",
        "settings": "fDM18EPWIzEO46een52v0W2mv/VVjRgiyA=="
    },
    {
        "id": 3,
        "createUser": "",
        "updateUser": "",
        "createTime": "2022-04-28T04:15:20.686726564-07:00",
        "kind": "other",
        "name": "1234",
        "description": "",
        "user": "",
        "password": "",
        "key": "PVEryD8Dm9y9q9JNVzToHaWWaMk=",
        "settings": ""
    }

]
```