### PR TITLE
:sparkles: Add application/facts sub-resource.

### DIFF
--- a/addon/application.go
+++ b/addon/application.go
@@ -132,3 +132,64 @@ func (h *AppTags) Delete(id uint) (err error) {
 	err = h.client.Delete(path)
 	return
 }
+
+//
+// Facts returns the tags API.
+func (h *Application) Facts(id uint) (f AppFacts) {
+	f = AppFacts{
+		client: h.client,
+		appId:  id,
+	}
+	return
+}
+
+//
+// AppFacts sub-resource API.
+// Provides association management of facts.
+type AppFacts struct {
+	client *Client
+	appId  uint
+}
+
+//
+// List associated tags.
+// Returns a list of tag names.
+func (h *AppFacts) List() (list []api.Fact, err error) {
+	list = []api.Fact{}
+	path := Params{api.ID: h.appId}.inject(api.ApplicationFactsRoot)
+	err = h.client.Get(path, &list)
+	return
+}
+
+//
+// Get a fact.
+func (h *AppFacts) Get(key string, valuePtr interface{}) (err error) {
+	path := Params{
+		api.ID:  h.appId,
+		api.Key: key,
+	}.inject(api.ApplicationFactRoot)
+	err = h.client.Get(path, valuePtr)
+	return
+}
+
+//
+// Set a fact (created as needed).
+func (h *AppFacts) Set(key string, value interface{}) (err error) {
+	path := Params{
+		api.ID:  h.appId,
+		api.Key: key,
+	}.inject(api.ApplicationFactRoot)
+	err = h.client.Put(path, value)
+	return
+}
+
+//
+// Delete a fact.
+func (h *AppFacts) Delete(key string) (err error) {
+	path := Params{
+		api.ID:  h.appId,
+		api.Key: key,
+	}.inject(api.ApplicationFactRoot)
+	err = h.client.Delete(path)
+	return
+}

--- a/api/application.go
+++ b/api/application.go
@@ -725,7 +725,6 @@ type FactMap map[string]interface{}
 //
 // Fact REST nested resource.
 type Fact struct {
-	Resource
 	Key   string      `json:"key"`
 	Value interface{} `json:"value"`
 }

