### PR TITLE
Fix tag conflict error in hack addon.

### DIFF
--- a/hack/cmd/addon/main.go
+++ b/hack/cmd/addon/main.go
@@ -252,7 +252,7 @@ func addTags(application *api.Application, names ...string) (err error) {
 				return
 			}
 		} else {
-			if wanted.TagType != tg.TagType {
+			if wanted.TagType.ID != tg.TagType.ID {
 				err = &SoftError{
 					Reason: "Tag conflict detected.",
 				}


### PR DESCRIPTION
The logic needs to compare the IDs not the `Ref` object.