### PR TITLE
[BACKPORT] Add inline dep csv import

### DIFF
--- a/api/import.go
+++ b/api/import.go
@@ -260,7 +260,7 @@ func (h ImportHandler) UploadCSV(ctx *gin.Context) {
 		case RecordTypeApplication:
 			// Check row format - length, expecting 15 fields + tags
 			if len(row) < 15 {
-				ctx.JSON(http.StatusBadRequest, gin.H{"error": "Invalid Application Import CSV format."})
+				ctx.JSON(http.StatusBadRequest, gin.H{"errorMessage": "Invalid Application Import CSV format."})
 				return
 			}
 			imp = h.applicationFromRow(fileName, row)


### PR DESCRIPTION
Beta backport of https://github.com/konveyor/tackle2-hub/pull/88

Dependencies were defined in Dependency and DependencyDrection columns in Tackle1.2, the new implementation moved dependencies to own lines (RecordType=2).

Re-adding dependency columns to Application line CSV format (and keeping own lines for dependencies too).