--- a/api/application.go
+++ b/api/application.go
@@ -49,6 +49,8 @@ func (h ApplicationHandler) AddRoutes(e *gin.Engine) {
 	routeGroup.POST(ApplicationTagsRoot, h.TagAdd)
 	routeGroup.DELETE(ApplicationTagRoot, h.TagDelete)
 	// Facts
+	routeGroup = e.Group("/")
+	routeGroup.Use(auth.Required("applications.facts"))
 	routeGroup.GET(ApplicationFactsRoot, h.FactList)
 	routeGroup.GET(ApplicationFactsRoot+"/", h.FactList)
 	routeGroup.GET(ApplicationFactRoot, h.FactGet)

--- a/api/application.go
+++ b/api/application.go
@@ -2,9 +2,11 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"github.com/gin-gonic/gin"
 	"github.com/konveyor/tackle2-hub/auth"
 	"github.com/konveyor/tackle2-hub/model"
+	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 	"net/http"
 	"strconv"
@@ -13,11 +15,13 @@ import (
 //
 // Routes
 const (
-	ApplicationsRoot    = "/applications"
-	ApplicationRoot     = ApplicationsRoot + "/:" + ID
-	ApplicationTagsRoot = ApplicationRoot + "/tags"
-	ApplicationTagRoot  = ApplicationTagsRoot + "/:" + ID2
-	AppBucketRoot       = ApplicationRoot + "/bucket/*" + Wildcard
+	ApplicationsRoot     = "/applications"
+	ApplicationRoot      = ApplicationsRoot + "/:" + ID
+	ApplicationTagsRoot  = ApplicationRoot + "/tags"
+	ApplicationTagRoot   = ApplicationTagsRoot + "/:" + ID2
+	ApplicationFactsRoot = ApplicationRoot + "/facts"
+	ApplicationFactRoot  = ApplicationFactsRoot + "/:" + Key
+	AppBucketRoot        = ApplicationRoot + "/bucket/*" + Wildcard
 )
 
 //
@@ -44,6 +48,13 @@ func (h ApplicationHandler) AddRoutes(e *gin.Engine) {
 	routeGroup.GET(ApplicationTagsRoot+"/", h.TagList)
 	routeGroup.POST(ApplicationTagsRoot, h.TagAdd)
 	routeGroup.DELETE(ApplicationTagRoot, h.TagDelete)
+	// Facts
+	routeGroup.GET(ApplicationFactsRoot, h.FactList)
+	routeGroup.GET(ApplicationFactsRoot+"/", h.FactList)
+	routeGroup.GET(ApplicationFactRoot, h.FactGet)
+	routeGroup.POST(ApplicationFactRoot, h.FactCreate)
+	routeGroup.PUT(ApplicationFactRoot, h.FactPut)
+	routeGroup.DELETE(ApplicationFactRoot, h.FactDelete)
 	// Bucket
 	routeGroup = e.Group("/")
 	routeGroup.Use(auth.Required("applications.bucket"))
@@ -122,16 +133,6 @@ func (h ApplicationHandler) Create(ctx *gin.Context) {
 	result := h.DB.Create(m)
 	if result.Error != nil {
 		h.reportError(ctx, result.Error)
-		return
-	}
-	err = h.DB.Model(m).Association("Identities").Replace("Identities", m.Identities)
-	if err != nil {
-		h.reportError(ctx, err)
-		return
-	}
-	err = h.DB.Model(m).Association("Tags").Replace("Tags", m.Tags)
-	if err != nil {
-		h.reportError(ctx, err)
 		return
 	}
 	r.With(m)
@@ -240,6 +241,28 @@ func (h ApplicationHandler) Update(ctx *gin.Context) {
 	if err != nil {
 		h.reportError(ctx, err)
 		return
+	}
+	db = h.DB.Model(m)
+	err = db.Association("Facts").Replace(m.Facts)
+	if err != nil {
+		h.reportError(ctx, err)
+		return
+	}
+	m = &model.Application{}
+	db = h.preLoad(h.DB, clause.Associations)
+	result = db.First(m, id)
+	if result.Error != nil {
+		h.reportError(ctx, result.Error)
+		return
+	}
+	for _, fact := range m.Facts {
+		if _, found := r.Facts[fact.Key]; !found {
+			h.DB.Delete(fact)
+			if err != nil {
+				h.reportError(ctx, err)
+				return
+			}
+		}
 	}
 
 	ctx.Status(http.StatusNoContent)
@@ -401,6 +424,193 @@ func (h ApplicationHandler) TagDelete(ctx *gin.Context) {
 	ctx.Status(http.StatusNoContent)
 }
 
+// FactList godoc
+// @summary List facts.
+// @description List facts.
+// @tags get
+// @produce json
+// @success 200 {object} []api.Fact
+// @router /applications/{id}/facts [get]
+// @param id path string true "Application ID"
+func (h ApplicationHandler) FactList(ctx *gin.Context) {
+	id := h.pk(ctx)
+	app := &model.Application{}
+	result := h.DB.First(app, id)
+	if result.Error != nil {
+		h.reportError(ctx, result.Error)
+		return
+	}
+	db := h.DB.Model(app).Association("Facts")
+	list := []model.Fact{}
+	err := db.Find(&list)
+	if err != nil {
+		h.reportError(ctx, err)
+		return
+	}
+	resources := []Fact{}
+	for i := range list {
+		r := Fact{}
+		r.With(&list[i])
+		resources = append(resources, r)
+	}
+	ctx.JSON(http.StatusOK, resources)
+}
+
+// FactGet godoc
+// @summary Get fact by name.
+// @description Get fact by name.
+// @tags get
+// @produce json
+// @success 200 {object} api.Fact
+// @router /applications/{id}/facts/{name} [get]
+// @param id path string true "Application ID"
+// @param key path string true "Fact key"
+func (h ApplicationHandler) FactGet(ctx *gin.Context) {
+	id := h.pk(ctx)
+	app := &model.Application{}
+	result := h.DB.First(app, id)
+	if result.Error != nil {
+		h.reportError(ctx, result.Error)
+		return
+	}
+	key := ctx.Param(Key)
+	list := []model.Fact{}
+	result = h.DB.Find(&list, "ApplicationID = ? AND Key = ?", id, key)
+	if result.Error != nil {
+		h.reportError(ctx, result.Error)
+		return
+	}
+	if len(list) < 1 {
+		ctx.Status(http.StatusNotFound)
+		return
+	}
+	r := Fact{}
+	r.With(&list[0])
+	ctx.JSON(http.StatusOK, r)
+}
+
+// FactCreate godoc
+// @summary Create a fact.
+// @description Create a fact.
+// @tags create
+// @accept json
+// @produce json
+// @success 201
+// @router /applications/{id}/facts/{key} [post]
+// @param id path string true "Application ID"
+// @param key path string true "Fact key"
+// @param fact body api.Fact true "Fact data"
+func (h ApplicationHandler) FactCreate(ctx *gin.Context) {
+	id := h.pk(ctx)
+	var v interface{}
+	err := ctx.BindJSON(&v)
+	if err != nil {
+		h.reportError(ctx, err)
+		return
+	}
+	app := &model.Application{}
+	result := h.DB.First(app, id)
+	if result.Error != nil {
+		h.reportError(ctx, result.Error)
+		return
+	}
+	key := ctx.Param(Key)
+	m := &model.Fact{}
+	m.Key = key
+	m.Value, _ = json.Marshal(v)
+	m.ApplicationID = id
+	result = h.DB.Create(m)
+	if result.Error != nil {
+		h.reportError(ctx, result.Error)
+		return
+	}
+	r := &Fact{}
+	r.With(m)
+	ctx.JSON(http.StatusCreated, r)
+}
+
+// FactPut godoc
+// @summary Update (or create) a fact.
+// @description Update (or create) a fact.
+// @tags update create
+// @accept json
+// @produce json
+// @success 204 201
+// @router /applications/{id}/facts/{key} [put post]
+// @param id path string true "Application ID"
+// @param key path string true "Fact key"
+// @param fact body api.Fact true "Fact data"
+func (h ApplicationHandler) FactPut(ctx *gin.Context) {
+	id := h.pk(ctx)
+	var v interface{}
+	err := ctx.BindJSON(&v)
+	if err != nil {
+		h.reportError(ctx, err)
+		return
+	}
+	app := &model.Application{}
+	result := h.DB.First(app, id)
+	if result.Error != nil {
+		h.reportError(ctx, result.Error)
+		return
+	}
+	key := ctx.Param(Key)
+	m := &model.Fact{}
+	result = h.DB.First(m, "ApplicationID = ? AND Key = ?", id, key)
+	if result.Error == nil {
+		m.Value, _ = json.Marshal(v)
+		db := h.DB.Model(m)
+		result = db.Updates(h.fields(m))
+		if result.Error != nil {
+			h.reportError(ctx, result.Error)
+		}
+		ctx.Status(http.StatusNoContent)
+		return
+	}
+	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
+		m.Key = key
+		m.Value, _ = json.Marshal(v)
+		m.ApplicationID = id
+		result = h.DB.Create(m)
+		if result.Error != nil {
+			h.reportError(ctx, result.Error)
+			return
+		}
+		r := &Fact{}
+		r.With(m)
+		ctx.JSON(http.StatusCreated, r)
+	} else {
+		h.reportError(ctx, result.Error)
+	}
+}
+
+// FactDelete godoc
+// @summary Delete a fact.
+// @description Delete a fact.
+// @tags delete
+// @success 204
+// @router /applications/{id}/facts/{key} [delete]
+// @param id path string true "Application ID"
+// @param key path string true "Fact key"
+func (h ApplicationHandler) FactDelete(ctx *gin.Context) {
+	id := h.pk(ctx)
+	app := &model.Application{}
+	result := h.DB.First(app, id)
+	if result.Error != nil {
+		h.reportError(ctx, result.Error)
+		return
+	}
+	fact := &model.Fact{}
+	key := ctx.Param(Key)
+	result = h.DB.Delete(fact, "ApplicationID = ? AND Key = ?", id, key)
+	if result.Error != nil {
+		h.reportError(ctx, result.Error)
+		return
+	}
+
+	ctx.Status(http.StatusNoContent)
+}
+
 //
 // Application REST resource.
 type Application struct {
@@ -410,7 +620,7 @@ type Application struct {
 	Bucket          string      `json:"bucket"`
 	Repository      *Repository `json:"repository"`
 	Binary          string      `json:"binary"`
-	Facts           Facts       `json:"facts"`
+	Facts           FactMap     `json:"facts"`
 	Review          *Ref        `json:"review"`
 	Comments        string      `json:"comments"`
 	Identities      []Ref       `json:"identities"`
@@ -428,7 +638,12 @@ func (r *Application) With(m *model.Application) {
 	r.Comments = m.Comments
 	r.Binary = m.Binary
 	_ = json.Unmarshal(m.Repository, &r.Repository)
-	_ = json.Unmarshal(m.Facts, &r.Facts)
+	r.Facts = FactMap{}
+	for i := range m.Facts {
+		f := Fact{}
+		f.With(&m.Facts[i])
+		r.Facts[f.Key] = f.Value
+	}
 	if m.Review != nil {
 		ref := &Ref{}
 		ref.With(m.Review.ID, "")
@@ -466,10 +681,11 @@ func (r *Application) Model() (m *model.Application) {
 	if r.BusinessService != nil {
 		m.BusinessServiceID = &r.BusinessService.ID
 	}
-	if r.Facts == nil {
-		r.Facts = Facts{}
+	m.Facts = []model.Fact{}
+	for k, v := range r.Facts {
+		f := Fact{Key: k, Value: v}
+		m.Facts = append(m.Facts, *f.Model())
 	}
-	m.Facts, _ = json.Marshal(r.Facts)
 	for _, ref := range r.Identities {
 		m.Identities = append(
 			m.Identities,
@@ -503,5 +719,25 @@ type Repository struct {
 }
 
 //
-// Facts about the application.
-type Facts map[string]interface{}
+// FactMap REST nested resource.
+type FactMap map[string]interface{}
+
+//
+// Fact REST nested resource.
+type Fact struct {
+	Resource
+	Key   string      `json:"key"`
+	Value interface{} `json:"value"`
+}
+
+func (r *Fact) With(m *model.Fact) {
+	r.Key = m.Key
+	_ = json.Unmarshal(m.Value, &r.Value)
+}
+
+func (r *Fact) Model() (m *model.Fact) {
+	m = &model.Fact{}
+	m.Key = r.Key
+	m.Value, _ = json.Marshal(r.Value)
+	return
+}

--- a/auth/role.go
+++ b/auth/role.go
@@ -16,6 +16,7 @@ var AddonRole = []string{
 	"applications:get",
 	"applications:put",
 	"applications.tags:*",
+	"applications.facts:*",
 	"applications.bucket:*",
 	"identities:get",
 	"identities:decrypt",

--- a/auth/roles.yaml
+++ b/auth/roles.yaml
@@ -15,6 +15,12 @@
         - get
         - post
         - put
+    - name: applications.facts
+      verbs:
+        - delete
+        - get
+        - post
+        - put
     - name: applications.tags
       verbs:
         - delete
@@ -157,6 +163,12 @@
         - get
         - post
         - put
+    - name: applications.facts
+      verbs:
+        - delete
+        - get
+        - post
+        - put
     - name: applications.tags
       verbs:
         - delete
@@ -278,6 +290,9 @@
       verbs:
         - post
     - name: applications
+      verbs:
+        - get
+    - name: applications.facts
       verbs:
         - get
     - name: applications.tags

--- a/hack/add/application.sh
+++ b/hack/add/application.sh
@@ -11,6 +11,10 @@ curl -X POST ${host}/applications -d \
       {"id":1},
       {"id":2}
     ],
+    "facts": {
+      "A": "1",
+      "B": "2"
+    },
     "tags":[
       {"id":1}
     ]

--- a/hack/add/application.sh
+++ b/hack/add/application.sh
@@ -43,6 +43,7 @@ curl -X POST ${host}/applications -d \
       "branch": "1.2.0"
     },
     "facts": {
+      "author": {"first":"Elmer","Last":"Fudd"},
       "analysed": true
     },
     "businessService": {"id":1}

--- a/hack/add/fact.sh
+++ b/hack/add/fact.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+host="${HOST:-localhost:8080}"
+
+curl -X POST ${host}/applications/1/facts/pet -d \ '{"kind":"dog","Age":4}' | jq -M .
+curl -X POST ${host}/applications/1/facts/address -d \ '{"street":"Maple","State":"AL"}' | jq -M .

--- a/hack/cmd/addon/main.go
+++ b/hack/cmd/addon/main.go
@@ -59,8 +59,8 @@ func main() {
 		}
 		//
 		// Set fact.
-		application.Facts["Listed"] = true
-		err = addon.Application.Update(application)
+		facts := addon.Application.Facts(application.ID)
+		err = facts.Set("Listed", true)
 		if err != nil {
 			return
 		}

--- a/hack/delete/fact.sh
+++ b/hack/delete/fact.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+host="${HOST:-localhost:8080}"
+
+curl -X DELETE ${host}/applications/1/facts/address

--- a/hack/update/application.sh
+++ b/hack/update/application.sh
@@ -4,14 +4,19 @@ host="${HOST:-localhost:8080}"
 
 curl -X PUT ${host}/applications/1 -d \
 '{
-    "name":"Dog2",
-    "description": "Dog2 application.",
+    "name":"Dog-updated",
+    "description": "Dog application.-updated",
     "businessService": {"id":1},
     "identities": [
+      {"id":1}
+    ],
+    "facts": {
+       "A":"1-updated",
+       "B":"2-updated",
+       "C":"3"
+    },
+    "tags":[
       {"id":1},
       {"id":2}
-    ],
-    "tags":[
-      {"id":1}
     ]
 }' | jq -M .

--- a/hack/update/fact.sh
+++ b/hack/update/fact.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+host="${HOST:-localhost:8080}"
+
+curl -X PUT ${host}/applications/1/facts/address -d \ '{"street": "Maple","City":"Huntsville","State":"AL"}' | jq -M .

--- a/migration/migrate_test.go
+++ b/migration/migrate_test.go
@@ -23,7 +23,6 @@ func TestFreshInstall(t *testing.T) {
 		&TestMigration{Version: 5, ShouldRun: true},
 	}
 
-
 	err := Migrate(migrations)
 	g.Expect(err).To(gomega.BeNil())
 

--- a/migration/v2/migrate.go
+++ b/migration/v2/migrate.go
@@ -17,16 +17,17 @@ func (r Migration) Apply(db *gorm.DB) (err error) {
 		err = liberr.Wrap(err)
 		return
 	}
-
 	constraint := "fk_BusinessService_Applications"
 	log.V(4).Info("Dropping constraint.", "constraint", constraint)
 	err = db.Migrator().DropConstraint(&model.Application{}, constraint)
 	if err != nil {
+		err = liberr.Wrap(err)
 		return
 	}
 	log.V(4).Info("Creating constraint.", "constraint", constraint)
 	err = db.Migrator().CreateConstraint(&model.Application{}, constraint)
 	if err != nil {
+		err = liberr.Wrap(err)
 		return
 	}
 

--- a/migration/v3/migrate.go
+++ b/migration/v3/migrate.go
@@ -1,8 +1,10 @@
 package v3
 
 import (
+	"encoding/json"
 	liberr "github.com/konveyor/controller/pkg/error"
 	"github.com/konveyor/controller/pkg/logging"
+	v2 "github.com/konveyor/tackle2-hub/migration/v2/model"
 	"github.com/konveyor/tackle2-hub/migration/v3/model"
 	"gorm.io/gorm"
 )
@@ -12,7 +14,10 @@ var log = logging.WithName("migration|v3")
 type Migration struct{}
 
 func (r Migration) Apply(db *gorm.DB) (err error) {
-	// Create tables for Trackers and Tickets
+	err = r.factMigration(db)
+	if err != nil {
+		return
+	}
 	err = db.AutoMigrate(r.Models()...)
 	if err != nil {
 		err = liberr.Wrap(err)
@@ -24,4 +29,45 @@ func (r Migration) Apply(db *gorm.DB) (err error) {
 
 func (r Migration) Models() []interface{} {
 	return model.All()
+}
+
+//
+// factMigration migrates Application.Facts.
+// This involves changing the Facts type from JSON which maps to
+// a column in the DB to an ORM virtual field. This, and the data
+// migration both require the v2 model.
+func (r Migration) factMigration(db *gorm.DB) (err error) {
+	migrator := db.Migrator()
+	list := []v2.Application{}
+	result := db.Find(&list)
+	if result.Error != nil {
+		err = liberr.Wrap(result.Error)
+		return
+	}
+	err = migrator.AutoMigrate(&model.Fact{})
+	if err != nil {
+		return
+	}
+	for _, m := range list {
+		d := map[string]interface{}{}
+		_ = json.Unmarshal(m.Facts, &d)
+		for k, v := range d {
+			jv, _ := json.Marshal(v)
+			fact := &model.Fact{}
+			fact.ApplicationID = m.ID
+			fact.Key = k
+			fact.Value = jv
+			result := db.Create(fact)
+			if result.Error != nil {
+				err = liberr.Wrap(result.Error)
+				return
+			}
+		}
+	}
+	err = migrator.DropColumn(&v2.Application{}, "Facts")
+	if err != nil {
+		err = liberr.Wrap(result.Error)
+		return
+	}
+	return
 }

--- a/migration/v3/model/application.go
+++ b/migration/v3/model/application.go
@@ -8,8 +8,8 @@ type Application struct {
 	Review            *Review `gorm:"constraint:OnDelete:CASCADE"`
 	Repository        JSON
 	Binary            string
+	Facts             []Fact
 	Comments          string
-	Facts             JSON
 	Tasks             []Task     `gorm:"constraint:OnDelete:CASCADE"`
 	Tags              []Tag      `gorm:"many2many:ApplicationTags;constraint:OnDelete:CASCADE"`
 	Identities        []Identity `gorm:"many2many:ApplicationIdentity;constraint:OnDelete:CASCADE"`

--- a/migration/v3/model/fact.go
+++ b/migration/v3/model/fact.go
@@ -1,0 +1,8 @@
+package model
+
+type Fact struct {
+	ApplicationID uint         `gorm:"<-:create;primaryKey"`
+	Key           string       `gorm:"<-:create;primaryKey"`
+	Value         JSON         `gorm:"not null"`
+	Application   *Application `gorm:"constraint:OnDelete:CASCADE"`
+}

--- a/migration/v3/model/pkg.go
+++ b/migration/v3/model/pkg.go
@@ -17,7 +17,6 @@ type JSON = datatypes.JSON
 //
 // Unchanged models imported from previous migration.
 type Model = v2.Model
-type Application = v2.Application
 type BucketOwner = v2.BucketOwner
 type BusinessService = v2.BusinessService
 type Dependency = v2.Dependency
@@ -68,5 +67,6 @@ func All() []interface{} {
 		Tracker{},
 		Ticket{},
 		File{},
+		Fact{},
 	}
 }

--- a/model/pkg.go
+++ b/model/pkg.go
@@ -17,6 +17,7 @@ type BucketOwner = model.BucketOwner
 type BusinessService = model.BusinessService
 type Dependency = model.Dependency
 type File = model.File
+type Fact = model.Fact
 type Identity = model.Identity
 type Import = model.Import
 type ImportSummary = model.ImportSummary


### PR DESCRIPTION
Support more granular and atomic API for managing application _facts_.

Added:
- GET /applications/facts
- GET /applications/facts/_key_.
- POST /applications/facts/_key_.
- PUT /applications/facts/_key_.  (created as needed)
- DELETE  /applications/facts/_key_.

Go binding.

- Applications.Facts()
  - List()
  - Get()
  - Set()  (created as needed)
  - Delete()
  
For backwards compat and convenience, The Application.Facts will continue to be supported but we should recommend as _Best Practice_ for API users to use the sub-mainly to avoid conflict.

**Note** There is a bug in the ORM where JSON fields with _number_ roots is not scanned (unmarshalled) correctly.  When fact were embedded in Application this was not an issue.  Moving each fact to a new model/table, each fact value is now the root.  Fact _number_ values  Example: Age=44 won't be supported until this is fixed in the ORM.