### PR TITLE
Update tackle CLI tool with Assessments and related fixes

### DIFF
--- a/hack/tool/README.md
+++ b/hack/tool/README.md
@@ -37,6 +37,9 @@ Verbose output ```-v / --verbose``` option logs all API requests and responses p
 Data directory ```-d / --data-dir``` specifies path to local directory with Tackle database records in JSON format (```./tackle-data``` by default).
 
 SSL warnings ```-w / --disable-ssl-warnings``` optional suppress ssl warning for api requests.
+
+Import errors could be skipped with ``` -i / --ignore-import-errors ``` -  not recommended - use with high attention to avoid data inconsistency. If the import has failed, it is recommended use ```tackle clean``` command to remove only imported resources.
+
 ## Example
 
 ```

--- a/hack/tool/tackle
+++ b/hack/tool/tackle
@@ -126,7 +126,7 @@ def cmdWanted(args, action):
 
 class Tackle12Import:
     # TYPES order matters for import/upload to Tackle2
-    TYPES = ['tags', 'tagtypes', 'jobfunctions', 'stakeholdergroups', 'stakeholders', 'businessservices', 'applications', 'proxies', 'dependencies', 'assessments','assessments-applications', 'assessments--assessment-risk', 'assessments--confidence', 'reviews', 'identities']
+    TYPES = ['tags', 'tagtypes', 'jobfunctions', 'stakeholdergroups', 'stakeholders', 'businessservices', 'applications', 'proxies', 'dependencies', 'assessments', 'assessments--assessment-risk', 'assessments--confidence', 'reviews', 'identities']
     TACKLE2_SEED_TYPES = ['tags', 'tagtypes', 'jobfunctions']
 
     def __init__(self, dataDir, tackle1Url, tackle1Token, tackle2Url, tackle2Token):
@@ -273,16 +273,16 @@ class Tackle12Import:
                 #? only if aasm.status == "COMPLETE" but want to keep also open assessments
                 # Prepare Assessment questions and answers
                 asqa1 = apiJSON(self.tackle1Url + "/api/pathfinder/assessments/%d" % assm.id, self.tackle1Token)
-                if True: #non emtpy?
-                    asqa               = Tackle2Object()
-                    asqa.id                = asqa1['id']
-                    asqa.applicationId     = asqa1['applicationId']
-                    assm.status            = asqa1['status']
-                    assm.stakeholders      = asqa1['stakeholders']
-                    assm.stakeholderGroups = asqa1['stakeholderGroups']
-                    asqa.questionnaire     = asqa1['questionnaire']
-                    self.add('assessments', asqa)
-                self.add('assessments-applications', assm)
+                #if True: #non emtpy?
+                asqa               = Tackle2Object()
+                asqa.id                = asqa1['id']
+                asqa.applicationId     = asqa1['applicationId']
+                asqa.status            = asqa1['status']
+                asqa.stakeholders      = asqa1['stakeholders']
+                asqa.stakeholderGroups = asqa1['stakeholderGroups']
+                asqa.questionnaire     = asqa1['questionnaire']
+                self.add('assessments', asqa)
+                #self.add('assessments-applications', assm)
 
             collection = apiJSON(self.tackle1Url + "/api/pathfinder/assessments/assessment-risk", self.tackle1Token, data=[{"applicationId": app.id}], method='POST')
             for assmr1 in collection:
@@ -407,15 +407,23 @@ class Tackle12Import:
 
     def preImportCheck(self):
         for t in self.TYPES:
+            # Pathfinder objects are dependent on Application which was checked before (and its check'd require iterating applications)
             if "assessment" in t:
-                continue    # Pathfinder objects are dependent on Application which was checked before (and its check'd require iterating applications)
+                continue
             print("Checking %s in destination Tackle2.." % t)
             destCollection = apiJSON(self.tackle2Url + tackle2path(t), self.tackle2Token)
             localCollection = loadDump(os.path.join(self.dataDir, t + '.json'))
             for importObj in localCollection:
+                # Pathfinder resources are dependent on Application, cheking it via applicationId
+                if t == "applications":
+                    # Check Application's Assessments first
+                    asmnts = apiJSON(self.tackle2Url + "/pathfinder/assessments?applicationId=%d" % importObj['id'], self.tackle2Token, ignoreErrors=True)
+                    if len(asmnts) > 0:
+                        print("ERROR: Pathfinder assessment for application ID %d already exists. Clean it before running the import with: tackle clean" % importObj['id'])
+                        exit(1)
                 for destObj in destCollection:
                     if importObj['id'] == destObj['id']:
-                        print("ERROR: Resource %s/%d \"%s\" already exists in Tackle2 destination as \"%s\". Clean it before running import." % (t, importObj['id'], importObj['name'], destObj['name']))
+                        print("ERROR: Resource %s/%d \"%s\" already exists in Tackle2 destination as \"%s\". Clean it before running the import with: tackle clean" % (t, importObj['id'], importObj['name'], destObj['name']))
                         exit(1)
 
     def cleanTackle2(self):
@@ -424,14 +432,17 @@ class Tackle12Import:
             dictCollection = loadDump(os.path.join(self.dataDir, t + '.json'))
             for dictObj in dictCollection:
                 if "assessment" in t:
-                    # Pathfinder skip
-                    #print("Deleting %s?applicationId=%s" % (t, dictObj['applicationId']))
-                    #apiJSON("%s/pathfinder/%s?applicationId=%d" % (self.tackle2Url, t, dictObj['applicationId']), self.tackle2Token, method='DELETE', ignoreErrors=True)
                     continue
-                else:
-                    # Hub
-                    print("Deleting %s/%s" % (t, dictObj['id']))
-                    apiJSON("%s/hub/%s/%d" % (self.tackle2Url, t, dictObj['id']), self.tackle2Token, method='DELETE', ignoreErrors=True)
+                # Pathfinder resources are dependent on Application
+                if t == "applications":
+                    # Delete related Application's Assessment resources first
+                    collection = apiJSON(self.tackle2Url + "/pathfinder/assessments?applicationId=%d" % dictObj['id'], self.tackle2Token, ignoreErrors=True)
+                    for assm in collection:
+                        print("Deleting assessment %s for applicationId=%s" % (assm['id'], dictObj['id']))
+                        apiJSON("%s/pathfinder/assessments/%s" % (self.tackle2Url, assm['id']), self.tackle2Token, method='DELETE', ignoreErrors=True)
+                # Hub resources
+                print("Deleting %s/%s" % (t, dictObj['id']))
+                apiJSON("%s/hub/%s/%d" % (self.tackle2Url, t, dictObj['id']), self.tackle2Token, method='DELETE', ignoreErrors=True)
 
 class Tackle2Object:
     def __init__(self, initAttrs = {}):

--- a/hack/tool/tackle
+++ b/hack/tool/tackle
@@ -126,7 +126,7 @@ def cmdWanted(args, action):
 
 class Tackle12Import:
     # TYPES order matters for import/upload to Tackle2
-    TYPES = ['tags', 'tagtypes', 'jobfunctions', 'stakeholdergroups', 'stakeholders', 'businessservices', 'applications', 'proxies', 'dependencies', 'assessments', 'assessments--assessment-risk', 'assessments--confidence', 'reviews', 'identities']
+    TYPES = ['tags', 'tagtypes', 'jobfunctions', 'stakeholdergroups', 'stakeholders', 'businessservices', 'applications', 'proxies', 'dependencies', 'assessments','assessments-applications', 'assessments--assessment-risk', 'assessments--confidence', 'reviews', 'identities']
     TACKLE2_SEED_TYPES = ['tags', 'tagtypes', 'jobfunctions']
 
     def __init__(self, dataDir, tackle1Url, tackle1Token, tackle2Url, tackle2Token):
@@ -252,14 +252,6 @@ class Tackle12Import:
             #app.facts           = app1['facts']
             self.add('applications', app)
 
-        ### PROXIES ###
-        # collection = apiJSON(self.tackle1Url + "/api/proxies", self.tackle1Token)
-        # for proxy1 in collection:
-        #     # Prepare Proxy
-        #     proxy                 = Tackle2Object(proxy1)
-        #     proxy.name            = proxy1['name']
-        #     self.add('proxies', proxy)
-
         ### DEPENDENCIES ###
         collection = apiJSON(self.tackle1Url + "/api/application-inventory/applications-dependency", self.tackle1Token)
         for dep1 in collection:
@@ -278,7 +270,19 @@ class Tackle12Import:
                 assm.id            = assm1['id']
                 assm.applicationId = assm1['applicationId']
                 assm.status        = assm1['status']
-                self.add('assessments', assm)
+                #? only if aasm.status == "COMPLETE" but want to keep also open assessments
+                # Prepare Assessment questions and answers
+                asqa1 = apiJSON(self.tackle1Url + "/api/pathfinder/assessments/%d" % assm.id, self.tackle1Token)
+                if True: #non emtpy?
+                    asqa               = Tackle2Object()
+                    asqa.id                = asqa1['id']
+                    asqa.applicationId     = asqa1['applicationId']
+                    assm.status            = asqa1['status']
+                    assm.stakeholders      = asqa1['stakeholders']
+                    assm.stakeholderGroups = asqa1['stakeholderGroups']
+                    asqa.questionnaire     = asqa1['questionnaire']
+                    self.add('assessments', asqa)
+                self.add('assessments-applications', assm)
 
             collection = apiJSON(self.tackle1Url + "/api/pathfinder/assessments/assessment-risk", self.tackle1Token, data=[{"applicationId": app.id}], method='POST')
             for assmr1 in collection:
@@ -297,14 +301,6 @@ class Tackle12Import:
                 conf.applicationId = conf1['applicationId']
                 conf.confidence    = conf1['confidence']
                 self.add('assessments--confidence', conf)
-
-        ### IDENTITIES ###
-        # collection = apiJSON(self.tackle1Url + "/api/", self.tackle1Token)
-        # for id1 in collection:
-        #     # Prepare Review
-        #     id                 = Tackle2Object(id1)
-        #     id.name            = id1['name']
-        #     self.add('identities', id)
 
         ### STAKEHOLDER ###
         collection = apiJSON(self.tackle1Url + "/api/controls/stakeholder", self.tackle1Token)
@@ -386,14 +382,27 @@ class Tackle12Import:
             saveJSON(os.path.join(self.dataDir, t), self.data[t])
 
     def uploadTackle2(self, ignoreErrors=False):
+        # Hub objects
         for t in self.TYPES:
             dictCollection = loadDump(os.path.join(self.dataDir, t + '.json'))
             for dictObj in dictCollection:
                 if "assessment" in t:
-                    continue    # Pathfinder skip
+                    continue    # Pathfinder objects are imported separately
                 print("Uploading %s.." % t)
                 debugPrint(dictObj)
                 apiJSON(self.tackle2Url + tackle2path(t), self.tackle2Token, dictObj, method='POST', ignoreErrors=ignoreErrors)
+
+        # Assessments / Pathfinder stuff import
+        dictCollection = loadDump(os.path.join(self.dataDir, 'assessments.json'))
+        print("Uploading assessments..")
+        for assmnt in dictCollection:
+            # Start the assessment
+            assmnt2 = apiJSON(self.tackle2Url + tackle2path('assessments'), self.tackle2Token, data={"applicationId": assmnt['applicationId']}, method='POST', ignoreErrors=ignoreErrors)
+            # Fill the assessment
+            apiJSON(self.tackle2Url + tackle2path("assessments/%d" % assmnt2['id']), self.tackle2Token, data=assmnt, method='PATCH', ignoreErrors=ignoreErrors) # id get ignored
+            # Optionally complete the assessment
+            if assmnt2['status'] == 'COMPLETE':
+                apiJSON(self.tackle2Url + tackle2path("assessments/%d" % assmnt2['id']), self.tackle2Token, data={'status': 'COMPLETE'}, method='PATCH', ignoreErrors=ignoreErrors)
 
 
     def preImportCheck(self):

--- a/hack/tool/tackle
+++ b/hack/tool/tackle
@@ -80,8 +80,11 @@ def apiJSON(url, token, data=None, method='GET', ignoreErrors=False):
         case 'POST':
             debugPrint("POST data: %s" % json.dumps(data))
             r = requests.post(url, data=json.dumps(data), headers={"Authorization": "Bearer %s" % token, "Content-Type": "application/json"}, verify=False)
+        case 'PATCH':
+            debugPrint("PATCH data: %s" % json.dumps(data))
+            r = requests.patch(url, data=json.dumps(data), headers={"Authorization": "Bearer %s" % token, "Content-Type": "application/json"}, verify=False)
         case _: # GET
-            r = requests.get(url, headers={"Authorization": "Bearer %s" % token, "Content-Type": "application/json"}, verify=False)  # add pagination?
+            r = requests.get(url, headers={"Authorization": "Bearer %s" % token, "Content-Type": "application/json"}, verify=False)
 
     if not r.ok:
         if ignoreErrors:
@@ -98,7 +101,7 @@ def apiJSON(url, token, data=None, method='GET', ignoreErrors=False):
     respData = json.loads(r.text)
     if '_embedded' in respData:
         debugPrint("Unwrapping Tackle1 JSON")
-        return respData['_embedded'][url.rsplit('/')[-1]] # unwrap Tackle1 JSON response (e.g. _embedded -> application -> [{...}])
+        return respData['_embedded'][url.rsplit('/')[-1].rsplit('?')[0]] # unwrap Tackle1 JSON response (e.g. _embedded -> application -> [{...}])
     else:
         return respData # raw return JSON (Tackle2, Pathfinder)
 
@@ -207,7 +210,7 @@ class Tackle12Import:
                 self.add('tagtypes', tt)
 
         ### APPLICATION ###
-        collection = apiJSON(self.tackle1Url + "/api/application-inventory/application", self.tackle1Token)
+        collection = apiJSON(self.tackle1Url + "/api/application-inventory/application?page=0&size=10000", self.tackle1Token)
         for app1 in collection:
             # Temp holder for tags
             tags = []
@@ -270,10 +273,8 @@ class Tackle12Import:
                 assm.id            = assm1['id']
                 assm.applicationId = assm1['applicationId']
                 assm.status        = assm1['status']
-                #? only if aasm.status == "COMPLETE" but want to keep also open assessments
                 # Prepare Assessment questions and answers
                 asqa1 = apiJSON(self.tackle1Url + "/api/pathfinder/assessments/%d" % assm.id, self.tackle1Token)
-                #if True: #non emtpy?
                 asqa               = Tackle2Object()
                 asqa.id                = asqa1['id']
                 asqa.applicationId     = asqa1['applicationId']
@@ -282,7 +283,6 @@ class Tackle12Import:
                 asqa.stakeholderGroups = asqa1['stakeholderGroups']
                 asqa.questionnaire     = asqa1['questionnaire']
                 self.add('assessments', asqa)
-                #self.add('assessments-applications', assm)
 
             collection = apiJSON(self.tackle1Url + "/api/pathfinder/assessments/assessment-risk", self.tackle1Token, data=[{"applicationId": app.id}], method='POST')
             for assmr1 in collection:
@@ -395,15 +395,31 @@ class Tackle12Import:
         # Assessments / Pathfinder stuff import
         dictCollection = loadDump(os.path.join(self.dataDir, 'assessments.json'))
         print("Uploading assessments..")
-        for assmnt in dictCollection:
+        for assmnt1 in dictCollection:
             # Start the assessment
-            assmnt2 = apiJSON(self.tackle2Url + tackle2path('assessments'), self.tackle2Token, data={"applicationId": assmnt['applicationId']}, method='POST', ignoreErrors=ignoreErrors)
-            # Fill the assessment
-            apiJSON(self.tackle2Url + tackle2path("assessments/%d" % assmnt2['id']), self.tackle2Token, data=assmnt, method='PATCH', ignoreErrors=ignoreErrors) # id get ignored
-            # Optionally complete the assessment
-            if assmnt2['status'] == 'COMPLETE':
-                apiJSON(self.tackle2Url + tackle2path("assessments/%d" % assmnt2['id']), self.tackle2Token, data={'status': 'COMPLETE'}, method='PATCH', ignoreErrors=ignoreErrors)
-
+            assmnt2 = apiJSON(self.tackle2Url + tackle2path('assessments'), self.tackle2Token, data={"applicationId": assmnt1['applicationId']}, method='POST', ignoreErrors=ignoreErrors)
+            # Populate the assessment questionnaire
+            assmnt2 = apiJSON(self.tackle2Url + tackle2path("assessments/%d" % assmnt2['id']), self.tackle2Token, ignoreErrors=ignoreErrors)
+            # Fill the assessment going through assessment to be imported and setting values to the newly created in Tackle2 (IDs changed, pairing with Order)
+            for category in assmnt1['questionnaire']['categories']:
+                debugPrint("Category %s" % category["order"])
+                for question in category['questions']:
+                    debugPrint("Question %s" % question["order"])
+                    for option in question['options']:
+                        debugPrint("Option %s" % option)
+                        if option['checked'] == True:
+                            # Find corresponding option in newly created assessment and check it
+                            destCategory = next(cat for cat in assmnt2['questionnaire']['categories'] if cat['order'] == category['order'])
+                            destQuestion = next(que for que in destCategory['questions'] if que['order'] == question['order'])
+                            destOption = next(opt for opt in destQuestion['options'] if opt['order'] == option['order'])
+                            debugPrint("Checking Tackle2 assessment option: %s" % destOption)
+                            destOption['checked'] = True
+            # Set remaining assessment attributes
+            assmnt2['status']            = assmnt1['status']
+            assmnt2['stakeholders']      = assmnt1['stakeholders']
+            assmnt2['stakeholderGroups'] = assmnt1['stakeholderGroups']
+            # Push the updated assessment
+            apiJSON(self.tackle2Url + tackle2path("assessments/%d" % assmnt2['id']), self.tackle2Token, data=assmnt2, method='PATCH', ignoreErrors=ignoreErrors)
 
     def preImportCheck(self):
         for t in self.TYPES:


### PR DESCRIPTION
Update of the tackle command line tool bringing changes below:
- export and import full assessment questionnaires
- removes resources not used in Tackle 1.2 (proxy and identity)
- minor updates in readme and related files

https://issues.redhat.com/browse/TACKLE-623