### PR TITLE
Taskgroup DELETE without transaciton: fixes database locked.

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -31,7 +31,6 @@ import (
 	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
 	"strings"
 	"syscall"
 )
@@ -185,8 +184,7 @@ func main() {
 		return
 	}
 	go func() {
-		done := signals.SetupSignalHandler()
-		err = addonManager.Start(done)
+		err = addonManager.Start(make(<-chan struct{}))
 		if err != nil {
 			err = liberr.Wrap(err)
 			return


### PR DESCRIPTION
Taskgroup DELETE without transaction: fixes `database locked` trace.
The sqlite3 database can encounter "database locked" error when using transactions.  The ORM (gorm) does not protect against this known limitation.

Also, noticed when testing that using the signals package to get the _stop channel_ for the manager makes killing the manager in the debugger annoying.  Not really needed since we don't ever plan to stop the manager.