### PR TITLE
Add application/tags subresource.

### DIFF
--- a/addon/application.go
+++ b/addon/application.go
@@ -86,3 +86,49 @@ func (h *Application) Bucket(id uint) (b *Bucket) {
 	}
 	return
 }
+
+//
+// Tags returns the tags API.
+func (h *Application) Tags(id uint) (tg AppTags) {
+	tg = AppTags{
+		client: h.client,
+		appId:  id,
+	}
+	return
+}
+
+//
+// AppTags sub-resource API.
+// Provides association management of tags to applications by name.
+type AppTags struct {
+	client *Client
+	appId  uint
+}
+
+//
+// List associated tags.
+// Returns a list of tag names.
+func (h *AppTags) List() (list []api.Ref, err error) {
+	list = []api.Ref{}
+	path := Params{api.ID: h.appId}.inject(api.ApplicationTagsRoot)
+	err = h.client.Get(path, &list)
+	return
+}
+
+//
+// Add ensures tag is associated with the application.
+func (h *AppTags) Add(id uint) (err error) {
+	path := Params{api.ID: h.appId}.inject(api.ApplicationTagsRoot)
+	err = h.client.Post(path, &api.Ref{ID: id})
+	return
+}
+
+//
+// Delete ensures the tag is not associated with the application.
+func (h *AppTags) Delete(id uint) (err error) {
+	path := Params{
+		api.ID:  h.appId,
+		api.ID2: id}.inject(api.ApplicationTagRoot)
+	err = h.client.Delete(path)
+	return
+}

--- a/addon/tag.go
+++ b/addon/tag.go
@@ -56,6 +56,39 @@ func (h *Tag) Delete(r *api.Tag) (err error) {
 }
 
 //
+// Find by name and type.
+func (h *Tag) Find(name string, tp uint) (r *api.Tag, found bool, err error) {
+	list := []api.Tag{}
+	err = h.client.Get(api.TagsRoot, &list)
+	if err != nil {
+		return
+	}
+	for i := range list {
+		if name == list[i].Name && tp == list[i].TagType.ID {
+			r = &list[i]
+			found = true
+			break
+		}
+	}
+	return
+}
+
+//
+// Ensure a tag exists.
+func (h *Tag) Ensure(wanted *api.Tag) (err error) {
+	tag, found, err := h.Find(wanted.Name, wanted.TagType.ID)
+	if err != nil {
+		return
+	}
+	if !found {
+		err = h.Create(wanted)
+	} else {
+		*wanted = *tag
+	}
+	return
+}
+
+//
 // TagType API.
 type TagType struct {
 	// hub API client.
@@ -102,6 +135,39 @@ func (h *TagType) Delete(r *api.TagType) (err error) {
 			"Addon deleted: tag(type).",
 			"object",
 			r)
+	}
+	return
+}
+
+//
+// Find by name.
+func (h *TagType) Find(name string) (r *api.TagType, found bool, err error) {
+	list := []api.TagType{}
+	err = h.client.Get(api.TagTypesRoot, &list)
+	if err != nil {
+		return
+	}
+	for i := range list {
+		if name == list[i].Name {
+			r = &list[i]
+			found = true
+			break
+		}
+	}
+	return
+}
+
+//
+// Ensure a tag-type exists.
+func (h *TagType) Ensure(wanted *api.TagType) (err error) {
+	tp, found, err := h.Find(wanted.Name)
+	if err != nil {
+		return
+	}
+	if !found {
+		err = h.Create(wanted)
+	} else {
+		*wanted = *tp
 	}
 	return
 }

--- a/api/pkg.go
+++ b/api/pkg.go
@@ -17,6 +17,7 @@ var (
 // Params
 const (
 	ID       = "id"
+	ID2      = "id2"
 	Key      = "key"
 	Name     = "name"
 	Wildcard = "wildcard"


### PR DESCRIPTION
Currently the only way to mange the tag references on an application is to fetch the application; edit the tags (refs) and update the application. 
The goal here is to provide a more focused/intuitive way to do this with less chance for conflict when managing tags concurrently.

To easily:
- Resolve tag type names.
- Resolve tag names.
- Ensure tags and types exist.
- Explicit API to associate/disassociate tags with applications.

Adds APIs:
- GET /applications/1/tags - _List associated tags (refs)_.
  - returns: []Ref
- POST /applications/1/tags - _Associate tag (by ref)_.
  - body: Ref
- DELETE /applications/1/tags/45 - _Disassociate tag (by ID)_.

Adds addon (binding) API:
- Application.Tags() - _Returns sub-resource API_.
  - List() - _List associated tags (refs)._
  - Add() - _Add tag association._
  - Delete() - _Delete tag association._
- TagType.Find() - _Find type by name_.
- TagType.Ensure() - _Ensure a type exists (created as needed)._
- Tag.Find() - _Find tag by name and type._
- Tag.Ensure() - _Ensure a tag exists (created as needed)._

---

Example A: _An addon is working with a set of well known tags (and types) that already exist and only needs to manage associations._

```
// Find tag type by name.
tp, found, err := addon.TagType.Find("LANG")

// Find tag by name and type.
tag, found, err := addon.Tag.Find("JAVA", tp.ID)

// Application tags collection.
tags = application.Tags(app.ID)

// Associate tag.
err = tags.Add(tag)
```

Example B: _An addon is working with tags (and types) not guaranteed to already exist._
```
// Ensure type exists.
tp := &api.TagType{
    Name: "DIRECTORY",
    Color: "#2b9af3",
    Rank: 3,
}
err = addon.TagType.Ensure(tp)

// Ensure tag exists.
tag := &api.Tag{
    Name: "JAVA"
    TagType: api.Ref{
        ID: tp.ID,
    }
}
err = addon.Tag.Ensure(tag)

// Application tags collection.
tags = application.Tags(app.ID)

// Associate tag.
err = tags.Add(tag.ID)
```