### PR TITLE
Fix Pathfinder API path

### DIFF
--- a/hack/tool/tackle
+++ b/hack/tool/tackle
@@ -107,7 +107,7 @@ def apiJSON(url, token, data=None, method='GET', ignoreErrors=False):
 
 def tackle2path(obj):
     if 'assessment' in obj:
-        return "/pathfinder/%s" % obj.replace("--", "/")    # Nested path decoding (e.g. assessments/assessment-risk)
+        return "/hub/pathfinder/%s" % obj.replace("--", "/")    # Nested path decoding (e.g. assessments/assessment-risk)
     return "/hub/%s" % obj
 
 def loadDump(path):
@@ -433,7 +433,7 @@ class Tackle12Import:
                 # Pathfinder resources are dependent on Application, cheking it via applicationId
                 if t == "applications":
                     # Check Application's Assessments first
-                    asmnts = apiJSON(self.tackle2Url + "/pathfinder/assessments?applicationId=%d" % importObj['id'], self.tackle2Token, ignoreErrors=True)
+                    asmnts = apiJSON(self.tackle2Url + "/hub/pathfinder/assessments?applicationId=%d" % importObj['id'], self.tackle2Token, ignoreErrors=True)
                     if len(asmnts) > 0:
                         print("ERROR: Pathfinder assessment for application ID %d already exists. Clean it before running the import with: tackle clean" % importObj['id'])
                         exit(1)
@@ -452,10 +452,10 @@ class Tackle12Import:
                 # Pathfinder resources are dependent on Application
                 if t == "applications":
                     # Delete related Application's Assessment resources first
-                    collection = apiJSON(self.tackle2Url + "/pathfinder/assessments?applicationId=%d" % dictObj['id'], self.tackle2Token, ignoreErrors=True)
+                    collection = apiJSON(self.tackle2Url + "/hub/pathfinder/assessments?applicationId=%d" % dictObj['id'], self.tackle2Token, ignoreErrors=True)
                     for assm in collection:
                         print("Deleting assessment %s for applicationId=%s" % (assm['id'], dictObj['id']))
-                        apiJSON("%s/pathfinder/assessments/%s" % (self.tackle2Url, assm['id']), self.tackle2Token, method='DELETE', ignoreErrors=True)
+                        apiJSON("%s/hub/pathfinder/assessments/%s" % (self.tackle2Url, assm['id']), self.tackle2Token, method='DELETE', ignoreErrors=True)
                 # Hub resources
                 print("Deleting %s/%s" % (t, dictObj['id']))
                 apiJSON("%s/hub/%s/%d" % (self.tackle2Url, t, dictObj['id']), self.tackle2Token, method='DELETE', ignoreErrors=True)


### PR DESCRIPTION
Pathfinder path under the Hub API has changed, updating the tackle CLI
tool to use the hub prefix also for pathfinder.

https://issues.redhat.com/browse/TACKLE-649