### PR TITLE
Fix invalid Application Import CSV format error

### DIFF
--- a/api/import.go
+++ b/api/import.go
@@ -258,6 +258,11 @@ func (h ImportHandler) UploadCSV(ctx *gin.Context) {
 		var imp model.Import
 		switch row[0] {
 		case RecordTypeApplication:
+			// Check row format - length, expecting 13 fields + tags
+			if len(row) < 13 {
+				ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid Application Import CSV format."})
+				return
+			}
 			imp = h.applicationFromRow(fileName, row)
 		case RecordTypeDependency:
 			imp = h.dependencyFromRow(fileName, row)


### PR DESCRIPTION
Adding check for CSV row length to ensure old Application Import CSV files import fails gracefully. Currently accepted CSV format was introduced in https://github.com/konveyor/tackle2-hub/pull/74 with UI sample https://github.com/konveyor/tackle2-ui/pull/148

https://issues.redhat.com/browse/TACKLE-560