### PR TITLE
Address #157 and #158 install controller-gen and upgrade to 0.10.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,12 +57,7 @@ generate: controller-gen
 controller-gen:
 ifeq (, $(shell which controller-gen))
 	@{ \
-	set -e ;\
-	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
-	cd $$CONTROLLER_GEN_TMP_DIR ;\
-	go mod init tmp ;\
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.5.0 ;\
-	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
+	go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.10.0 ;\
 	}
 CONTROLLER_GEN=$(GOBIN)/controller-gen
 else


### PR DESCRIPTION
Fixes #157 
Fixes #158 

I am unsure if this upgrade to controller-gen 0.10.0 is safe.  
I can confirm I was able to compile on Linux and Mac after this change, have not confirmed I can run correctly yet.  