### PR TITLE
Add RBAC scope for bucket subresource.

### DIFF
--- a/api/application.go
+++ b/api/application.go
@@ -36,6 +36,8 @@ func (h ApplicationHandler) AddRoutes(e *gin.Engine) {
 	routeGroup.PUT(ApplicationRoot, h.Update)
 	routeGroup.DELETE(ApplicationsRoot, h.DeleteList)
 	routeGroup.DELETE(ApplicationRoot, h.Delete)
+	routeGroup = e.Group("/")
+	routeGroup.Use(auth.Required("applications.bucket"))
 	routeGroup.POST(AppBucketRoot, h.BucketUpload)
 	routeGroup.PUT(AppBucketRoot, h.BucketUpload)
 	routeGroup.GET(AppBucketRoot, h.BucketGet)

--- a/api/task.go
+++ b/api/task.go
@@ -48,6 +48,8 @@ func (h TaskHandler) AddRoutes(e *gin.Engine) {
 	routeGroup.DELETE(TaskRoot, h.Delete)
 	routeGroup.PUT(TaskSubmitRoot, h.Submit, h.Update)
 	routeGroup.PUT(TaskCancelRoot, h.Cancel)
+	routeGroup = e.Group("/")
+	routeGroup.Use(auth.Required("tasks.bucket"))
 	routeGroup.GET(TaskBucketRoot, h.BucketGet)
 	routeGroup.POST(TaskBucketRoot, h.BucketUpload)
 	routeGroup.PUT(TaskBucketRoot, h.BucketUpload)

--- a/api/taskgroup.go
+++ b/api/taskgroup.go
@@ -38,11 +38,13 @@ func (h TaskGroupHandler) AddRoutes(e *gin.Engine) {
 	routeGroup.PUT(TaskGroupRoot, h.Update)
 	routeGroup.GET(TaskGroupRoot, h.Get)
 	routeGroup.PUT(TaskGroupSubmitRoot, h.Submit, h.Update)
+	routeGroup.DELETE(TaskGroupRoot, h.Delete)
+	routeGroup = e.Group("/")
+	routeGroup.Use(auth.Required("tasks.bucket"))
 	routeGroup.GET(TaskGroupBucketRoot, h.BucketGet)
 	routeGroup.POST(TaskGroupBucketRoot, h.BucketUpload)
 	routeGroup.PUT(TaskGroupBucketRoot, h.BucketUpload)
 	routeGroup.DELETE(TaskGroupBucketRoot, h.BucketDelete)
-	routeGroup.DELETE(TaskGroupRoot, h.Delete)
 }
 
 // Get godoc

--- a/auth/role.go
+++ b/auth/role.go
@@ -15,6 +15,7 @@ var Settings = &settings.Settings
 var AddonRole = []string{
 	"applications:get",
 	"applications:put",
+	"applications.bucket:*",
 	"identities:get",
 	"identities:decrypt",
 	"proxies:get",
@@ -23,6 +24,7 @@ var AddonRole = []string{
 	"tagtypes:*",
 	"tasks:get",
 	"tasks.report:*",
+	"tasks.bucket:get",
 }
 
 //

--- a/auth/roles.yaml
+++ b/auth/roles.yaml
@@ -15,6 +15,12 @@
         - get
         - post
         - put
+    - name: applications.bucket
+      verbs:
+        - delete
+        - get
+        - post
+        - put
     - name: assessments
       verbs:
         - delete
@@ -95,6 +101,12 @@
         - post
         - put
     - name: tasks
+      verbs:
+        - delete
+        - get
+        - post
+        - put
+    - name: tasks.bucket
       verbs:
         - delete
         - get
@@ -121,6 +133,12 @@
         - get
         - post
         - put
+    - name: applications.bucket
+      verbs:
+        - delete
+        - get
+        - post
+        - put
     - name: assessments
       verbs:
         - delete
@@ -197,6 +215,12 @@
         - get
         - post
         - put
+    - name: tasks.bucket
+      verbs:
+        - delete
+        - get
+        - post
+        - put
     - name: cache
       verbs:
         - get
@@ -209,6 +233,9 @@
       verbs:
         - post
     - name: applications
+      verbs:
+        - get
+    - name: applications.bucket
       verbs:
         - get
     - name: assessments
@@ -257,6 +284,12 @@
       verbs:
         - get
     - name: tasks
+      verbs:
+        - delete
+        - get
+        - post
+        - put
+    - name: tasks.bucket
       verbs:
         - delete
         - get


### PR DESCRIPTION
Signed-off-by: Jeff Ortel <jortel@redhat.com>

Fixes 403 error introduced with RWX solution when deleting the bucket. This solution adds specific scopes for the bucket resource and grants ALL which includes DELETE to addons for the application bucket.  It would be best not to give DELETE on applications to addons.

```
{"level":"info","ts":1674081007.5718358,"logger":"addon","msg":"|403|  DELETE /applications/2/bucket/windup/report"}
{"level":"error","ts":1674081007.5718448,"logger":"addon","msg":"Addon failed.","error":"Forbidden","stacktrace":"github.com/go-logr/zapr.
```