### PR TITLE
Allow empty App-BusinessService link in CSV import

### DIFF
--- a/api/application.go
+++ b/api/application.go
@@ -308,7 +308,7 @@ type Application struct {
 	Comments        string      `json:"comments"`
 	Identities      []Ref       `json:"identities"`
 	Tags            []Ref       `json:"tags"`
-	BusinessService Ref         `json:"businessService"`
+	BusinessService *Ref        `json:"businessService"`
 }
 
 //
@@ -327,7 +327,7 @@ func (r *Application) With(m *model.Application) {
 		ref.With(m.Review.ID, "")
 		r.Review = ref
 	}
-	r.BusinessService = r.ref(m.BusinessServiceID, m.BusinessService)
+	r.BusinessService = r.refPtr(m.BusinessServiceID, m.BusinessService)
 	r.Identities = []Ref{}
 	for _, id := range m.Identities {
 		ref := Ref{}
@@ -347,15 +347,17 @@ func (r *Application) With(m *model.Application) {
 // Model builds a model.
 func (r *Application) Model() (m *model.Application) {
 	m = &model.Application{
-		Name:              r.Name,
-		Description:       r.Description,
-		Comments:          r.Comments,
-		BusinessServiceID: r.BusinessService.ID,
-		Binary:            r.Binary,
+		Name:        r.Name,
+		Description: r.Description,
+		Comments:    r.Comments,
+		Binary:      r.Binary,
 	}
 	m.ID = r.ID
 	if r.Repository != nil {
 		m.Repository, _ = json.Marshal(r.Repository)
+	}
+	if r.BusinessService != nil {
+		m.BusinessServiceID = &r.BusinessService.ID
 	}
 	if r.Facts == nil {
 		r.Facts = Facts{}

--- a/importer/manager.go
+++ b/importer/manager.go
@@ -157,7 +157,9 @@ func (m *Manager) createApplication(imp *model.Import) (ok bool) {
 			businessService = &bs
 		}
 	}
-	if businessService.ID == 0 {
+
+	// If not found business service in database and import specifies some non-empty business service, proceeed with create it
+	if businessService.ID == 0 && normBusinessServiceName != "" {
 		if imp.ImportSummary.CreateEntities {
 			// Create a new BusinessService if not existed
 			businessService.Name = imp.BusinessService
@@ -171,7 +173,11 @@ func (m *Manager) createApplication(imp *model.Import) (ok bool) {
 			return
 		}
 	}
-	app.BusinessService = businessService
+
+	// Assign business service to the application if was specified
+	if businessService.ID != 0 {
+		app.BusinessService = businessService
+	}
 
 	// Process import Tags & TagTypes
 	tagTypes := []model.TagType{}

--- a/model/application.go
+++ b/model/application.go
@@ -15,7 +15,7 @@ type Application struct {
 	Tasks             []Task     `gorm:"constraint:OnDelete:CASCADE"`
 	Tags              []Tag      `gorm:"many2many:ApplicationTags;constraint:OnDelete:CASCADE"`
 	Identities        []Identity `gorm:"many2many:ApplicationIdentity;constraint:OnDelete:CASCADE"`
-	BusinessServiceID uint       `gorm:"index"`
+	BusinessServiceID *uint      `gorm:"index"`
 	BusinessService   *BusinessService
 }
 

--- a/model/control.go
+++ b/model/control.go
@@ -4,7 +4,7 @@ type BusinessService struct {
 	Model
 	Name          string `gorm:"index;unique;not null"`
 	Description   string
-	Applications  []Application `gorm:"constraint:OnDelete:CASCADE"`
+	Applications  []Application `gorm:"constraint:OnDelete:SET NULL"`
 	StakeholderID *uint         `gorm:"index"`
 	Stakeholder   *Stakeholder
 }


### PR DESCRIPTION
Application CSV import have BusinessService field which could be empty and that should not result to creation a new BusinessService record with empty name, but should make an Application without linked BusinessService.

Part of code making BusinessService association on Application with pointer comes from @mansam's closed PR https://github.com/konveyor/tackle2-hub/pull/127

Fixes https://issues.redhat.com/browse/TACKLE-719