### PR TITLE
:seedling: enforce style on PR titles

### DIFF
--- a/.github/workflows/verifyPR.yml
+++ b/.github/workflows/verifyPR.yml
@@ -1,0 +1,18 @@
+name: PR Checks
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    name: Verify PR contents
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Check Title
+      id: verifier
+      uses: konveyor/release-tools/cmd/verify-pr@main
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This change makes it so that subsequent Pull Requests made to this project must follow the rules laid out in https://github.com/konveyor/release-tools/blob/main/VERSIONING.md

Signed-off-by: David Zager <david.j.zager@gmail.com>