### PR TITLE
Track Username that created or updated models

### DIFF
--- a/api/application.go
+++ b/api/application.go
@@ -2,11 +2,13 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	"github.com/konveyor/tackle2-hub/auth"
 	"github.com/konveyor/tackle2-hub/model"
 	"gorm.io/gorm/clause"
-	"net/http"
 )
 
 //
@@ -79,6 +81,9 @@ func (h ApplicationHandler) List(ctx *gin.Context) {
 		h.listFailed(ctx, result.Error)
 		return
 	}
+
+	fmt.Printf("|||||||||||||| current user: %s", h.CurrentUsername(ctx))
+
 	resources := []Application{}
 	for i := range list {
 		r := Application{}

--- a/api/application.go
+++ b/api/application.go
@@ -106,7 +106,7 @@ func (h ApplicationHandler) Create(ctx *gin.Context) {
 		return
 	}
 	m := r.Model()
-	m.CreateUser = h.BaseHandler.CurrentUsername(ctx)
+	m.CreateUser = h.BaseHandler.CurrentUser(ctx)
 	result := h.DB.Create(m)
 	if result.Error != nil {
 		h.createFailed(ctx, result.Error)
@@ -170,7 +170,7 @@ func (h ApplicationHandler) Update(ctx *gin.Context) {
 	}
 	m := r.Model()
 	m.ID = id
-	m.UpdateUser = h.BaseHandler.CurrentUsername(ctx)
+	m.UpdateUser = h.BaseHandler.CurrentUser(ctx)
 	db := h.DB.Model(m)
 	db = db.Omit(clause.Associations)
 	db = db.Omit("Bucket")

--- a/api/application.go
+++ b/api/application.go
@@ -2,13 +2,11 @@ package api
 
 import (
 	"encoding/json"
-	"fmt"
-	"net/http"
-
 	"github.com/gin-gonic/gin"
 	"github.com/konveyor/tackle2-hub/auth"
 	"github.com/konveyor/tackle2-hub/model"
 	"gorm.io/gorm/clause"
+	"net/http"
 )
 
 //
@@ -81,9 +79,6 @@ func (h ApplicationHandler) List(ctx *gin.Context) {
 		h.listFailed(ctx, result.Error)
 		return
 	}
-
-	fmt.Printf("|||||||||||||| current user: %s", h.CurrentUsername(ctx))
-
 	resources := []Application{}
 	for i := range list {
 		r := Application{}
@@ -111,6 +106,7 @@ func (h ApplicationHandler) Create(ctx *gin.Context) {
 		return
 	}
 	m := r.Model()
+	m.CreateUser = h.BaseHandler.CurrentUsername(ctx)
 	result := h.DB.Create(m)
 	if result.Error != nil {
 		h.createFailed(ctx, result.Error)
@@ -174,6 +170,7 @@ func (h ApplicationHandler) Update(ctx *gin.Context) {
 	}
 	m := r.Model()
 	m.ID = id
+	m.UpdateUser = h.BaseHandler.CurrentUsername(ctx)
 	db := h.DB.Model(m)
 	db = db.Omit(clause.Associations)
 	db = db.Omit("Bucket")

--- a/api/base.go
+++ b/api/base.go
@@ -4,18 +4,20 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"reflect"
+	"strconv"
+	"time"
+
 	"github.com/gin-gonic/gin"
 	"github.com/konveyor/tackle2-hub/auth"
 	"github.com/konveyor/tackle2-hub/model"
 	"github.com/mattn/go-sqlite3"
 	"gorm.io/gorm"
-	"io/ioutil"
-	"net/http"
-	"os"
-	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strconv"
-	"time"
 )
 
 //
@@ -252,6 +254,24 @@ func (h *BaseHandler) modBody(
 	b, _ := json.Marshal(r)
 	bfr := bytes.NewBuffer(b)
 	ctx.Request.Body = ioutil.NopCloser(bfr)
+	return
+}
+
+//tady dát volání auth providera pro username možná s cachováním
+//
+// Get user info from Keycloak
+func (h *BaseHandler) CurrentUsername(ctx *gin.Context) (username string) {
+	fmt.Printf("++++++++++++++ gin ctx: %v", ctx)
+	token := ctx.GetHeader("Authorization")
+
+	username, err := h.AuthProvider.GetUsername(token)
+	if err != nil {
+		fmt.Printf("+++++++++++++++ failed get userInfo, err: %v", err)
+		return ""
+	}
+
+	fmt.Printf("+++++++++++++++++++++ userName: %v", username)
+
 	return
 }
 

--- a/api/base.go
+++ b/api/base.go
@@ -2,10 +2,12 @@ package api
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"github.com/gin-gonic/gin"
 	"github.com/konveyor/tackle2-hub/auth"
+	"github.com/konveyor/tackle2-hub/model"
 	"github.com/mattn/go-sqlite3"
 	"gorm.io/gorm"
 	"io/ioutil"

--- a/api/base.go
+++ b/api/base.go
@@ -257,14 +257,14 @@ func (h *BaseHandler) modBody(
 }
 
 //
-// CurrentUsername gets username from Keycloak auth token
-func (h *BaseHandler) CurrentUsername(ctx *gin.Context) (username string) {
+// CurrentUser gets username from Keycloak auth token
+func (h *BaseHandler) CurrentUser(ctx *gin.Context) (user string) {
 	token := ctx.GetHeader("Authorization")
 	// Consider later add username to ctx and cache for single request?
-	username, err := h.AuthProvider.Username(token)
+	user, err := h.AuthProvider.User(token)
 	if err != nil {
-		fmt.Printf("Failed get current username, err: %v\n", err)
-		username = ""
+		fmt.Printf("Failed to get current user, err: %v\n", err)
+		user = ""
 	}
 	return
 }

--- a/api/base.go
+++ b/api/base.go
@@ -2,22 +2,19 @@ package api
 
 import (
 	"bytes"
-	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/gin-gonic/gin"
+	"github.com/konveyor/tackle2-hub/auth"
+	"github.com/mattn/go-sqlite3"
+	"gorm.io/gorm"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"reflect"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"strconv"
 	"time"
-
-	"github.com/gin-gonic/gin"
-	"github.com/konveyor/tackle2-hub/auth"
-	"github.com/konveyor/tackle2-hub/model"
-	"github.com/mattn/go-sqlite3"
-	"gorm.io/gorm"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 //
@@ -257,21 +254,16 @@ func (h *BaseHandler) modBody(
 	return
 }
 
-//tady dát volání auth providera pro username možná s cachováním
 //
-// Get user info from Keycloak
+// CurrentUsername gets username from Keycloak auth token
 func (h *BaseHandler) CurrentUsername(ctx *gin.Context) (username string) {
-	fmt.Printf("++++++++++++++ gin ctx: %v", ctx)
 	token := ctx.GetHeader("Authorization")
-
-	username, err := h.AuthProvider.GetUsername(token)
+	// Consider later add username to ctx and cache for single request?
+	username, err := h.AuthProvider.Username(token)
 	if err != nil {
-		fmt.Printf("+++++++++++++++ failed get userInfo, err: %v", err)
-		return ""
+		fmt.Printf("Failed get current username, err: %v\n", err)
+		username = ""
 	}
-
-	fmt.Printf("+++++++++++++++++++++ userName: %v", username)
-
 	return
 }
 

--- a/api/businessservice.go
+++ b/api/businessservice.go
@@ -99,6 +99,7 @@ func (h BusinessServiceHandler) Create(ctx *gin.Context) {
 		return
 	}
 	m := r.Model()
+	m.CreateUser = h.BaseHandler.CurrentUsername(ctx)
 	result := h.DB.Create(m)
 	if result.Error != nil {
 		h.createFailed(ctx, result.Error)
@@ -152,6 +153,7 @@ func (h BusinessServiceHandler) Update(ctx *gin.Context) {
 	}
 	m := r.Model()
 	m.ID = id
+	m.UpdateUser = h.BaseHandler.CurrentUsername(ctx)
 	db := h.DB.Model(m)
 	db = db.Omit(clause.Associations)
 	result := db.Updates(h.fields(m))

--- a/api/businessservice.go
+++ b/api/businessservice.go
@@ -99,7 +99,7 @@ func (h BusinessServiceHandler) Create(ctx *gin.Context) {
 		return
 	}
 	m := r.Model()
-	m.CreateUser = h.BaseHandler.CurrentUsername(ctx)
+	m.CreateUser = h.BaseHandler.CurrentUser(ctx)
 	result := h.DB.Create(m)
 	if result.Error != nil {
 		h.createFailed(ctx, result.Error)
@@ -153,7 +153,7 @@ func (h BusinessServiceHandler) Update(ctx *gin.Context) {
 	}
 	m := r.Model()
 	m.ID = id
-	m.UpdateUser = h.BaseHandler.CurrentUsername(ctx)
+	m.UpdateUser = h.BaseHandler.CurrentUser(ctx)
 	db := h.DB.Model(m)
 	db = db.Omit(clause.Associations)
 	result := db.Updates(h.fields(m))

--- a/api/dependency.go
+++ b/api/dependency.go
@@ -110,6 +110,7 @@ func (h DependencyHandler) Create(ctx *gin.Context) {
 		return
 	}
 	m := r.Model()
+	m.CreateUser = h.BaseHandler.CurrentUsername(ctx)
 	result := h.DB.Create(&m)
 	if result.Error != nil {
 		h.createFailed(ctx, result.Error)

--- a/api/dependency.go
+++ b/api/dependency.go
@@ -110,7 +110,7 @@ func (h DependencyHandler) Create(ctx *gin.Context) {
 		return
 	}
 	m := r.Model()
-	m.CreateUser = h.BaseHandler.CurrentUsername(ctx)
+	m.CreateUser = h.BaseHandler.CurrentUser(ctx)
 	result := h.DB.Create(&m)
 	if result.Error != nil {
 		h.createFailed(ctx, result.Error)

--- a/api/group.go
+++ b/api/group.go
@@ -99,7 +99,7 @@ func (h StakeholderGroupHandler) Create(ctx *gin.Context) {
 		return
 	}
 	m := r.Model()
-	m.CreateUser = h.BaseHandler.CurrentUsername(ctx)
+	m.CreateUser = h.BaseHandler.CurrentUser(ctx)
 	result := h.DB.Create(m)
 	if result.Error != nil {
 		h.createFailed(ctx, result.Error)
@@ -153,7 +153,7 @@ func (h StakeholderGroupHandler) Update(ctx *gin.Context) {
 	}
 	m := r.Model()
 	m.ID = id
-	m.UpdateUser = h.BaseHandler.CurrentUsername(ctx)
+	m.UpdateUser = h.BaseHandler.CurrentUser(ctx)
 	db := h.DB.Model(m)
 	db = db.Omit(clause.Associations)
 	result := db.Updates(h.fields(m))

--- a/api/group.go
+++ b/api/group.go
@@ -99,6 +99,7 @@ func (h StakeholderGroupHandler) Create(ctx *gin.Context) {
 		return
 	}
 	m := r.Model()
+	m.CreateUser = h.BaseHandler.CurrentUsername(ctx)
 	result := h.DB.Create(m)
 	if result.Error != nil {
 		h.createFailed(ctx, result.Error)
@@ -152,6 +153,7 @@ func (h StakeholderGroupHandler) Update(ctx *gin.Context) {
 	}
 	m := r.Model()
 	m.ID = id
+	m.UpdateUser = h.BaseHandler.CurrentUsername(ctx)
 	db := h.DB.Model(m)
 	db = db.Omit(clause.Associations)
 	result := db.Updates(h.fields(m))

--- a/api/identity.go
+++ b/api/identity.go
@@ -97,7 +97,7 @@ func (h IdentityHandler) Create(ctx *gin.Context) {
 		return
 	}
 	m := r.Model()
-	m.CreateUser = h.BaseHandler.CurrentUsername(ctx)
+	m.CreateUser = h.BaseHandler.CurrentUser(ctx)
 	ref := &model.Identity{}
 	err = m.Encrypt(ref)
 	if err != nil {
@@ -168,7 +168,7 @@ func (h IdentityHandler) Update(ctx *gin.Context) {
 		return
 	}
 	m.ID = id
-	m.UpdateUser = h.BaseHandler.CurrentUsername(ctx)
+	m.UpdateUser = h.BaseHandler.CurrentUser(ctx)
 	db := h.DB.Model(m)
 	err = db.Updates(h.fields(m)).Error
 	if err != nil {

--- a/api/identity.go
+++ b/api/identity.go
@@ -97,6 +97,7 @@ func (h IdentityHandler) Create(ctx *gin.Context) {
 		return
 	}
 	m := r.Model()
+	m.CreateUser = h.BaseHandler.CurrentUsername(ctx)
 	ref := &model.Identity{}
 	err = m.Encrypt(ref)
 	if err != nil {
@@ -167,6 +168,7 @@ func (h IdentityHandler) Update(ctx *gin.Context) {
 		return
 	}
 	m.ID = id
+	m.UpdateUser = h.BaseHandler.CurrentUsername(ctx)
 	db := h.DB.Model(m)
 	err = db.Updates(h.fields(m)).Error
 	if err != nil {

--- a/api/import.go
+++ b/api/import.go
@@ -229,6 +229,7 @@ func (h ImportHandler) UploadCSV(ctx *gin.Context) {
 		ImportStatus: InProgress,
 		Content:      buf.Bytes(),
 	}
+	m.CreateUser = h.BaseHandler.CurrentUsername(ctx)
 	result := h.DB.Create(&m)
 	if result.Error != nil {
 		h.createFailed(ctx, result.Error)

--- a/api/import.go
+++ b/api/import.go
@@ -229,7 +229,7 @@ func (h ImportHandler) UploadCSV(ctx *gin.Context) {
 		ImportStatus: InProgress,
 		Content:      buf.Bytes(),
 	}
-	m.CreateUser = h.BaseHandler.CurrentUsername(ctx)
+	m.CreateUser = h.BaseHandler.CurrentUser(ctx)
 	result := h.DB.Create(&m)
 	if result.Error != nil {
 		h.createFailed(ctx, result.Error)

--- a/api/jobfunction.go
+++ b/api/jobfunction.go
@@ -99,7 +99,7 @@ func (h JobFunctionHandler) Create(ctx *gin.Context) {
 		return
 	}
 	m := r.Model()
-	m.CreateUser = h.BaseHandler.CurrentUsername(ctx)
+	m.CreateUser = h.BaseHandler.CurrentUser(ctx)
 	result := h.DB.Create(m)
 	if result.Error != nil {
 		h.createFailed(ctx, result.Error)
@@ -153,7 +153,7 @@ func (h JobFunctionHandler) Update(ctx *gin.Context) {
 	}
 	m := r.Model()
 	m.ID = id
-	m.UpdateUser = h.BaseHandler.CurrentUsername(ctx)
+	m.UpdateUser = h.BaseHandler.CurrentUser(ctx)
 	db := h.DB.Model(m)
 	db = db.Omit(clause.Associations)
 	result := db.Updates(h.fields(m))

--- a/api/jobfunction.go
+++ b/api/jobfunction.go
@@ -99,6 +99,7 @@ func (h JobFunctionHandler) Create(ctx *gin.Context) {
 		return
 	}
 	m := r.Model()
+	m.CreateUser = h.BaseHandler.CurrentUsername(ctx)
 	result := h.DB.Create(m)
 	if result.Error != nil {
 		h.createFailed(ctx, result.Error)
@@ -152,6 +153,7 @@ func (h JobFunctionHandler) Update(ctx *gin.Context) {
 	}
 	m := r.Model()
 	m.ID = id
+	m.UpdateUser = h.BaseHandler.CurrentUsername(ctx)
 	db := h.DB.Model(m)
 	db = db.Omit(clause.Associations)
 	result := db.Updates(h.fields(m))

--- a/api/proxy.go
+++ b/api/proxy.go
@@ -101,7 +101,7 @@ func (h ProxyHandler) Create(ctx *gin.Context) {
 		return
 	}
 	m := proxy.Model()
-	m.CreateUser = h.BaseHandler.CurrentUsername(ctx)
+	m.CreateUser = h.BaseHandler.CurrentUser(ctx)
 	result := h.DB.Create(m)
 	if result.Error != nil {
 		h.createFailed(ctx, result.Error)
@@ -155,7 +155,7 @@ func (h ProxyHandler) Update(ctx *gin.Context) {
 	}
 	m := r.Model()
 	m.ID = id
-	m.UpdateUser = h.BaseHandler.CurrentUsername(ctx)
+	m.UpdateUser = h.BaseHandler.CurrentUser(ctx)
 	db := h.DB.Model(m)
 	db = db.Omit(clause.Associations)
 	result := db.Updates(h.fields(m))

--- a/api/proxy.go
+++ b/api/proxy.go
@@ -101,6 +101,7 @@ func (h ProxyHandler) Create(ctx *gin.Context) {
 		return
 	}
 	m := proxy.Model()
+	m.CreateUser = h.BaseHandler.CurrentUsername(ctx)
 	result := h.DB.Create(m)
 	if result.Error != nil {
 		h.createFailed(ctx, result.Error)
@@ -154,6 +155,7 @@ func (h ProxyHandler) Update(ctx *gin.Context) {
 	}
 	m := r.Model()
 	m.ID = id
+	m.UpdateUser = h.BaseHandler.CurrentUsername(ctx)
 	db := h.DB.Model(m)
 	db = db.Omit(clause.Associations)
 	result := db.Updates(h.fields(m))

--- a/api/review.go
+++ b/api/review.go
@@ -100,6 +100,7 @@ func (h ReviewHandler) Create(ctx *gin.Context) {
 		return
 	}
 	m := review.Model()
+	m.CreateUser = h.BaseHandler.CurrentUsername(ctx)
 	result := h.DB.Create(m)
 	if result.Error != nil {
 		h.createFailed(ctx, result.Error)
@@ -153,6 +154,7 @@ func (h ReviewHandler) Update(ctx *gin.Context) {
 	}
 	m := r.Model()
 	m.ID = id
+	m.UpdateUser = h.BaseHandler.CurrentUsername(ctx)
 	db := h.DB.Model(m)
 	db.Omit(clause.Associations)
 	result := db.Updates(h.fields(m))

--- a/api/review.go
+++ b/api/review.go
@@ -100,7 +100,7 @@ func (h ReviewHandler) Create(ctx *gin.Context) {
 		return
 	}
 	m := review.Model()
-	m.CreateUser = h.BaseHandler.CurrentUsername(ctx)
+	m.CreateUser = h.BaseHandler.CurrentUser(ctx)
 	result := h.DB.Create(m)
 	if result.Error != nil {
 		h.createFailed(ctx, result.Error)
@@ -154,7 +154,7 @@ func (h ReviewHandler) Update(ctx *gin.Context) {
 	}
 	m := r.Model()
 	m.ID = id
-	m.UpdateUser = h.BaseHandler.CurrentUsername(ctx)
+	m.UpdateUser = h.BaseHandler.CurrentUser(ctx)
 	db := h.DB.Model(m)
 	db.Omit(clause.Associations)
 	result := db.Updates(h.fields(m))

--- a/api/setting.go
+++ b/api/setting.go
@@ -110,6 +110,7 @@ func (h SettingHandler) Create(ctx *gin.Context) {
 	}
 
 	m := setting.Model()
+	m.CreateUser = h.BaseHandler.CurrentUsername(ctx)
 	result := h.DB.Create(&m)
 	if result.Error != nil {
 		h.createFailed(ctx, result.Error)
@@ -150,6 +151,7 @@ func (h SettingHandler) Update(ctx *gin.Context) {
 	}
 
 	m := updates.Model()
+	m.UpdateUser = h.BaseHandler.CurrentUsername(ctx)
 	db := h.DB.Model(m)
 	db = db.Where("key", key)
 	result := db.Updates(h.fields(m))

--- a/api/setting.go
+++ b/api/setting.go
@@ -110,7 +110,7 @@ func (h SettingHandler) Create(ctx *gin.Context) {
 	}
 
 	m := setting.Model()
-	m.CreateUser = h.BaseHandler.CurrentUsername(ctx)
+	m.CreateUser = h.BaseHandler.CurrentUser(ctx)
 	result := h.DB.Create(&m)
 	if result.Error != nil {
 		h.createFailed(ctx, result.Error)
@@ -151,7 +151,7 @@ func (h SettingHandler) Update(ctx *gin.Context) {
 	}
 
 	m := updates.Model()
-	m.UpdateUser = h.BaseHandler.CurrentUsername(ctx)
+	m.UpdateUser = h.BaseHandler.CurrentUser(ctx)
 	db := h.DB.Model(m)
 	db = db.Where("key", key)
 	result := db.Updates(h.fields(m))

--- a/api/stakeholder.go
+++ b/api/stakeholder.go
@@ -99,7 +99,7 @@ func (h StakeholderHandler) Create(ctx *gin.Context) {
 		return
 	}
 	m := r.Model()
-	m.CreateUser = h.BaseHandler.CurrentUsername(ctx)
+	m.CreateUser = h.BaseHandler.CurrentUser(ctx)
 	result := h.DB.Create(m)
 	if result.Error != nil {
 		h.createFailed(ctx, result.Error)
@@ -153,7 +153,7 @@ func (h StakeholderHandler) Update(ctx *gin.Context) {
 	}
 	m := r.Model()
 	m.ID = id
-	m.UpdateUser = h.BaseHandler.CurrentUsername(ctx)
+	m.UpdateUser = h.BaseHandler.CurrentUser(ctx)
 	db := h.DB.Model(m)
 	db = db.Omit(clause.Associations)
 	result := db.Updates(h.fields(m))

--- a/api/stakeholder.go
+++ b/api/stakeholder.go
@@ -99,6 +99,7 @@ func (h StakeholderHandler) Create(ctx *gin.Context) {
 		return
 	}
 	m := r.Model()
+	m.CreateUser = h.BaseHandler.CurrentUsername(ctx)
 	result := h.DB.Create(m)
 	if result.Error != nil {
 		h.createFailed(ctx, result.Error)
@@ -152,6 +153,7 @@ func (h StakeholderHandler) Update(ctx *gin.Context) {
 	}
 	m := r.Model()
 	m.ID = id
+	m.UpdateUser = h.BaseHandler.CurrentUsername(ctx)
 	db := h.DB.Model(m)
 	db = db.Omit(clause.Associations)
 	result := db.Updates(h.fields(m))

--- a/api/tag.go
+++ b/api/tag.go
@@ -99,6 +99,7 @@ func (h TagHandler) Create(ctx *gin.Context) {
 		return
 	}
 	m := r.Model()
+	m.CreateUser = h.BaseHandler.CurrentUsername(ctx)
 	result := h.DB.Create(m)
 	if result.Error != nil {
 		h.createFailed(ctx, result.Error)
@@ -152,6 +153,7 @@ func (h TagHandler) Update(ctx *gin.Context) {
 	}
 	m := r.Model()
 	m.ID = id
+	m.UpdateUser = h.BaseHandler.CurrentUsername(ctx)
 	db := h.DB.Model(m)
 	db = db.Omit(clause.Associations)
 	result := db.Updates(h.fields(m))

--- a/api/tag.go
+++ b/api/tag.go
@@ -99,7 +99,7 @@ func (h TagHandler) Create(ctx *gin.Context) {
 		return
 	}
 	m := r.Model()
-	m.CreateUser = h.BaseHandler.CurrentUsername(ctx)
+	m.CreateUser = h.BaseHandler.CurrentUser(ctx)
 	result := h.DB.Create(m)
 	if result.Error != nil {
 		h.createFailed(ctx, result.Error)
@@ -153,7 +153,7 @@ func (h TagHandler) Update(ctx *gin.Context) {
 	}
 	m := r.Model()
 	m.ID = id
-	m.UpdateUser = h.BaseHandler.CurrentUsername(ctx)
+	m.UpdateUser = h.BaseHandler.CurrentUser(ctx)
 	db := h.DB.Model(m)
 	db = db.Omit(clause.Associations)
 	result := db.Updates(h.fields(m))

--- a/api/tagtype.go
+++ b/api/tagtype.go
@@ -99,6 +99,7 @@ func (h TagTypeHandler) Create(ctx *gin.Context) {
 		return
 	}
 	m := r.Model()
+	m.CreateUser = h.BaseHandler.CurrentUsername(ctx)
 	result := h.DB.Create(m)
 	if result.Error != nil {
 		h.createFailed(ctx, result.Error)
@@ -152,6 +153,7 @@ func (h TagTypeHandler) Update(ctx *gin.Context) {
 	}
 	m := r.Model()
 	m.ID = id
+	m.UpdateUser = h.BaseHandler.CurrentUsername(ctx)
 	db := h.DB.Model(m)
 	db = db.Omit(clause.Associations)
 	result := db.Updates(h.fields(m))

--- a/api/tagtype.go
+++ b/api/tagtype.go
@@ -99,7 +99,7 @@ func (h TagTypeHandler) Create(ctx *gin.Context) {
 		return
 	}
 	m := r.Model()
-	m.CreateUser = h.BaseHandler.CurrentUsername(ctx)
+	m.CreateUser = h.BaseHandler.CurrentUser(ctx)
 	result := h.DB.Create(m)
 	if result.Error != nil {
 		h.createFailed(ctx, result.Error)
@@ -153,7 +153,7 @@ func (h TagTypeHandler) Update(ctx *gin.Context) {
 	}
 	m := r.Model()
 	m.ID = id
-	m.UpdateUser = h.BaseHandler.CurrentUsername(ctx)
+	m.UpdateUser = h.BaseHandler.CurrentUser(ctx)
 	db := h.DB.Model(m)
 	db = db.Omit(clause.Associations)
 	result := db.Updates(h.fields(m))

--- a/api/task.go
+++ b/api/task.go
@@ -137,6 +137,7 @@ func (h TaskHandler) Create(ctx *gin.Context) {
 		return
 	}
 	m := r.Model()
+	m.CreateUser = h.BaseHandler.CurrentUsername(ctx)
 	result := h.DB.Create(&m)
 	if result.Error != nil {
 		h.createFailed(ctx, result.Error)
@@ -330,6 +331,7 @@ func (h TaskHandler) CreateReport(ctx *gin.Context) {
 	}
 	report.TaskID = id
 	m := report.Model()
+	m.CreateUser = h.BaseHandler.CurrentUsername(ctx)
 	result := h.DB.Create(m)
 	if result.Error != nil {
 		h.createFailed(ctx, result.Error)
@@ -358,6 +360,7 @@ func (h TaskHandler) UpdateReport(ctx *gin.Context) {
 	}
 	report.TaskID = id
 	m := report.Model()
+	m.UpdateUser = h.BaseHandler.CurrentUsername(ctx)
 	db := h.DB.Model(m)
 	db = db.Where("taskid", id)
 	result := db.Updates(h.fields(m))

--- a/api/task.go
+++ b/api/task.go
@@ -137,7 +137,7 @@ func (h TaskHandler) Create(ctx *gin.Context) {
 		return
 	}
 	m := r.Model()
-	m.CreateUser = h.BaseHandler.CurrentUsername(ctx)
+	m.CreateUser = h.BaseHandler.CurrentUser(ctx)
 	result := h.DB.Create(&m)
 	if result.Error != nil {
 		h.createFailed(ctx, result.Error)
@@ -331,7 +331,7 @@ func (h TaskHandler) CreateReport(ctx *gin.Context) {
 	}
 	report.TaskID = id
 	m := report.Model()
-	m.CreateUser = h.BaseHandler.CurrentUsername(ctx)
+	m.CreateUser = h.BaseHandler.CurrentUser(ctx)
 	result := h.DB.Create(m)
 	if result.Error != nil {
 		h.createFailed(ctx, result.Error)
@@ -360,7 +360,7 @@ func (h TaskHandler) UpdateReport(ctx *gin.Context) {
 	}
 	report.TaskID = id
 	m := report.Model()
-	m.UpdateUser = h.BaseHandler.CurrentUsername(ctx)
+	m.UpdateUser = h.BaseHandler.CurrentUser(ctx)
 	db := h.DB.Model(m)
 	db = db.Where("taskid", id)
 	result := db.Updates(h.fields(m))

--- a/api/taskgroup.go
+++ b/api/taskgroup.go
@@ -130,7 +130,7 @@ func (h TaskGroupHandler) Create(ctx *gin.Context) {
 			})
 		return
 	}
-	m.CreateUser = h.BaseHandler.CurrentUsername(ctx)
+	m.CreateUser = h.BaseHandler.CurrentUser(ctx)
 	result := db.Create(&m)
 	if result.Error != nil {
 		h.createFailed(ctx, result.Error)
@@ -167,7 +167,7 @@ func (h TaskGroupHandler) Update(ctx *gin.Context) {
 	m := updated.Model()
 	m.ID = current.ID
 	m.Bucket = current.Bucket
-	m.UpdateUser = h.BaseHandler.CurrentUsername(ctx)
+	m.UpdateUser = h.BaseHandler.CurrentUser(ctx)
 	db := h.DB.Model(m)
 	switch updated.State {
 	case "", tasking.Created:

--- a/api/taskgroup.go
+++ b/api/taskgroup.go
@@ -130,6 +130,7 @@ func (h TaskGroupHandler) Create(ctx *gin.Context) {
 			})
 		return
 	}
+	m.CreateUser = h.BaseHandler.CurrentUsername(ctx)
 	result := db.Create(&m)
 	if result.Error != nil {
 		h.createFailed(ctx, result.Error)
@@ -166,6 +167,7 @@ func (h TaskGroupHandler) Update(ctx *gin.Context) {
 	m := updated.Model()
 	m.ID = current.ID
 	m.Bucket = current.Bucket
+	m.UpdateUser = h.BaseHandler.CurrentUsername(ctx)
 	db := h.DB.Model(m)
 	switch updated.State {
 	case "", tasking.Created:

--- a/api/volume.go
+++ b/api/volume.go
@@ -100,7 +100,7 @@ func (h VolumeHandler) Update(ctx *gin.Context) {
 	}
 	m := r.Model()
 	m.ID = id
-	m.UpdateUser = h.BaseHandler.CurrentUsername(ctx)
+	m.UpdateUser = h.BaseHandler.CurrentUser(ctx)
 	db := h.DB.Model(m)
 	db = db.Omit(clause.Associations)
 	result := db.Updates(h.fields(m))

--- a/api/volume.go
+++ b/api/volume.go
@@ -100,6 +100,7 @@ func (h VolumeHandler) Update(ctx *gin.Context) {
 	}
 	m := r.Model()
 	m.ID = id
+	m.UpdateUser = h.BaseHandler.CurrentUsername(ctx)
 	db := h.DB.Model(m)
 	db = db.Omit(clause.Associations)
 	result := db.Updates(h.fields(m))

--- a/auth/provider.go
+++ b/auth/provider.go
@@ -39,6 +39,12 @@ func (r *NoAuth) Scopes(token string) (scopes []Scope, err error) {
 }
 
 //
+// GetUsername mocks username for NoAuth
+func (r *NoAuth) GetUsername(token string) (name string, err error) {
+	return "--admin--", nil
+}
+
+//
 // NoAuthScope always permits access.
 type NoAuthScope struct{}
 

--- a/auth/provider.go
+++ b/auth/provider.go
@@ -3,15 +3,19 @@ package auth
 import (
 	"context"
 	"errors"
-	"github.com/Nerzal/gocloak/v10"
-	"github.com/golang-jwt/jwt/v4"
+	"fmt"
 	"strings"
 	"time"
+
+	"github.com/Nerzal/gocloak/v10"
+	"github.com/golang-jwt/jwt/v4"
 )
 
 type Provider interface {
 	// Scopes decodes a list of scopes from the token.
 	Scopes(token string) ([]Scope, error)
+	// GetUsername resolves token to username using Keycloak service
+	GetUsername(token string) (name string, err error)
 }
 
 //
@@ -111,6 +115,26 @@ func (r *Keycloak) newScope(s string) (scope KeycloakScope) {
 	} else {
 		scope.resource = s
 	}
+	return
+}
+
+//
+// GetUsername resolves token to username using Keycloak service
+func (r *Keycloak) GetUsername(token string) (name string, err error) {
+	fmt.Printf("--------------------------- Getting userInfo with token: %v", token)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+	defer cancel()
+	//decoded, _, err := r.client.DecodeAccessToken(ctx, token, r.realm)
+
+	//fmt.Printf("DEBUG: token: %s, realm: %s", t2, r.realm)
+	userInfo, err := r.client.GetUserInfo(ctx, token, r.realm)
+	if err != nil {
+		fmt.Printf("------------------ failed get userInfo, err: %v", err)
+		return
+	}
+	fmt.Printf("-------------------------- userInfo: %v", userInfo)
+
+	name = *userInfo.Name
 	return
 }
 

--- a/auth/provider.go
+++ b/auth/provider.go
@@ -3,17 +3,18 @@ package auth
 import (
 	"context"
 	"errors"
-	"github.com/Nerzal/gocloak/v10"
-	"github.com/golang-jwt/jwt/v4"
 	"strings"
 	"time"
+
+	"github.com/Nerzal/gocloak/v10"
+	"github.com/golang-jwt/jwt/v4"
 )
 
 type Provider interface {
 	// Scopes decodes a list of scopes from the token.
 	Scopes(token string) ([]Scope, error)
-	// Username parses preffered_name field from the token.
-	Username(token string) (username string, err error)
+	// User parses preffered_username field from the token.
+	User(token string) (user string, err error)
 }
 
 //
@@ -37,8 +38,8 @@ func (r *NoAuth) Scopes(token string) (scopes []Scope, err error) {
 }
 
 //
-// Username mocks username for NoAuth
-func (r *NoAuth) Username(token string) (name string, err error) {
+// User mocks username for NoAuth
+func (r *NoAuth) User(token string) (name string, err error) {
 	return "admin.noauth", nil
 }
 
@@ -123,21 +124,15 @@ func (r *Keycloak) newScope(s string) (scope KeycloakScope) {
 }
 
 //
-// Username resolves token to username using Keycloak service.
-func (r *Keycloak) Username(token string) (username string, err error) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
+// User resolves token to Keycloak username.
+func (r *Keycloak) User(token string) (user string, err error) {
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	decoded, claims, err := r.client.DecodeAccessToken(ctx, token, r.realm)
-	if err != nil {
-		err = errors.New("invalid token for username")
-		return
-	}
-	if !decoded.Valid {
-		err = errors.New("invalid token for username")
-		return
-	}
-	// Get preferred_username from the token payload
-	username, ok := (*claims)["preferred_username"].(string)
+	// Token validity should be checked before in Scopes method
+	_, claims, err := r.client.DecodeAccessToken(ctx, token, r.realm)
+
+	// Get preferred_username from the token payload as the user
+	user, ok := (*claims)["preferred_username"].(string)
 	if !ok {
 		err = errors.New("cannot parse preferred_username from token")
 		return

--- a/auth/provider.go
+++ b/auth/provider.go
@@ -3,11 +3,10 @@ package auth
 import (
 	"context"
 	"errors"
-	"strings"
-	"time"
-
 	"github.com/Nerzal/gocloak/v10"
 	"github.com/golang-jwt/jwt/v4"
+	"strings"
+	"time"
 )
 
 type Provider interface {


### PR DESCRIPTION
Extending auth provider to get current User's username (```preffered_username``` field from JWT token generated by Keycloak) and setting CreateUser and UpdateUser attributes on models in create&update API calls.

### Development notes
I struggled with gocloak GetUserInfo() method which always failed as part hub's auth middleware on missing or invalid token. Even wrote standalone GetUserInfo-like method in golang directly with net/http https://gist.github.com/aufi/57556376c440301713bde6b04b57ca4a it without gocloak and tested it with curl, however no sucess from the running hub.

Finally, the solution was already part of the existing auth token and its decode method which reads access scopes. So a new method getting the username was added to the auth provider and API Base was updated to call the Username method with token from gin context.

Adding an example on what is currently encoded in the Keycloak token:
![image](https://user-images.githubusercontent.com/555381/170962347-bded6ba0-e6c3-4400-93bc-30f09c068912.png)


https://issues.redhat.com/browse/TACKLE-424