### PR TITLE
Add full cleanup to tackle tool

### DIFF
--- a/hack/tool/README.md
+++ b/hack/tool/README.md
@@ -12,6 +12,24 @@ Use ```tackle-config.yml.example``` file as a template to set your Tackle endpoi
 - ```export-tackle1``` exports Tackle 1.2 API objects into local JSON files
 - ```import``` creates objects in Tackle 2 from local JSON files
 - ```clean``` deletes objects uploaded to Tackle 2 from local JSON files
+- ```clean-all``` deletes ALL data from Tackle 2 (including seeds)
+
+### Scenarios
+
+#### Migrate data from running Tackle 1.2 to running Tackle 2 instance
+
+With tags, tag-types and job functions automatic re-mapping.
+
+- ```tackle export-tackle1```
+- ```tackle import```
+
+#### Export data from Tackle 1.2 to be later imported to some Tackle 2 instance
+
+With full export and full cleanup of the Tackle 2 before running the import.
+
+- ```tackle --skip-destination-check export-tackle1``` (ensures that all seeds objects are exported too)
+- ```tackle clean-all```
+- ```tackle import```
 
 ### Export Tackle 1.2
 

--- a/hack/tool/README.md
+++ b/hack/tool/README.md
@@ -4,6 +4,33 @@ A tool for Konveyor Tackle application maintenance written in Python.
 
 For more details about the Tackle project, see [Tackle2-Hub README](https://github.com/konveyor/tackle2-hub) or https://github.com/konveyor/tackle-documentation.
 
+## Scenarios
+
+### Migrate data from running Tackle 1.2 to running Tackle 2 instance
+
+Migrate data updating refs to the seed objects matching to the destination Tackle 2 (tags, tag-types and job functions seeded).
+
+- ```tackle export-tackle1```
+- ```tackle import```
+
+### Export data from Tackle 1.2 to be later imported to some Tackle 2 instance
+
+Exports full data dump including seeds to be later imported to currently not available Tackle 2 instance, which needs a cleanup before running the import.
+
+- ```tackle --skip-destination-check export-tackle1```
+- ```tackle clean-all```
+- ```tackle import```
+
+### If the import failed
+
+The ```tackle import``` command could fail in a pre-import check phase which ensures there are no resources of given type with the same ID in the destination Tackle 2 (error after ```Checking tagtypes in destination Tackle2..``` etc.). In this case, run ```tackle clean``` command, which will remove such objects from the destination Tackle 2 API or remove it manually either from the destination Tackle 2 or from the JSON data files.
+
+If the import failed in the upload phase (error after ```Uploading tagtypes..``` etc.), try  ```tackle clean``` to remove already imported objects followed by  ```tackle clean-all``` which lists all resources of all known data types in the destination Tackle 2 API and deletes it (without looking to local data files).
+
+Note on ```clean-all``` command, it deletes all resources from Tackle 2 Hub API, however Pathfinder API doesn't support listing assessments without providing an applicationID. The applications could not be present in Hub, so an "orphaned" assessments could stay in Pathfinder. In order to resolve potential collision with imported data, run  ```tackle clean``` together with the ```clean-all``` command.
+
+Caution: all clean actions might delete objects already present in the Tackle 2 and unrelated to the import data.
+
 ## Usage
 
 Use ```tackle-config.yml.example``` file as a template to set your Tackle endpoints and credentials and save it as ```tackle-config.yml``` before running the ```tackle``` command.
@@ -12,24 +39,7 @@ Use ```tackle-config.yml.example``` file as a template to set your Tackle endpoi
 - ```export-tackle1``` exports Tackle 1.2 API objects into local JSON files
 - ```import``` creates objects in Tackle 2 from local JSON files
 - ```clean``` deletes objects uploaded to Tackle 2 from local JSON files
-- ```clean-all``` deletes ALL data from Tackle 2 (including seeds)
-
-### Scenarios
-
-#### Migrate data from running Tackle 1.2 to running Tackle 2 instance
-
-With tags, tag-types and job functions automatic re-mapping.
-
-- ```tackle export-tackle1```
-- ```tackle import```
-
-#### Export data from Tackle 1.2 to be later imported to some Tackle 2 instance
-
-With full export and full cleanup of the Tackle 2 before running the import.
-
-- ```tackle --skip-destination-check export-tackle1``` (ensures that all seeds objects are exported too)
-- ```tackle clean-all```
-- ```tackle import```
+- ```clean-all``` deletes ALL data returned by Tackle 2 (including seeds, additional to ```clean```), skips some pathfinder stuff without index action
 
 ### Export Tackle 1.2
 
@@ -44,7 +54,14 @@ Check local JSON dump files in ```./tackle-data``` directory (if needed) and cre
 The import command connects to Tackle2 Hub, check existing objects for possible collisions (by IDs) and uploads resources from local JSON files.
 
 ### Delete uploaded objects
+
 To delete objects previously created by the ```import``` command, run ```tackle clean```. This can address also existing Tackle 2 objects which are in collision with local JSON dump files.
+
+### Delete all objects
+
+The Tackle2 instance could be cleaned-up with ```tackle clean``` command. It lists objects from all data types and deletes such resources.
+
+There is a exception with Pathfinder API which doesn't support listing assessments without knowledge of applicationIDs, so this might stay in Pathfinder database.
 
 ### Command line options
 
@@ -53,6 +70,8 @@ Config file ```-c / --config``` path specifies a YAML file with configuration op
 Verbose output ```-v / --verbose``` option logs all API requests and responses providing more information for possible debugging (```off``` by default).
 
 Data directory ```-d / --data-dir``` specifies path to local directory with Tackle database records in JSON format (```./tackle-data``` by default).
+
+A full export without having access to the destination Tackle 2 and including all seed objects can be executed with ```-s / --skip-destination-check``` option. When importing such data, the destination Tackle 2 needs to be empty (run ```clean-all``` first).
 
 SSL warnings ```-w / --disable-ssl-warnings``` optional suppress ssl warning for api requests.
 
@@ -67,7 +86,7 @@ usage: tackle [-h] [-c [CONFIG]] [-d [DATA_DIR]] [-v] [-s] [action ...]
 Konveyor Tackle maintenance tool.
 
 positional arguments:
-  action                One or more Tackle commands that should be executed, options: export-tackle1 import clean
+  action                One or more Tackle commands that should be executed, options: export-tackle1 import clean clean-all
 
 options:
   -h, --help            show this help message and exit
@@ -103,4 +122,4 @@ tackle1:
 
 ```
 
-Unverified HTTPS warnings from Python could be hidden by ```export PYTHONWARNINGS="ignore:Unverified HTTPS request"```.
+Unverified HTTPS warnings from Python could be hidden by ```export PYTHONWARNINGS="ignore:Unverified HTTPS request"``` or with ```-w``` command option.

--- a/hack/tool/tackle
+++ b/hack/tool/tackle
@@ -460,6 +460,25 @@ class Tackle12Import:
                 print("Deleting %s/%s" % (t, dictObj['id']))
                 apiJSON("%s/hub/%s/%d" % (self.tackle2Url, t, dictObj['id']), self.tackle2Token, method='DELETE', ignoreErrors=True)
 
+    def cleanAllTackle2(self):
+        self.TYPES.reverse()
+        for t in self.TYPES:
+            # Pathfinder resources are dependent on Application, skip it
+            if "assessment" in t:
+                continue
+            destCollection = apiJSON(self.tackle2Url + tackle2path(t), self.tackle2Token)
+            for dictObj in destCollection:
+                if t == "applications":
+                    # Delete related Application's Assessment resources first
+                    collection = apiJSON(self.tackle2Url + "/hub/pathfinder/assessments?applicationId=%d" % dictObj['id'], self.tackle2Token, ignoreErrors=True)
+                    for assm in collection:
+                        print("Deleting assessment %s for applicationId=%s" % (assm['id'], dictObj['id']))
+                        apiJSON("%s/hub/pathfinder/assessments/%s" % (self.tackle2Url, assm['id']), self.tackle2Token, method='DELETE', ignoreErrors=True)
+                # Hub resources
+                print("Deleting %s/%s" % (t, dictObj['id']))
+                apiJSON("%s/hub/%s/%d" % (self.tackle2Url, t, dictObj['id']), self.tackle2Token, method='DELETE', ignoreErrors=True)
+
+
 class Tackle2Object:
     def __init__(self, initAttrs = {}):
         if initAttrs:
@@ -523,6 +542,19 @@ if cmdWanted(args, "clean"):
     # Run the cleanup
     print("Cleaning data created in Tackle2")
     tackle12import.cleanTackle2()
+
+# Clean ALL objects in Tackle2
+if cmdWanted(args, "clean-all"):
+    cmdExecuted = True
+    # Gather Keycloak access token for Tackle 2
+    token2 = getKeycloakToken(c['url'], c['username'], c['password'])
+
+    # Setup Tackle 1.2->2.0 data migration object
+    tackle12import = Tackle12Import(args.data_dir, '', '', c['url'], token2)
+
+    # Run the cleanup including seeds
+    print("Cleaning ALL data in Tackle2")
+    tackle12import.cleanAllTackle2()
 
 # Print help if action was not specified
 if not cmdExecuted:

--- a/hack/tool/tackle
+++ b/hack/tool/tackle
@@ -129,8 +129,8 @@ def cmdWanted(args, action):
 
 class Tackle12Import:
     # TYPES order matters for import/upload to Tackle2
-    TYPES = ['tags', 'tagtypes', 'jobfunctions', 'stakeholdergroups', 'stakeholders', 'businessservices', 'applications', 'proxies', 'dependencies', 'assessments', 'assessments--assessment-risk', 'assessments--confidence', 'reviews', 'identities']
-    TACKLE2_SEED_TYPES = ['tags', 'tagtypes', 'jobfunctions']
+    TYPES = ['tagtypes', 'tags', 'jobfunctions', 'stakeholdergroups', 'stakeholders', 'businessservices', 'applications', 'proxies', 'dependencies', 'assessments', 'assessments--assessment-risk', 'assessments--confidence', 'reviews', 'identities']
+    TACKLE2_SEED_TYPES = ['tagtypes', 'tags', 'jobfunctions']
 
     def __init__(self, dataDir, tackle1Url, tackle1Token, tackle2Url, tackle2Token):
         self.dataDir      = dataDir


### PR DESCRIPTION
Adding clean-all command to support scenario exporting Tackle 1.2 and importing later to some Tackle 2 instance which needs to be cleaned-up first and updating order of import objects which created empty tag types first and then tags with refs to the created tag types.

Also updated README with expected scenarios how the tool should be used.

https://issues.redhat.com/browse/TACKLE-660