### PR TITLE
TACKLE-558: Task cancel.

### DIFF
--- a/api/task.go
+++ b/api/task.go
@@ -458,7 +458,6 @@ func (h *TaskHandler) omitted(db *gorm.DB) (out *gorm.DB) {
 		"Canceled",
 		"Error",
 		"Retries",
-		"TaskGroupID",
 	} {
 		out = out.Omit(f)
 	}

--- a/api/task.go
+++ b/api/task.go
@@ -448,16 +448,19 @@ func (h TaskHandler) DeleteReport(ctx *gin.Context) {
 //   - Create
 //   - Update.
 func (h *TaskHandler) omitted(db *gorm.DB) (out *gorm.DB) {
-	db = db.Omit("Bucket")
-	db = db.Omit("Image")
-	db = db.Omit("Pod")
-	db = db.Omit("Started")
-	db = db.Omit("Terminated")
-	db = db.Omit("Canceled")
-	db = db.Omit("Error")
-	db = db.Omit("Report")
-	db = db.Omit("TaskGroupID")
 	out = db
+	for _, f := range []string{
+		"Bucket",
+		"Image",
+		"Pod",
+		"Started",
+		"Terminated",
+		"Canceled",
+		"Error",
+		"TaskGroupID",
+	} {
+		out = out.Omit(f)
+	}
 	return
 }
 

--- a/api/task.go
+++ b/api/task.go
@@ -457,6 +457,7 @@ func (h *TaskHandler) omitted(db *gorm.DB) (out *gorm.DB) {
 		"Terminated",
 		"Canceled",
 		"Error",
+		"Retries",
 		"TaskGroupID",
 	} {
 		out = out.Omit(f)

--- a/api/task.go
+++ b/api/task.go
@@ -292,7 +292,7 @@ func (h TaskHandler) Cancel(ctx *gin.Context) {
 			tasking.Failed,
 			tasking.Canceled,
 		})
-	err := db.Update("Canceled", time.Now()).Error
+	err := db.Update("Canceled", true).Error
 	if err != nil {
 		h.updateFailed(ctx, err)
 		return
@@ -444,7 +444,9 @@ func (h TaskHandler) DeleteReport(ctx *gin.Context) {
 }
 
 //
-// Fields omitted by Create and Update.
+// Fields omitted by:
+//   - Create
+//   - Update.
 func (h *TaskHandler) omitted(db *gorm.DB) (out *gorm.DB) {
 	db = db.Omit("Bucket")
 	db = db.Omit("Image")

--- a/hack/update/cancel.sh
+++ b/hack/update/cancel.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+host="${HOST:-localhost:8080}"
+
+# ID to update (default:1)
+id="${1:-1}"
+
+
+curl -I -X PUT ${host}/tasks/${id}/cancel

--- a/model/task.go
+++ b/model/task.go
@@ -35,6 +35,7 @@ type Task struct {
 	Terminated    *time.Time
 	State         string `gorm:"index"`
 	Error         string
+	Canceled      bool
 	Pod           string `gorm:"index"`
 	Retries       int
 	Report        *TaskReport `gorm:"constraint:OnDelete:CASCADE"`

--- a/model/task.go
+++ b/model/task.go
@@ -35,9 +35,9 @@ type Task struct {
 	Terminated    *time.Time
 	State         string `gorm:"index"`
 	Error         string
-	Canceled      bool
 	Pod           string `gorm:"index"`
 	Retries       int
+	Canceled      bool
 	Report        *TaskReport `gorm:"constraint:OnDelete:CASCADE"`
 	ApplicationID *uint
 	Application   *Application

--- a/task/manager.go
+++ b/task/manager.go
@@ -370,6 +370,8 @@ func (r *Task) Delete(client k8s.Client) (err error) {
 		err = liberr.Wrap(err)
 		return
 	}
+	mark := time.Now()
+	r.Terminated = &mark
 	return
 }
 
@@ -381,13 +383,7 @@ func (r *Task) Cancel(client k8s.Client) (err error) {
 		return
 	}
 	r.State = Canceled
-	r.Pod = ""
 	r.Bucket = ""
-	switch r.State {
-	case Running:
-		mark := time.Now()
-		r.Terminated = &mark
-	}
 	Log.Info(
 		"Task canceled.",
 		"id",

--- a/task/manager.go
+++ b/task/manager.go
@@ -121,7 +121,7 @@ func (m *Manager) startReady() {
 	for i := range list {
 		task := &list[i]
 		if task.Canceled {
-			m.cancel(task)
+			m.canceled(task)
 			continue
 		}
 		switch task.State {
@@ -176,7 +176,7 @@ func (m *Manager) updateRunning() {
 	}
 	for _, running := range list {
 		if running.Canceled {
-			m.cancel(&running)
+			m.canceled(&running)
 			continue
 		}
 		rt := Task{&running}
@@ -222,8 +222,8 @@ func (m *Manager) postpone(ready *model.Task, list []model.Task) (postponed bool
 }
 
 //
-// cancel the task.
-func (m *Manager) cancel(task *model.Task) {
+// The task has been canceled.
+func (m *Manager) canceled(task *model.Task) {
 	rt := Task{task}
 	err := rt.Cancel(m.Client)
 	Log.Trace(err)


### PR DESCRIPTION
Add support for canceling tasks.
Adds: `/tasks/:id/cancel` endpoint which updates the Task.canceled attribute.
The task manager will:
- delete the associated pod.
- release the bucket.
- set the state=_Canceled_.

Related: With the addition of another update endpoint, it made sense to de-duplicate the omitted fields.

https://issues.redhat.com/browse/TACKLE-558