### PR TITLE
Add --no-auth to Tackle tool

### DIFF
--- a/hack/tool/README.md
+++ b/hack/tool/README.md
@@ -94,11 +94,12 @@ SSL warnings ```-w / --disable-ssl-warnings``` optional suppress ssl warning for
 
 Import errors could be skipped with ``` -i / --ignore-import-errors ``` -  not recommended - use with high attention to avoid data inconsistency. If the import has failed, it is recommended use ```tackle clean``` command to remove only imported resources.
 
+Tackle2 deployments without auth feature (```feature_auth_required: false```), should use ```-n / --no-auth``` flag to skip Keycloak auth token creation, using empty token for Tackle API calls.
+
 ## Example
 
 ```
-$ tackle --help
-usage: tackle [-h] [-c [CONFIG]] [-d [DATA_DIR]] [-v] [-s] [action ...]
+usage: tackle [-h] [-c [CONFIG]] [-d [DATA_DIR]] [-v] [-s] [-w] [-i] [-n] [action ...]
 
 Konveyor Tackle maintenance tool.
 
@@ -118,8 +119,7 @@ options:
                         Do not display warnings during ssl check for api requests.
   -i, --ignore-import-errors
                         Skip to next item if an item fails load.
-
-
+  -n, --no-auth         Skip Keycloak token creation, use empty auth token in Tackle API calls.
 ```
 
 API endpoints and credentials should be set in a config file (```tackle-config.yml``` by default).

--- a/hack/tool/tackle
+++ b/hack/tool/tackle
@@ -24,6 +24,8 @@ parser.add_argument('-w','--disable-ssl-warnings', dest='disableSslWarnings', ac
                     help='Do not display warnings during ssl check for api requests.')
 parser.add_argument('-i','--ignore-import-errors', dest='ignoreImportErrors', action='store_const', const=True, default=False,
                     help='Skip to next item if an item fails load.')
+parser.add_argument('-n','--no-auth', dest='noAuth', action='store_const', const=True, default=False,
+                    help='Skip Keycloak token creation, use empty Auth token in Tackle API calls.')
 args = parser.parse_args()
 
 ###############################################################################
@@ -59,6 +61,10 @@ def debugPrint(str):
         print(str)
 
 def getKeycloakToken(host, username, password, client_id='tackle-ui', realm='tackle'):
+    if args.noAuth:
+        print("Skipping auth token creation for %s, using empty." % host)
+        return ""
+
     print("Getting auth token from %s" % host)
     url  = "%s/auth/realms/%s/protocol/openid-connect/token" % (host, realm)
     data = {'username': username, 'password': password, 'client_id': client_id, 'grant_type': 'password'}


### PR DESCRIPTION
Adding --no-auth (-n shortcut) flag to Tackle CLI tool. If used, Keycloak token creation is skipped and empty token is used in Tackle API calls.

Needed for RHPDS setup.