### PR TITLE
Run task with security context runAsUser:0 (root) on OCP.

### DIFF
--- a/task/manager.go
+++ b/task/manager.go
@@ -439,6 +439,7 @@ func (r *Task) specification(addon *crd.Addon, secret *core.Secret) (specificati
 //
 // container builds the pod container.
 func (r *Task) container(addon *crd.Addon) (container core.Container) {
+	userid := int64(0)
 	container = core.Container{
 		Name:            "main",
 		Image:           r.Image,
@@ -476,6 +477,9 @@ func (r *Task) container(addon *crd.Addon) (container core.Container) {
 				Name:      "bucket",
 				MountPath: Settings.Hub.Bucket.Path,
 			},
+		},
+		SecurityContext: &core.SecurityContext{
+			RunAsUser: &userid,
 		},
 	}
 	mounts := addon.Spec.Mounts


### PR DESCRIPTION
Run task with security context runAsUser:0 (root) on OCP.
This is needed so addon SSH component can create `/etc/ssh/known_hosts`  Also, make troubleshooting MUCH easier when ssh(ing) to the pod.  The injected (generated) user on OCP is a pain.

This is only need for OCP.

Requires: https://github.com/konveyor/tackle2-operator/pull/79