### PR TITLE
Always set error messages for invalid CSV records

### DIFF
--- a/importer/manager.go
+++ b/importer/manager.go
@@ -56,6 +56,14 @@ func (m *Manager) processImports() (err error) {
 			ok = m.createApplication(&imp)
 		case api.RecordTypeDependency:
 			ok = m.createDependency(&imp)
+		default:
+			errMsg := ""
+			if imp.RecordType1 == "" {
+				errMsg = "Empty Record Type."
+			} else {
+				errMsg = fmt.Sprintf("Invalid or unknown Record Type '%s'. Must be '1' for Application or '2' for Dependency.", imp.RecordType1)
+			}
+			imp.ErrorMessage = errMsg
 		}
 		imp.IsValid = ok
 		imp.Processed = true


### PR DESCRIPTION
Unknown and empty records in Application CSV importes were skipped in background import process (and counted as invalid) until now.

Adding error message to each such unknown record to match expectations from Tackle 1.2 usage.

Fixes: https://issues.redhat.com/browse/TACKLE-634
Fixes: https://issues.redhat.com/browse/TACKLE-742
Fixes: https://issues.redhat.com/browse/TACKLE-743