### PR TITLE
Fix task leaks

### DIFF
--- a/tasking/manager.go
+++ b/tasking/manager.go
@@ -236,8 +236,31 @@ func (r *Task) Run() (err error) {
 		err = liberr.Wrap(err)
 		return
 	}
+	defer func() {
+		if err != nil {
+			_ = r.client.Delete(context.TODO(), &secret)
+		}
+	}()
 	pod := r.pod(&secret)
 	err = r.client.Create(context.TODO(), &pod)
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	defer func() {
+		if err != nil {
+			_ = r.client.Delete(context.TODO(), &pod)
+		}
+	}()
+	secret.OwnerReferences = append(
+		secret.OwnerReferences,
+		meta.OwnerReference{
+			APIVersion: "v1",
+			Kind:       "Pod",
+			Name:       pod.Name,
+			UID:        pod.UID,
+		})
+	err = r.client.Update(context.TODO(), &secret)
 	if err != nil {
 		err = liberr.Wrap(err)
 		return

--- a/tasking/manager.go
+++ b/tasking/manager.go
@@ -34,7 +34,7 @@ const (
 //
 // Policies
 const (
-	Isolated = "Isolated"
+	Isolated = "isolated"
 )
 
 var (

--- a/tasking/reaper.go
+++ b/tasking/reaper.go
@@ -7,7 +7,6 @@ import (
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 	core "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"os"
 	"os/exec"
 	"path"
@@ -137,21 +136,8 @@ func (r *TaskReaper) deletePod(m *model.Task) (err error) {
 		return
 	}
 	pod := &core.Pod{}
-	err = r.Client.Get(
-		context.TODO(),
-		client.ObjectKey{
-			Namespace: path.Dir(m.Pod),
-			Name:      path.Base(m.Pod),
-		},
-		pod)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			err = nil
-		} else {
-			err = liberr.Wrap(err)
-		}
-		return
-	}
+	pod.Namespace = path.Dir(m.Pod)
+	pod.Name = path.Base(m.Pod)
 	err = r.Client.Delete(context.TODO(), pod)
 	if err == nil {
 		Log.Info(

--- a/tasking/reaper.go
+++ b/tasking/reaper.go
@@ -133,6 +133,9 @@ func (r *TaskReaper) release(m *model.Task) {
 //
 // deletePod Deletes the associated pod as needed.
 func (r *TaskReaper) deletePod(m *model.Task) (err error) {
+	if m.Pod == "" {
+		return
+	}
 	pod := &core.Pod{}
 	err = r.Client.Get(
 		context.TODO(),
@@ -167,7 +170,11 @@ func (r *TaskReaper) deletePod(m *model.Task) (err error) {
 //
 // delete task.
 func (r *TaskReaper) delete(m *model.Task) {
-	err := r.DB.Delete(m).Error
+	err := r.deletePod(m)
+	if err != nil {
+		Log.Trace(err)
+	}
+	err = r.DB.Select(clause.Associations).Delete(m).Error
 	if err == nil {
 		Log.Info("Task deleted.", "id", m.ID)
 	} else {


### PR DESCRIPTION
Fix a few leaks:
- The TaskReport not being deleted in the DB when the Reaper deletes tasks.
- The task's secret is not deleted when the task is deleted by Reaper & API.  Added ownerRef.
- The secret or pod can be leaked depending on where the task manager fails to create resources.