### PR TITLE
Add error for unknown RecordTypes in CSV import

### DIFF
--- a/api/import.go
+++ b/api/import.go
@@ -246,6 +246,9 @@ func (h ImportHandler) UploadCSV(ctx *gin.Context) {
 		ctx.Status(http.StatusBadRequest)
 	}
 
+	// Counter for unknown RecordType rows (!=1 or !=2)
+	unknownRecordsCnt := 0
+
 	for {
 		row, err := csvReader.Read()
 		if err != nil {
@@ -267,15 +270,17 @@ func (h ImportHandler) UploadCSV(ctx *gin.Context) {
 		case RecordTypeDependency:
 			imp = h.dependencyFromRow(fileName, row)
 		default:
-			imp = model.Import{
-				Filename:    fileName,
-				RecordType1: row[0],
-			}
+			// Accept only known RecordTypes
+			unknownRecordsCnt += 1
 		}
 		imp.ImportSummary = m
 		result := h.DB.Create(&imp)
 		if result.Error != nil {
 			h.createFailed(ctx, result.Error)
+			return
+		}
+		if unknownRecordsCnt > 0 {
+			ctx.JSON(http.StatusBadRequest, gin.H{"errorMessage": fmt.Sprintf("Import CSV was successfully uploaded, but there was %d unknown records.", unknownRecordsCnt)})
 			return
 		}
 	}


### PR DESCRIPTION
QE requested validating RecordTypes during CSV import to keep user up-to-date with amount of records which was accepted/rejected and rejected with unknown type.

The type is processed during initial CSV upload, so adding counter displaying user a error message with information that there is some amount of not accepted records.

https://issues.redhat.com/browse/TACKLE-634