### PR TITLE
:bug: Fix tackle import without buckets subdirectory

### DIFF
--- a/hack/tool/tackle
+++ b/hack/tool/tackle
@@ -637,6 +637,9 @@ class TackleTool:
 
     def uploadTackle2Buckets(self):
         bucketDir = "%s/buckets/" % self.dataDir
+        if not os.path.exists(bucketDir):
+            print("Warning: Buckets directory %s doesn't exist, skipping." % bucketDir)
+            return
         for bucketArchive in os.listdir(bucketDir):
             ownerPath = bucketArchive.replace("--", "/").replace(".tar.gz", "")
             if os.path.getsize(bucketDir + bucketArchive) > 0:


### PR DESCRIPTION
Fixing import action for tackle CLI from a dump originated in Tackle 1.2 which didn't have expected data-directory/buckets subdirectory. Workaround with --skip-buckets was possible but that's not that nice.

Signed-off-by: Marek Aufart <maufart@redhat.com>