### PR TITLE
Cascade application delete to pathfinder.

### DIFF
--- a/api/application.go
+++ b/api/application.go
@@ -143,6 +143,12 @@ func (h ApplicationHandler) Delete(ctx *gin.Context) {
 		h.deleteFailed(ctx, result.Error)
 		return
 	}
+	p := Pathfinder{}
+	err := p.DeleteAssessment([]uint{id}, ctx)
+	if err != nil {
+		h.deleteFailed(ctx, err)
+		return
+	}
 	result = h.DB.Delete(m)
 	if result.Error != nil {
 		h.deleteFailed(ctx, result.Error)
@@ -164,6 +170,12 @@ func (h ApplicationHandler) DeleteList(ctx *gin.Context) {
 	err := ctx.BindJSON(&ids)
 	if err != nil {
 		h.bindFailed(ctx, err)
+		return
+	}
+	p := Pathfinder{}
+	err = p.DeleteAssessment(ids, ctx)
+	if err != nil {
+		h.deleteFailed(ctx, err)
 		return
 	}
 	err = h.DB.Delete(

--- a/api/pathfinder.go
+++ b/api/pathfinder.go
@@ -1,12 +1,18 @@
 package api
 
 import (
+	"bytes"
+	"encoding/json"
 	"github.com/gin-gonic/gin"
+	liberr "github.com/konveyor/controller/pkg/error"
 	"github.com/konveyor/tackle2-hub/auth"
+	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"path"
+	"strconv"
 )
 
 //
@@ -46,4 +52,70 @@ func (h PathfinderHandler) ReverseProxy(ctx *gin.Context) {
 	}
 
 	proxy.ServeHTTP(ctx.Writer, ctx.Request)
+}
+
+//
+// Pathfinder client.
+type Pathfinder struct {
+}
+
+//
+// DeleteAssessment deletes associated assessments by application Ids.
+func (r *Pathfinder) DeleteAssessment(ids []uint, ctx *gin.Context) (err error) {
+	client := r.client()
+	body := map[string][]uint{"applicationIds": ids}
+	b, _ := json.Marshal(body)
+	header := http.Header{
+		Authorization: ctx.Request.Header[Authorization],
+		ContentLength: []string{strconv.Itoa(len(b))},
+		ContentType:   []string{"application/json"},
+	}
+	request := r.request(
+		http.MethodDelete,
+		"bulkDelete",
+		header)
+	reader := bytes.NewReader(b)
+	request.Body = ioutil.NopCloser(reader)
+	result, err := client.Do(request)
+	if err != nil {
+		return
+	}
+	status := result.StatusCode
+	switch status {
+	case http.StatusNoContent:
+		Log.Info(
+			"Assessment(s) deleted for applications.",
+			"Ids",
+			ids)
+	default:
+		err = liberr.New(http.StatusText(status))
+	}
+
+	return
+}
+
+//
+// Build the client.
+func (r *Pathfinder) client() (client *http.Client) {
+	client = &http.Client{
+		Transport: &http.Transport{DisableKeepAlives: true},
+	}
+	return
+}
+
+//
+// Build the request
+func (r *Pathfinder) request(method, endpoint string, header http.Header) (request *http.Request) {
+	u, _ := url.Parse(os.Getenv("PATHFINDER_URL"))
+	u.Path = path.Join(
+		u.Path,
+		PathfinderRoot,
+		AssessmentsRoot,
+		endpoint)
+	request = &http.Request{
+		Method: method,
+		Header: header,
+		URL:    u,
+	}
+	return
 }

--- a/api/pkg.go
+++ b/api/pkg.go
@@ -24,6 +24,14 @@ const (
 )
 
 //
+// Headers
+const (
+	Authorization = "Authorization"
+	ContentLength = "Content-Length"
+	ContentType   = "Content-Type"
+)
+
+//
 // All builds all handlers.
 func All() []Handler {
 	return []Handler{


### PR DESCRIPTION
Cascade application delete to pathfinder. Need to complete: https://issues.redhat.com/browse/TACKLE-673.
The UI will no longer need to explicitly delete of assessments when an application is deleted.

Requires: new pathfinder _bulkDelete_ endpoint.