### PR TITLE
fix: the closing tag was missing from the li element in html of the example addon code

### DIFF
--- a/hack/cmd/addon/main.go
+++ b/hack/cmd/addon/main.go
@@ -149,7 +149,7 @@ func buildIndex(output string) (err error) {
 	for _, name := range list {
 		body = append(
 			body,
-			"<li><a href=\""+name.Name()+"\">"+name.Name()+"</a>")
+			"<li><a href=\""+name.Name()+"\">"+name.Name()+"</a></li>")
 	}
 
 	body = append(body, "</ul>")


### PR DESCRIPTION
Signed-off-by: Harikrishnan Balagopal <harikrishmenon@gmail.com>