### PR TITLE
[Backport 2.1] Validate non-empty Application Name in CSV Import

### DIFF
--- a/importer/manager.go
+++ b/importer/manager.go
@@ -128,6 +128,7 @@ func (m *Manager) createApplication(imp *model.Import) (ok bool) {
 
 	if app.Name == "" {
 		imp.ErrorMessage = "Application Name is mandatory."
+		return
 	}
 
 	repository := api.Repository{

--- a/importer/manager.go
+++ b/importer/manager.go
@@ -125,6 +125,11 @@ func (m *Manager) createApplication(imp *model.Import) (ok bool) {
 		Description: imp.Description,
 		Comments:    imp.Comments,
 	}
+
+	if app.Name == "" {
+		imp.ErrorMessage = "Application Name is mandatory."
+	}
+
 	repository := api.Repository{
 		Kind:   imp.RepositoryKind,
 		URL:    imp.RepositoryURL,


### PR DESCRIPTION
2.1.0 backport of https://github.com/konveyor/tackle2-hub/pull/142

Adding error message for empty application name in CSV import matching to Tackle 1.2.

Fixes https://issues.redhat.com/browse/TACKLE-749