### PR TITLE
refactor: consolidate API error reporting

### DIFF
--- a/api/addon.go
+++ b/api/addon.go
@@ -56,7 +56,7 @@ func (h AddonHandler) Get(ctx *gin.Context) {
 			ctx.Status(http.StatusNotFound)
 			return
 		} else {
-			h.getFailed(ctx, err)
+			h.reportError(ctx, err)
 			return
 		}
 	}
@@ -82,7 +82,7 @@ func (h AddonHandler) List(ctx *gin.Context) {
 		},
 		list)
 	if err != nil {
-		h.listFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 	content := []Addon{}

--- a/api/adoptionplan.go
+++ b/api/adoptionplan.go
@@ -53,7 +53,7 @@ func (h AdoptionPlanHandler) Graph(ctx *gin.Context) {
 
 	err := ctx.BindJSON(&requestedApps)
 	if err != nil {
-		h.bindFailed(ctx, err)
+		h.reportError(ctx, err)
 	}
 
 	var ids []uint
@@ -65,14 +65,14 @@ func (h AdoptionPlanHandler) Graph(ctx *gin.Context) {
 	db := h.preLoad(h.DB, clause.Associations)
 	result := db.Where("applicationId IN ?", ids).Find(&reviews)
 	if result.Error != nil {
-		h.getFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 
 	var deps []model.Dependency
 	result = h.DB.Where("toId IN ? AND fromId IN ?", ids, ids).Find(&deps)
 	if result.Error != nil {
-		h.getFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 

--- a/api/application.go
+++ b/api/application.go
@@ -58,7 +58,7 @@ func (h ApplicationHandler) Get(ctx *gin.Context) {
 	db := h.preLoad(h.DB, clause.Associations)
 	result := db.First(m, id)
 	if result.Error != nil {
-		h.getFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	r := Application{}
@@ -79,7 +79,7 @@ func (h ApplicationHandler) List(ctx *gin.Context) {
 	db := h.preLoad(h.DB, clause.Associations)
 	result := db.Find(&list)
 	if result.Error != nil {
-		h.listFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	resources := []Application{}
@@ -105,24 +105,24 @@ func (h ApplicationHandler) Create(ctx *gin.Context) {
 	r := &Application{}
 	err := ctx.BindJSON(r)
 	if err != nil {
-		h.bindFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 	m := r.Model()
 	m.CreateUser = h.BaseHandler.CurrentUser(ctx)
 	result := h.DB.Create(m)
 	if result.Error != nil {
-		h.createFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	err = h.DB.Model(m).Association("Identities").Replace("Identities", m.Identities)
 	if err != nil {
-		h.createFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 	err = h.DB.Model(m).Association("Tags").Replace("Tags", m.Tags)
 	if err != nil {
-		h.createFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 	r.With(m)
@@ -142,18 +142,18 @@ func (h ApplicationHandler) Delete(ctx *gin.Context) {
 	m := &model.Application{}
 	result := h.DB.First(m, id)
 	if result.Error != nil {
-		h.deleteFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	p := Pathfinder{}
 	err := p.DeleteAssessment([]uint{id}, ctx)
 	if err != nil {
-		h.deleteFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 	result = h.DB.Delete(m)
 	if result.Error != nil {
-		h.deleteFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 
@@ -171,13 +171,13 @@ func (h ApplicationHandler) DeleteList(ctx *gin.Context) {
 	ids := []uint{}
 	err := ctx.BindJSON(&ids)
 	if err != nil {
-		h.bindFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 	p := Pathfinder{}
 	err = p.DeleteAssessment(ids, ctx)
 	if err != nil {
-		h.deleteFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 	err = h.DB.Delete(
@@ -185,7 +185,7 @@ func (h ApplicationHandler) DeleteList(ctx *gin.Context) {
 		"id IN ?",
 		ids).Error
 	if err != nil {
-		h.deleteFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 
@@ -206,7 +206,7 @@ func (h ApplicationHandler) Update(ctx *gin.Context) {
 	r := &Application{}
 	err := ctx.BindJSON(r)
 	if err != nil {
-		h.bindFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 	m := r.Model()
@@ -217,19 +217,19 @@ func (h ApplicationHandler) Update(ctx *gin.Context) {
 	db = db.Omit("Bucket")
 	result := db.Updates(h.fields(m))
 	if result.Error != nil {
-		h.updateFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	db = h.DB.Model(m)
 	err = db.Association("Identities").Replace(m.Identities)
 	if err != nil {
-		h.updateFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 	db = h.DB.Model(m)
 	err = db.Association("Tags").Replace(m.Tags)
 	if err != nil {
-		h.updateFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 
@@ -249,7 +249,7 @@ func (h ApplicationHandler) BucketGet(ctx *gin.Context) {
 	m := &model.Application{}
 	result := h.DB.First(m, id)
 	if result.Error != nil {
-		h.getFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 
@@ -269,7 +269,7 @@ func (h ApplicationHandler) BucketUpload(ctx *gin.Context) {
 	m := &model.Application{}
 	result := h.DB.First(m, id)
 	if result.Error != nil {
-		h.getFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 
@@ -289,7 +289,7 @@ func (h ApplicationHandler) BucketDelete(ctx *gin.Context) {
 	m := &model.Application{}
 	result := h.DB.First(m, id)
 	if result.Error != nil {
-		h.deleteFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 

--- a/api/businessservice.go
+++ b/api/businessservice.go
@@ -48,7 +48,7 @@ func (h BusinessServiceHandler) Get(ctx *gin.Context) {
 	db := h.preLoad(h.DB, clause.Associations)
 	result := db.First(m, id)
 	if result.Error != nil {
-		h.getFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 
@@ -69,7 +69,7 @@ func (h BusinessServiceHandler) List(ctx *gin.Context) {
 	db := h.preLoad(h.DB, clause.Associations)
 	result := db.Find(&list)
 	if result.Error != nil {
-		h.listFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	resources := []BusinessService{}
@@ -95,14 +95,14 @@ func (h BusinessServiceHandler) Create(ctx *gin.Context) {
 	r := &BusinessService{}
 	err := ctx.BindJSON(r)
 	if err != nil {
-		h.bindFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 	m := r.Model()
 	m.CreateUser = h.BaseHandler.CurrentUser(ctx)
 	result := h.DB.Create(m)
 	if result.Error != nil {
-		h.createFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	r.With(m)
@@ -122,12 +122,12 @@ func (h BusinessServiceHandler) Delete(ctx *gin.Context) {
 	m := &model.BusinessService{}
 	result := h.DB.First(m, id)
 	if result.Error != nil {
-		h.deleteFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	result = h.DB.Delete(m)
 	if result.Error != nil {
-		h.deleteFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 
@@ -148,7 +148,7 @@ func (h BusinessServiceHandler) Update(ctx *gin.Context) {
 	r := &BusinessService{}
 	err := ctx.BindJSON(r)
 	if err != nil {
-		h.bindFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 	m := r.Model()
@@ -158,7 +158,7 @@ func (h BusinessServiceHandler) Update(ctx *gin.Context) {
 	db = db.Omit(clause.Associations)
 	result := db.Updates(h.fields(m))
 	if result.Error != nil {
-		h.updateFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 

--- a/api/cache.go
+++ b/api/cache.go
@@ -50,7 +50,7 @@ func (h CacheHandler) Get(ctx *gin.Context) {
 		if os.IsNotExist(err) {
 			ctx.Status(http.StatusNotFound)
 		} else {
-			h.getFailed(ctx, err)
+			h.reportError(ctx, err)
 		}
 		return
 	}
@@ -79,13 +79,13 @@ func (h CacheHandler) Delete(ctx *gin.Context) {
 		if os.IsNotExist(err) {
 			ctx.Status(http.StatusNoContent)
 		} else {
-			h.getFailed(ctx, err)
+			h.reportError(ctx, err)
 		}
 		return
 	}
 	err = nas.RmDir(path)
 	if err != nil {
-		h.deleteFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 

--- a/api/dependency.go
+++ b/api/dependency.go
@@ -47,7 +47,7 @@ func (h DependencyHandler) Get(ctx *gin.Context) {
 	db := h.preLoad(h.DB, clause.Associations)
 	result := db.First(m, id)
 	if result.Error != nil {
-		h.getFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	r := Dependency{}
@@ -79,7 +79,7 @@ func (h DependencyHandler) List(ctx *gin.Context) {
 	db = h.preLoad(db, clause.Associations)
 	result := db.Find(&list)
 	if result.Error != nil {
-		h.listFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 
@@ -106,14 +106,14 @@ func (h DependencyHandler) Create(ctx *gin.Context) {
 	r := Dependency{}
 	err := ctx.BindJSON(&r)
 	if err != nil {
-		h.createFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 	m := r.Model()
 	m.CreateUser = h.BaseHandler.CurrentUser(ctx)
 	err = m.Create(h.DB)
 	if err != nil {
-		h.createFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 
@@ -133,12 +133,12 @@ func (h DependencyHandler) Delete(ctx *gin.Context) {
 	m := &model.Dependency{}
 	result := h.DB.First(m, id)
 	if result.Error != nil {
-		h.deleteFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	result = h.DB.Delete(m)
 	if result.Error != nil {
-		h.deleteFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 

--- a/api/group.go
+++ b/api/group.go
@@ -48,7 +48,7 @@ func (h StakeholderGroupHandler) Get(ctx *gin.Context) {
 	db := h.preLoad(h.DB, clause.Associations)
 	result := db.First(m, id)
 	if result.Error != nil {
-		h.getFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	r := StakeholderGroup{}
@@ -69,7 +69,7 @@ func (h StakeholderGroupHandler) List(ctx *gin.Context) {
 	db := h.preLoad(h.DB, clause.Associations)
 	result := db.Find(&list)
 	if result.Error != nil {
-		h.listFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	resources := []StakeholderGroup{}
@@ -95,14 +95,14 @@ func (h StakeholderGroupHandler) Create(ctx *gin.Context) {
 	r := &StakeholderGroup{}
 	err := ctx.BindJSON(r)
 	if err != nil {
-		h.bindFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 	m := r.Model()
 	m.CreateUser = h.BaseHandler.CurrentUser(ctx)
 	result := h.DB.Create(m)
 	if result.Error != nil {
-		h.createFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	r.With(m)
@@ -122,12 +122,12 @@ func (h StakeholderGroupHandler) Delete(ctx *gin.Context) {
 	m := &model.StakeholderGroup{}
 	result := h.DB.First(m, id)
 	if result.Error != nil {
-		h.deleteFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	result = h.DB.Delete(m)
 	if result.Error != nil {
-		h.deleteFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 
@@ -148,7 +148,7 @@ func (h StakeholderGroupHandler) Update(ctx *gin.Context) {
 	r := &StakeholderGroup{}
 	err := ctx.BindJSON(r)
 	if err != nil {
-		h.bindFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 	m := r.Model()
@@ -158,13 +158,13 @@ func (h StakeholderGroupHandler) Update(ctx *gin.Context) {
 	db = db.Omit(clause.Associations)
 	result := db.Updates(h.fields(m))
 	if result.Error != nil {
-		h.updateFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	db = h.DB.Model(m)
 	err = db.Association("Stakeholders").Replace(m.Stakeholders)
 	if err != nil {
-		h.updateFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 

--- a/api/identity.go
+++ b/api/identity.go
@@ -52,7 +52,7 @@ func (h IdentityHandler) Get(ctx *gin.Context) {
 	m := &model.Identity{}
 	result := h.DB.First(m, id)
 	if result.Error != nil {
-		h.getFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	r := Identity{}
@@ -91,7 +91,7 @@ func (h IdentityHandler) List(ctx *gin.Context) {
 	}
 	result := db.Find(&list)
 	if result.Error != nil {
-		h.listFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	decrypted := ctx.GetBool(Decrypted)
@@ -126,7 +126,7 @@ func (h IdentityHandler) Create(ctx *gin.Context) {
 	r := &Identity{}
 	err := ctx.BindJSON(r)
 	if err != nil {
-		h.bindFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 	m := r.Model()
@@ -134,12 +134,12 @@ func (h IdentityHandler) Create(ctx *gin.Context) {
 	ref := &model.Identity{}
 	err = m.Encrypt(ref)
 	if err != nil {
-		h.updateFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 	result := h.DB.Create(m)
 	if result.Error != nil {
-		h.createFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	r.With(m)
@@ -159,12 +159,12 @@ func (h IdentityHandler) Delete(ctx *gin.Context) {
 	identity := &model.Identity{}
 	result := h.DB.First(identity, id)
 	if result.Error != nil {
-		h.deleteFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	result = h.DB.Delete(identity)
 	if result.Error != nil {
-		h.deleteFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 
@@ -185,19 +185,19 @@ func (h IdentityHandler) Update(ctx *gin.Context) {
 	r := &Identity{}
 	err := ctx.BindJSON(r)
 	if err != nil {
-		h.bindFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 	ref := &model.Identity{}
 	err = h.DB.First(ref, id).Error
 	if err != nil {
-		h.updateFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 	m := r.Model()
 	err = m.Encrypt(ref)
 	if err != nil {
-		h.updateFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 	m.ID = id
@@ -205,7 +205,7 @@ func (h IdentityHandler) Update(ctx *gin.Context) {
 	db := h.DB.Model(m)
 	err = db.Updates(h.fields(m)).Error
 	if err != nil {
-		h.updateFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 

--- a/api/import.go
+++ b/api/import.go
@@ -73,7 +73,7 @@ func (h ImportHandler) GetImport(ctx *gin.Context) {
 	db := h.preLoad(h.DB, "ImportTags")
 	result := db.First(m, id)
 	if result.Error != nil {
-		h.getFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	ctx.JSON(http.StatusOK, m.AsMap())
@@ -103,7 +103,7 @@ func (h ImportHandler) ListImports(ctx *gin.Context) {
 	db = h.preLoad(db, "ImportTags")
 	result := db.Find(&list)
 	if result.Error != nil {
-		h.listFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	resources := []Import{}
@@ -126,7 +126,7 @@ func (h ImportHandler) DeleteImport(ctx *gin.Context) {
 	id := ctx.Param(ID)
 	result := h.DB.Delete(&model.Import{}, id)
 	if result.Error != nil {
-		h.deleteFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 
@@ -148,7 +148,7 @@ func (h ImportHandler) GetSummary(ctx *gin.Context) {
 	db := h.preLoad(h.DB, "Imports")
 	result := db.First(m, id)
 	if result.Error != nil {
-		h.getFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	ctx.JSON(http.StatusOK, m)
@@ -167,7 +167,7 @@ func (h ImportHandler) ListSummaries(ctx *gin.Context) {
 	db := h.preLoad(h.DB, "Imports")
 	result := db.Find(&list)
 	if result.Error != nil {
-		h.listFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	resources := []ImportSummary{}
@@ -192,7 +192,7 @@ func (h ImportHandler) DeleteSummary(ctx *gin.Context) {
 	id := ctx.Param(ID)
 	result := h.DB.Delete(&model.ImportSummary{}, id)
 	if result.Error != nil {
-		h.deleteFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 
@@ -242,7 +242,7 @@ func (h ImportHandler) UploadCSV(ctx *gin.Context) {
 	m.CreateUser = h.BaseHandler.CurrentUser(ctx)
 	result := h.DB.Create(&m)
 	if result.Error != nil {
-		h.createFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	_, err = fileReader.Seek(0, 0)
@@ -286,7 +286,7 @@ func (h ImportHandler) UploadCSV(ctx *gin.Context) {
 		imp.ImportSummary = m
 		result := h.DB.Create(&imp)
 		if result.Error != nil {
-			h.createFailed(ctx, result.Error)
+			h.reportError(ctx, result.Error)
 			return
 		}
 	}
@@ -310,7 +310,7 @@ func (h ImportHandler) DownloadCSV(ctx *gin.Context) {
 	m := &model.ImportSummary{}
 	result := h.DB.First(m, id)
 	if result.Error != nil {
-		h.getFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	ctx.Writer.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", m.Filename))

--- a/api/jobfunction.go
+++ b/api/jobfunction.go
@@ -48,7 +48,7 @@ func (h JobFunctionHandler) Get(ctx *gin.Context) {
 	db := h.preLoad(h.DB, clause.Associations)
 	result := db.First(m, id)
 	if result.Error != nil {
-		h.getFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	r := JobFunction{}
@@ -69,7 +69,7 @@ func (h JobFunctionHandler) List(ctx *gin.Context) {
 	db := h.preLoad(h.DB, clause.Associations)
 	result := db.Find(&list)
 	if result.Error != nil {
-		h.listFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	resources := []JobFunction{}
@@ -95,14 +95,14 @@ func (h JobFunctionHandler) Create(ctx *gin.Context) {
 	r := &JobFunction{}
 	err := ctx.BindJSON(r)
 	if err != nil {
-		h.bindFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 	m := r.Model()
 	m.CreateUser = h.BaseHandler.CurrentUser(ctx)
 	result := h.DB.Create(m)
 	if result.Error != nil {
-		h.createFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	r.With(m)
@@ -122,12 +122,12 @@ func (h JobFunctionHandler) Delete(ctx *gin.Context) {
 	m := &model.JobFunction{}
 	result := h.DB.First(m, id)
 	if result.Error != nil {
-		h.deleteFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	result = h.DB.Delete(m)
 	if result.Error != nil {
-		h.deleteFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 
@@ -148,7 +148,7 @@ func (h JobFunctionHandler) Update(ctx *gin.Context) {
 	r := &JobFunction{}
 	err := ctx.BindJSON(r)
 	if err != nil {
-		h.bindFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 	m := r.Model()
@@ -158,7 +158,7 @@ func (h JobFunctionHandler) Update(ctx *gin.Context) {
 	db = db.Omit(clause.Associations)
 	result := db.Updates(h.fields(m))
 	if result.Error != nil {
-		h.updateFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 

--- a/api/proxy.go
+++ b/api/proxy.go
@@ -51,7 +51,7 @@ func (h ProxyHandler) Get(ctx *gin.Context) {
 	db := h.preLoad(h.DB, clause.Associations)
 	result := db.First(proxy, id)
 	if result.Error != nil {
-		h.getFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	r := Proxy{}
@@ -76,7 +76,7 @@ func (h ProxyHandler) List(ctx *gin.Context) {
 	}
 	result := db.Find(&list)
 	if result.Error != nil {
-		h.listFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	resources := []Proxy{}
@@ -108,7 +108,7 @@ func (h ProxyHandler) Create(ctx *gin.Context) {
 	m.CreateUser = h.BaseHandler.CurrentUser(ctx)
 	result := h.DB.Create(m)
 	if result.Error != nil {
-		h.createFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	proxy.With(m)
@@ -128,12 +128,12 @@ func (h ProxyHandler) Delete(ctx *gin.Context) {
 	proxy := &model.Proxy{}
 	result := h.DB.First(proxy, id)
 	if result.Error != nil {
-		h.deleteFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	result = h.DB.Delete(proxy, id)
 	if result.Error != nil {
-		h.deleteFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 
@@ -154,7 +154,7 @@ func (h ProxyHandler) Update(ctx *gin.Context) {
 	r := &Proxy{}
 	err := ctx.BindJSON(r)
 	if err != nil {
-		h.bindFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 	m := r.Model()
@@ -164,7 +164,7 @@ func (h ProxyHandler) Update(ctx *gin.Context) {
 	db = db.Omit(clause.Associations)
 	result := db.Updates(h.fields(m))
 	if result.Error != nil {
-		h.updateFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 

--- a/api/review.go
+++ b/api/review.go
@@ -50,7 +50,7 @@ func (h ReviewHandler) Get(ctx *gin.Context) {
 	db := h.preLoad(h.DB, clause.Associations)
 	result := db.First(m, id)
 	if result.Error != nil {
-		h.getFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	r := Review{}
@@ -71,7 +71,7 @@ func (h ReviewHandler) List(ctx *gin.Context) {
 	db := h.preLoad(h.DB, clause.Associations)
 	result := db.Find(&list)
 	if result.Error != nil {
-		h.listFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	resources := []Review{}
@@ -103,7 +103,7 @@ func (h ReviewHandler) Create(ctx *gin.Context) {
 	m.CreateUser = h.BaseHandler.CurrentUser(ctx)
 	result := h.DB.Create(m)
 	if result.Error != nil {
-		h.createFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	review.With(m)
@@ -123,12 +123,12 @@ func (h ReviewHandler) Delete(ctx *gin.Context) {
 	m := &model.Review{}
 	result := h.DB.First(m, id)
 	if result.Error != nil {
-		h.deleteFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	result = h.DB.Delete(m)
 	if result.Error != nil {
-		h.deleteFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 
@@ -149,7 +149,7 @@ func (h ReviewHandler) Update(ctx *gin.Context) {
 	r := &Review{}
 	err := ctx.BindJSON(r)
 	if err != nil {
-		h.bindFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 	m := r.Model()
@@ -159,7 +159,7 @@ func (h ReviewHandler) Update(ctx *gin.Context) {
 	db.Omit(clause.Associations)
 	result := db.Updates(h.fields(m))
 	if result.Error != nil {
-		h.updateFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 
@@ -184,7 +184,7 @@ func (h ReviewHandler) CopyReview(ctx *gin.Context) {
 	m := model.Review{}
 	result := h.DB.First(&m, c.SourceReview)
 	if result.Error != nil {
-		h.createFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	for _, id := range c.TargetApplications {
@@ -199,21 +199,21 @@ func (h ReviewHandler) CopyReview(ctx *gin.Context) {
 		existing := []model.Review{}
 		result = h.DB.Find(&existing, "applicationid = ?", id)
 		if result.Error != nil {
-			h.createFailed(ctx, result.Error)
+			h.reportError(ctx, result.Error)
 			return
 		}
 		// if the application doesn't already have a review, create one.
 		if len(existing) == 0 {
 			result = h.DB.Create(copied)
 			if result.Error != nil {
-				h.createFailed(ctx, result.Error)
+				h.reportError(ctx, result.Error)
 				return
 			}
 			// if the application already has a review, replace it with the copied review.
 		} else {
 			result = h.DB.Model(&existing[0]).Updates(h.fields(copied))
 			if result.Error != nil {
-				h.createFailed(ctx, result.Error)
+				h.reportError(ctx, result.Error)
 				return
 			}
 		}

--- a/api/setting.go
+++ b/api/setting.go
@@ -49,7 +49,7 @@ func (h SettingHandler) Get(ctx *gin.Context) {
 	key := ctx.Param(Key)
 	result := h.DB.Where(&model.Setting{Key: key}).First(setting)
 	if result.Error != nil {
-		h.getFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	r := Setting{}
@@ -69,7 +69,7 @@ func (h SettingHandler) List(ctx *gin.Context) {
 	var list []model.Setting
 	result := h.DB.Find(&list)
 	if result.Error != nil {
-		h.listFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	resources := []Setting{}
@@ -95,7 +95,7 @@ func (h SettingHandler) Create(ctx *gin.Context) {
 	setting := Setting{}
 	err := ctx.BindJSON(&setting)
 	if err != nil {
-		h.bindFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 
@@ -113,7 +113,7 @@ func (h SettingHandler) Create(ctx *gin.Context) {
 	m.CreateUser = h.BaseHandler.CurrentUser(ctx)
 	result := h.DB.Create(&m)
 	if result.Error != nil {
-		h.createFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	setting.With(m)
@@ -146,7 +146,7 @@ func (h SettingHandler) Update(ctx *gin.Context) {
 	updates.Key = key
 	err := ctx.BindJSON(&updates.Value)
 	if err != nil {
-		h.bindFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 
@@ -156,7 +156,7 @@ func (h SettingHandler) Update(ctx *gin.Context) {
 	db = db.Where("key", key)
 	result := db.Updates(h.fields(m))
 	if result.Error != nil {
-		h.updateFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 	}
 
 	ctx.Status(http.StatusNoContent)
@@ -183,7 +183,7 @@ func (h SettingHandler) Delete(ctx *gin.Context) {
 
 	result := h.DB.Delete(&model.Setting{}, Key, key)
 	if result.Error != nil {
-		h.deleteFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 

--- a/api/stakeholder.go
+++ b/api/stakeholder.go
@@ -48,7 +48,7 @@ func (h StakeholderHandler) Get(ctx *gin.Context) {
 	db := h.preLoad(h.DB, clause.Associations)
 	result := db.First(m, id)
 	if result.Error != nil {
-		h.getFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 
@@ -69,7 +69,7 @@ func (h StakeholderHandler) List(ctx *gin.Context) {
 	db := h.preLoad(h.DB, clause.Associations)
 	result := db.Find(&list)
 	if result.Error != nil {
-		h.listFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	resources := []Stakeholder{}
@@ -95,14 +95,14 @@ func (h StakeholderHandler) Create(ctx *gin.Context) {
 	r := &Stakeholder{}
 	err := ctx.BindJSON(r)
 	if err != nil {
-		h.bindFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 	m := r.Model()
 	m.CreateUser = h.BaseHandler.CurrentUser(ctx)
 	result := h.DB.Create(m)
 	if result.Error != nil {
-		h.createFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	r.With(m)
@@ -122,12 +122,12 @@ func (h StakeholderHandler) Delete(ctx *gin.Context) {
 	m := &model.Stakeholder{}
 	result := h.DB.First(m, id)
 	if result.Error != nil {
-		h.deleteFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	result = h.DB.Delete(m)
 	if result.Error != nil {
-		h.deleteFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 
@@ -148,7 +148,7 @@ func (h StakeholderHandler) Update(ctx *gin.Context) {
 	r := &Stakeholder{}
 	err := ctx.BindJSON(r)
 	if err != nil {
-		h.bindFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 	m := r.Model()
@@ -158,13 +158,13 @@ func (h StakeholderHandler) Update(ctx *gin.Context) {
 	db = db.Omit(clause.Associations)
 	result := db.Updates(h.fields(m))
 	if result.Error != nil {
-		h.updateFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	db = h.DB.Model(m)
 	err = db.Association("Groups").Replace(m.Groups)
 	if err != nil {
-		h.updateFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 

--- a/api/tag.go
+++ b/api/tag.go
@@ -48,7 +48,7 @@ func (h TagHandler) Get(ctx *gin.Context) {
 	db := h.preLoad(h.DB, clause.Associations)
 	result := db.First(m, id)
 	if result.Error != nil {
-		h.getFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 
@@ -69,7 +69,7 @@ func (h TagHandler) List(ctx *gin.Context) {
 	db := h.preLoad(h.DB, clause.Associations)
 	result := db.Find(&list)
 	if result.Error != nil {
-		h.listFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	resources := []Tag{}
@@ -95,14 +95,14 @@ func (h TagHandler) Create(ctx *gin.Context) {
 	r := &Tag{}
 	err := ctx.BindJSON(r)
 	if err != nil {
-		h.bindFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 	m := r.Model()
 	m.CreateUser = h.BaseHandler.CurrentUser(ctx)
 	result := h.DB.Create(m)
 	if result.Error != nil {
-		h.createFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	r.With(m)
@@ -122,12 +122,12 @@ func (h TagHandler) Delete(ctx *gin.Context) {
 	m := &model.Tag{}
 	result := h.DB.First(m, id)
 	if result.Error != nil {
-		h.deleteFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	result = h.DB.Delete(m)
 	if result.Error != nil {
-		h.deleteFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 
@@ -148,7 +148,7 @@ func (h TagHandler) Update(ctx *gin.Context) {
 	r := &Tag{}
 	err := ctx.BindJSON(r)
 	if err != nil {
-		h.bindFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 	m := r.Model()
@@ -158,7 +158,7 @@ func (h TagHandler) Update(ctx *gin.Context) {
 	db = db.Omit(clause.Associations)
 	result := db.Updates(h.fields(m))
 	if result.Error != nil {
-		h.updateFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 

--- a/api/tagtype.go
+++ b/api/tagtype.go
@@ -48,7 +48,7 @@ func (h TagTypeHandler) Get(ctx *gin.Context) {
 	db := h.preLoad(h.DB, clause.Associations)
 	result := db.First(m, id)
 	if result.Error != nil {
-		h.getFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 
@@ -69,7 +69,7 @@ func (h TagTypeHandler) List(ctx *gin.Context) {
 	db := h.preLoad(h.DB, clause.Associations)
 	result := db.Find(&list)
 	if result.Error != nil {
-		h.listFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	resources := []TagType{}
@@ -95,14 +95,14 @@ func (h TagTypeHandler) Create(ctx *gin.Context) {
 	r := TagType{}
 	err := ctx.BindJSON(&r)
 	if err != nil {
-		h.bindFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 	m := r.Model()
 	m.CreateUser = h.BaseHandler.CurrentUser(ctx)
 	result := h.DB.Create(m)
 	if result.Error != nil {
-		h.createFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	r.With(m)
@@ -122,12 +122,12 @@ func (h TagTypeHandler) Delete(ctx *gin.Context) {
 	m := &model.TagType{}
 	result := h.DB.First(m, id)
 	if result.Error != nil {
-		h.deleteFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	result = h.DB.Delete(m)
 	if result.Error != nil {
-		h.deleteFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 
@@ -148,7 +148,7 @@ func (h TagTypeHandler) Update(ctx *gin.Context) {
 	r := &TagType{}
 	err := ctx.BindJSON(r)
 	if err != nil {
-		h.bindFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 	m := r.Model()
@@ -158,7 +158,7 @@ func (h TagTypeHandler) Update(ctx *gin.Context) {
 	db = db.Omit(clause.Associations)
 	result := db.Updates(h.fields(m))
 	if result.Error != nil {
-		h.updateFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 

--- a/api/taskgroup.go
+++ b/api/taskgroup.go
@@ -61,7 +61,7 @@ func (h TaskGroupHandler) Get(ctx *gin.Context) {
 	db := h.DB.Preload(clause.Associations)
 	result := db.First(m, id)
 	if result.Error != nil {
-		h.getFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	r := TaskGroup{}
@@ -82,7 +82,7 @@ func (h TaskGroupHandler) List(ctx *gin.Context) {
 	db := h.DB.Preload(clause.Associations)
 	result := db.Find(&list)
 	if result.Error != nil {
-		h.listFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 	resources := []TaskGroup{}
@@ -108,7 +108,7 @@ func (h TaskGroupHandler) Create(ctx *gin.Context) {
 	r := &TaskGroup{}
 	err := ctx.BindJSON(r)
 	if err != nil {
-		h.createFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 	db := h.DB
@@ -135,7 +135,7 @@ func (h TaskGroupHandler) Create(ctx *gin.Context) {
 	m.CreateUser = h.BaseHandler.CurrentUser(ctx)
 	result := db.Create(&m)
 	if result.Error != nil {
-		h.createFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 
@@ -163,7 +163,7 @@ func (h TaskGroupHandler) Update(ctx *gin.Context) {
 	current := &model.TaskGroup{}
 	err = h.DB.First(current, id).Error
 	if err != nil {
-		h.getFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 	m := updated.Model()
@@ -191,7 +191,7 @@ func (h TaskGroupHandler) Update(ctx *gin.Context) {
 	db = db.Where("state IN ?", []string{"", tasking.Created})
 	err = db.Updates(h.fields(m)).Error
 	if err != nil {
-		h.updateFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 
@@ -211,7 +211,7 @@ func (h TaskGroupHandler) Delete(ctx *gin.Context) {
 	db := h.DB.Preload(clause.Associations)
 	err := db.First(m, id).Error
 	if err != nil {
-		h.deleteFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 	for _, task := range m.Tasks {
@@ -220,7 +220,7 @@ func (h TaskGroupHandler) Delete(ctx *gin.Context) {
 			err := rt.Delete(h.Client)
 			if err != nil {
 				if !k8serr.IsNotFound(err) {
-					h.deleteFailed(ctx, err)
+					h.reportError(ctx, err)
 					return
 				}
 			}
@@ -228,14 +228,14 @@ func (h TaskGroupHandler) Delete(ctx *gin.Context) {
 		db := h.DB.Select(clause.Associations)
 		err = db.Delete(task).Error
 		if err != nil {
-			h.deleteFailed(ctx, err)
+			h.reportError(ctx, err)
 			return
 		}
 	}
 	db = h.DB.Select(clause.Associations)
 	err = db.Delete(m).Error
 	if err != nil {
-		h.deleteFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 
@@ -268,7 +268,7 @@ func (h TaskGroupHandler) Submit(ctx *gin.Context) {
 	}
 	err := h.modBody(ctx, r, mod)
 	if err != nil {
-		h.updateFailed(ctx, err)
+		h.reportError(ctx, err)
 		return
 	}
 	ctx.Next()
@@ -287,7 +287,7 @@ func (h TaskGroupHandler) BucketGet(ctx *gin.Context) {
 	m := &model.TaskGroup{}
 	result := h.DB.First(m, id)
 	if result.Error != nil {
-		h.getFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 
@@ -307,7 +307,7 @@ func (h TaskGroupHandler) BucketUpload(ctx *gin.Context) {
 	id := h.pk(ctx)
 	result := h.DB.First(m, id)
 	if result.Error != nil {
-		h.getFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 
@@ -327,7 +327,7 @@ func (h TaskGroupHandler) BucketDelete(ctx *gin.Context) {
 	id := h.pk(ctx)
 	result := h.DB.First(m, id)
 	if result.Error != nil {
-		h.deleteFailed(ctx, result.Error)
+		h.reportError(ctx, result.Error)
 		return
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/Nerzal/gocloak/v10 v10.0.1
 	github.com/gin-gonic/gin v1.8.1
+	github.com/go-playground/validator/v10 v10.10.0
 	github.com/golang-jwt/jwt/v4 v4.4.2
 	github.com/google/uuid v1.1.2
 	github.com/konveyor/controller v0.8.0


### PR DESCRIPTION
Consolidate the `*Failed` methods on the `BaseHandler` into a single method named `reportError` that preserves the same behavior.

* Gin binding errors are reported as `400 Bad Request`.
* RecordNotFound is reported as `404 Not Found` unless the HTTP method is `DELETE`. In that case it is reported as `204 No Content` (same as a successful delete).
* `fs.ErrNotExist` reported as `404 Not Found`.
* `DependencyCyclicError` is reported as `409 Conflict`.
* Unique and Primary Key constraint violations are reported as `409 Conflict`.

Signed-off-by: Sam Lucidi <slucidi@redhat.com>