### PR TITLE
Refresh ubi base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ENV GOPATH=$APP_ROOT
 COPY --chown=1001:0 . .
 RUN make docker
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.4
+FROM registry.access.redhat.com/ubi8/ubi-minimal
 COPY --from=builder /opt/app-root/src/bin/hub /usr/local/bin/tackle-hub
 RUN microdnf -y install \
   sqlite \


### PR DESCRIPTION
- ubi8 base images cut at 8.4 which has not been updated in 6 months , use latest