### PR TITLE
Add /assessments endpoint as rev-proxy to path finder.

### DIFF
--- a/api/pathfinder.go
+++ b/api/pathfinder.go
@@ -1,0 +1,48 @@
+package api
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/konveyor/tackle2-hub/auth"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"os"
+)
+
+//
+// Routes
+const (
+	PathfinderRoot   = "/pathfinder"
+	AssessmentsRoot  = "assessments"
+	AssessmentsRootX = AssessmentsRoot + "/*" + Wildcard
+)
+
+//
+// PathfinderHandler handles assessment routes.
+type PathfinderHandler struct {
+	BaseHandler
+}
+
+//
+// AddRoutes adds routes.
+func (h PathfinderHandler) AddRoutes(e *gin.Engine) {
+	routeGroup := e.Group(PathfinderRoot)
+	routeGroup.Use(auth.AuthorizationRequired(h.AuthProvider, AssessmentsRoot))
+	routeGroup.Any(AssessmentsRoot, h.ReverseProxy)
+	routeGroup.Any(AssessmentsRootX, h.ReverseProxy)
+}
+
+//
+// ReverseProxy - forward to pathfinder.
+func (h PathfinderHandler) ReverseProxy(ctx *gin.Context) {
+	pathfinder := os.Getenv("PATHFINDER_URL")
+	target, _ := url.Parse(pathfinder)
+	proxy := httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			req.URL.Scheme = target.Scheme
+			req.URL.Host = target.Host
+		},
+	}
+
+	proxy.ServeHTTP(ctx.Writer, ctx.Request)
+}

--- a/api/pkg.go
+++ b/api/pkg.go
@@ -45,6 +45,7 @@ func All() []Handler {
 		&TaskHandler{},
 		&TaskGroupHandler{},
 		&VolumeHandler{},
+		&PathfinderHandler{},
 	}
 }
 


### PR DESCRIPTION
Add /assessments endpoint to be rev-proxied to pathfinder.
This is a short-term solution to be improved later by either:
- re-implement assessment (pathfinder) in tackle hub.
- make pathfinder an addon.

This requires PRs in the:
- The UI needs to its rev-proxy to route to the hub.
- The operator needs to define the PATHFINDER_URL in the hub pod.