### PR TITLE
Update swagger with TaskGroup fix and app identity

### DIFF
--- a/api/taskgroup.go
+++ b/api/taskgroup.go
@@ -150,7 +150,7 @@ func (h TaskGroupHandler) Create(ctx *gin.Context) {
 // @success 204
 // @router /taskgroups/{id} [put]
 // @param id path string true "Task ID"
-// @param task body Task true "Task data"
+// @param task body TaskGroup true "Task data"
 func (h TaskGroupHandler) Update(ctx *gin.Context) {
 	id := h.pk(ctx)
 	updated := &TaskGroup{}

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -311,38 +311,6 @@ const docTemplate = `{
                 }
             }
         },
-        "/applications/{id}/identities": {
-            "get": {
-                "description": "List identities for an application.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "get"
-                ],
-                "summary": "List identities for an application.",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "Application ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/api.Identity"
-                            }
-                        }
-                    }
-                }
-            }
-        },
         "/applications/{id}/tasks/{id}/content/{wildcard}": {
             "get": {
                 "description": "Get bucket content by ID and path.",
@@ -2208,7 +2176,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.Task"
+                            "$ref": "#/definitions/api.TaskGroup"
                         }
                     }
                 ],

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -299,38 +299,6 @@
                 }
             }
         },
-        "/applications/{id}/identities": {
-            "get": {
-                "description": "List identities for an application.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "get"
-                ],
-                "summary": "List identities for an application.",
-                "parameters": [
-                    {
-                        "type": "integer",
-                        "description": "Application ID",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/api.Identity"
-                            }
-                        }
-                    }
-                }
-            }
-        },
         "/applications/{id}/tasks/{id}/content/{wildcard}": {
             "get": {
                 "description": "Get bucket content by ID and path.",
@@ -2196,7 +2164,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/api.Task"
+                            "$ref": "#/definitions/api.TaskGroup"
                         }
                     }
                 ],

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -689,27 +689,6 @@ paths:
       summary: Upload bucket content by ID and path.
       tags:
       - post
-  /applications/{id}/identities:
-    get:
-      description: List identities for an application.
-      parameters:
-      - description: Application ID
-        in: path
-        name: id
-        required: true
-        type: integer
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            items:
-              $ref: '#/definitions/api.Identity'
-            type: array
-      summary: List identities for an application.
-      tags:
-      - get
   /applications/{id}/tasks/{id}/content/{wildcard}:
     get:
       description: Get bucket content by ID and path.
@@ -1954,7 +1933,7 @@ paths:
         name: task
         required: true
         schema:
-          $ref: '#/definitions/api.Task'
+          $ref: '#/definitions/api.TaskGroup'
       responses:
         "204":
           description: ""


### PR DESCRIPTION
Updating swagger docs with
- fix of update TaskGroup param type (Task->TaskGroup)
- removing application/:is/identititis endpoint (already removed form API in #150)

Related to: https://issues.redhat.com/browse/TACKLE-932

Signed-off-by: Marek Aufart <maufart@redhat.com>