### PR TITLE
Send 204 for empty buckets archive GET

### DIFF
--- a/api/bucket.go
+++ b/api/bucket.go
@@ -193,10 +193,9 @@ func (h *BucketHandler) getDirArchive(ctx *gin.Context, dir string) {
 		return
 	}
 
-	// Return empty response instead of empty tar.gz archive
+	// Indicate empty tar.gz archive with the 204 HTTP code
 	if entriesCount < 1 {
 		ctx.Status(http.StatusNoContent)
-		return
 	}
 
 	fromTar := bufio.NewReader(&tarOutput)

--- a/api/bucket.go
+++ b/api/bucket.go
@@ -195,7 +195,7 @@ func (h *BucketHandler) getDirArchive(ctx *gin.Context, dir string) {
 
 	// Indicate empty tar.gz archive with the 204 HTTP code
 	if entriesCount < 1 {
-		ctx.Status(http.StatusNoContent)
+		ctx.Writer.WriteHeader(http.StatusNoContent)
 	}
 
 	fromTar := bufio.NewReader(&tarOutput)


### PR DESCRIPTION
The buckets GET archive dir produces empty tar.gz archive if the directry was empty. It makes more sense to return 204 and no data in such case to tell client, that there is no data instead of sending 200 with empty tar.gz (that is ~100Bytes size).

Example:
```
# NON EMPTY
$ curl -vOJ -H "X-Directory:archive" localhost:8080/applications/1/bucket/
*   Trying 127.0.0.1:8080...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /applications/1/bucket/ HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.79.1
> Accept: */*
> X-Directory:archive
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< Content-Disposition: attachment; filename="ff44af38-73e8-46c2-8a37-3c679c006352.tar.gz"
< Date: Fri, 21 Oct 2022 13:31:39 GMT
< Content-Length: 178
< Content-Type: application/x-gzip
< 
{ [178 bytes data]
100   178  100   178    0     0  37872      0 --:--:-- --:--:-- --:--:-- 44500
* Connection #0 to host localhost left intact
 
# EMPTY
$ curl -vOJ -H "X-Directory:archive" localhost:8080/applications/1/bucket/
*   Trying 127.0.0.1:8080...
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0* Connected to localhost (127.0.0.1) port 8080 (#0)
> GET /applications/1/bucket/ HTTP/1.1
> Host: localhost:8080
> User-Agent: curl/7.79.1
> Accept: */*
> X-Directory:archive
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 204 No Content
< Content-Disposition: attachment; filename="ff44af38-73e8-46c2-8a37-3c679c006352.tar.gz"
< Date: Fri, 21 Oct 2022 16:23:56 GMT
< 
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
* Connection #0 to host localhost left intact

```

Signed-off-by: Marek Aufart <maufart@redhat.com>