### PR TITLE
Update tool README with requirements

### DIFF
--- a/hack/tool/README.md
+++ b/hack/tool/README.md
@@ -33,7 +33,9 @@ Caution: all clean actions might delete objects already present in the Tackle 2 
 
 ## Requirements
 
-The tool requires Python >= 3.9 to be installed (which should be present by default on most systems) and PyYAML module (install with package manager ```dnf install python3-pyyaml``` or Python PIP tool ```python3 -m pip install pyyaml```).
+The tool requires Python3 to be installed, PyYAML module and git to get the source code, install it with  ```dnf install python39 python3-pyyaml git``` (for Red Hat-like Linux distros).
+
+Since git and python3 should be present on most systems, it might be enought just install PyYAML with Python PIP tool ```python3 -m pip install pyyaml``` without need to use your OS package manager.
 
 ## Usage
 

--- a/hack/tool/README.md
+++ b/hack/tool/README.md
@@ -31,9 +31,22 @@ Note on ```clean-all``` command, it deletes all resources from Tackle 2 Hub API,
 
 Caution: all clean actions might delete objects already present in the Tackle 2 and unrelated to the import data.
 
+## Requirements
+
+The tool requires Python >= 3.9 to be installed (which should be present by default on most systems) and PyYAML module (install with package manager ```dnf install python3-pyyaml``` or Python PIP tool ```python3 -m pip install pyyaml```).
+
 ## Usage
 
-Use ```tackle-config.yml.example``` file as a template to set your Tackle endpoints and credentials and save it as ```tackle-config.yml``` before running the ```tackle``` command.
+Clone Github repository:
+```git clone https://github.com/konveyor/tackle2-hub.git```
+
+Change to the tool directory:
+```cd hack/tool```
+
+Use ```tackle-config.yml.example``` file as a template to set your Tackle endpoints and credentials and save it as ```tackle-config.yml```.
+
+Run the tackle tool:
+```./tackle```
 
 ### Supported actions
 - ```export-tackle1``` exports Tackle 1.2 API objects into local JSON files

--- a/hack/tool/README.md
+++ b/hack/tool/README.md
@@ -33,9 +33,11 @@ Caution: all clean actions might delete objects already present in the Tackle 2 
 
 ## Requirements
 
-The tool requires Python3 to be installed, PyYAML module and git to get the source code, install it with  ```dnf install python39 python3-pyyaml git``` (for Red Hat-like Linux distros).
+The tool requires Python3 with YAML parser to be installed. A Python 3.6 (default in RHEL8) has YAML already included, but e.g. Python 3.9 (default in RHEL9) requires install a PyYAML module. Also git is needed to get the source code.
 
-Since git and python3 should be present on most systems, it might be enought just install PyYAML with Python PIP tool ```python3 -m pip install pyyaml``` without need to use your OS package manager.
+Install requirements with  ```dnf install python39 python3-pyyaml git``` for RHEL-like Linux or corresponding for your operating system.
+
+Since Python3 and git should be present on most developers/sysadmins systems, it might be enought just ensure there presence of PyYAML with Python PIP tool ```python3 -m pip install pyyaml``` without need to use operating system package manager.
 
 ## Usage
 

--- a/hack/tool/tackle
+++ b/hack/tool/tackle
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import argparse
 import copy
@@ -74,17 +74,16 @@ def getKeycloakToken(host, username, password, client_id='tackle-ui', realm='tac
 
 def apiJSON(url, token, data=None, method='GET', ignoreErrors=False):
     debugPrint("Querying: %s" % url)
-    match method:
-        case 'DELETE':
-            r = requests.delete(url, headers={"Authorization": "Bearer %s" % token, "Content-Type": "application/json"}, verify=False)
-        case 'POST':
-            debugPrint("POST data: %s" % json.dumps(data))
-            r = requests.post(url, data=json.dumps(data), headers={"Authorization": "Bearer %s" % token, "Content-Type": "application/json"}, verify=False)
-        case 'PATCH':
-            debugPrint("PATCH data: %s" % json.dumps(data))
-            r = requests.patch(url, data=json.dumps(data), headers={"Authorization": "Bearer %s" % token, "Content-Type": "application/json"}, verify=False)
-        case _: # GET
-            r = requests.get(url, headers={"Authorization": "Bearer %s" % token, "Content-Type": "application/json"}, verify=False)
+    if method == 'DELETE':
+        r = requests.delete(url, headers={"Authorization": "Bearer %s" % token, "Content-Type": "application/json"}, verify=False)
+    elif method == 'POST':
+        debugPrint("POST data: %s" % json.dumps(data))
+        r = requests.post(url, data=json.dumps(data), headers={"Authorization": "Bearer %s" % token, "Content-Type": "application/json"}, verify=False)
+    elif method == 'PATCH':
+        debugPrint("PATCH data: %s" % json.dumps(data))
+        r = requests.patch(url, data=json.dumps(data), headers={"Authorization": "Bearer %s" % token, "Content-Type": "application/json"}, verify=False)
+    else: # GET
+        r = requests.get(url, headers={"Authorization": "Bearer %s" % token, "Content-Type": "application/json"}, verify=False)
 
     if not r.ok:
         if ignoreErrors:

--- a/hack/tool/tackle
+++ b/hack/tool/tackle
@@ -499,7 +499,9 @@ if cmdWanted(args, "export-tackle1"):
     cmdExecuted = True
     # Gather Keycloak access tokens for Tackle1&2
     token1 = getKeycloakToken(c['tackle1']['url'], c['tackle1']['username'], c['tackle1']['password'])
-    token2 = getKeycloakToken(c['url'], c['username'], c['password'])
+    token2 = ""
+    if not args.skipDestCheck:
+        token2 = getKeycloakToken(c['url'], c['username'], c['password'])
 
     # Setup Tackle 1.2->2.0 data migration object
     tackle12import = Tackle12Import(args.data_dir, c['tackle1']['url'], token1, c['url'], token2)


### PR DESCRIPTION
Adding Python and PyYAML requirement into tackle tool README, updates making it working on Python3, but <= 3.9, few minor usage updates and skip Tackle2 token request when using --skip-destination-check option.

Now should work on Python 3.6 (RHEL8) out-of-the box and Python 3.9 (RHEL9) with manually installed PyYAML.