### PR TITLE
TACKLE-654: Better support DB concurrency.

### DIFF
--- a/database/db_test.go
+++ b/database/db_test.go
@@ -1,0 +1,39 @@
+package database
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/konveyor/tackle2-hub/model"
+	"os"
+	"testing"
+)
+
+var N = 800
+
+func TestConcurrent(t *testing.T) {
+	Settings.DB.Path = "/tmp/concurrent.db"
+	_ = os.Remove(Settings.DB.Path)
+	db, err := Open(true)
+	if err != nil {
+		panic(err)
+	}
+	dq := make(chan int, N)
+	for w := 0; w < N; w++ {
+		go func(id int) {
+			fmt.Printf("Started %d\n", id)
+			for n := 0; n < N; n++ {
+				v, _ := json.Marshal(fmt.Sprintf("Test-%d", n))
+				m := &model.Setting{Key: fmt.Sprintf("key-%d-%d", id, n), Value: v}
+				uErr := db.Create(m).Error
+				if uErr != nil {
+					panic(uErr)
+				}
+			}
+			dq <- id
+		}(w)
+	}
+	for w := 0; w < N; w++ {
+		id := <-dq
+		fmt.Printf("Done %d\n", id)
+	}
+}

--- a/database/pkg.go
+++ b/database/pkg.go
@@ -17,9 +17,9 @@ var log = logging.WithName("db")
 var Settings = &settings.Settings
 
 const (
-	ConnectionString = "file:%s"
-	FKsOn            = "?_foreign_keys=yes"
-	FKsOff           = "?_foreign_keys=no"
+	ConnectionString = "file:%s?_journal=WAL"
+	FKsOn            = "&_foreign_keys=yes"
+	FKsOff           = "&_foreign_keys=no"
 )
 
 //
@@ -31,7 +31,6 @@ func Open(enforceFKs bool) (db *gorm.DB, err error) {
 	} else {
 		connStr += FKsOff
 	}
-
 	db, err = gorm.Open(
 		sqlite.Open(connStr),
 		&gorm.Config{
@@ -44,6 +43,12 @@ func Open(enforceFKs bool) (db *gorm.DB, err error) {
 		err = liberr.Wrap(err)
 		return
 	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	sqlDB.SetMaxOpenConns(1)
 	err = db.AutoMigrate(model.Setting{})
 	if err != nil {
 		err = liberr.Wrap(err)


### PR DESCRIPTION
As recommended by sqlite3 driver [documentation](https://pkg.go.dev/github.com/mattn/go-sqlite3#section-readme), we need to:
- Set the `_journal=WAL` in the DSN (better performance).
- Limit the open connections to (1).

The included unit test reproduced the _database locked_ error.  This patch eliminates the error.

https://issues.redhat.com/browse/TACKLE-654