### PR TITLE
:sparkles: Add file support.

### DIFF
--- a/addon/adapter.go
+++ b/addon/adapter.go
@@ -50,6 +50,8 @@ type Adapter struct {
 	TagType TagType
 	// Tag API.
 	Tag Tag
+	// File API.
+	File File
 	// client A REST client.
 	client *Client
 }
@@ -133,6 +135,9 @@ func newAdapter() (adapter *Adapter) {
 			client: client,
 		},
 		Tag: Tag{
+			client: client,
+		},
+		File: File{
 			client: client,
 		},
 		client: client,

--- a/addon/client.go
+++ b/addon/client.go
@@ -279,7 +279,7 @@ func (r *Client) BucketPut(source, destination string) (err error) {
 		defer func() {
 			_ = writer.Close()
 		}()
-		part, nErr := writer.CreateFormFile(api.File, pathlib.Base(source))
+		part, nErr := writer.CreateFormFile(api.FileField, pathlib.Base(source))
 		if err != nil {
 			err = liberr.Wrap(nErr)
 			return

--- a/addon/file.go
+++ b/addon/file.go
@@ -1,0 +1,52 @@
+package addon
+
+import (
+	"github.com/konveyor/tackle2-hub/api"
+	pathlib "path"
+)
+
+//
+// File API.
+type File struct {
+	// hub API client.
+	client *Client
+}
+
+//
+// Get downloads a file.
+func (h *File) Get(id uint, destination string) (err error) {
+	path := Params{api.ID: id}.inject(api.FileRoot)
+	isDir, err := h.client.isDir(destination, false)
+	if err != nil {
+		return
+	}
+	if isDir {
+		r := &api.File{}
+		err = h.client.Get(path, r)
+		if err != nil {
+			return
+		}
+		destination = pathlib.Join(
+			destination,
+			r.Name)
+	}
+	err = h.client.FileGet(path, destination)
+	return
+}
+
+//
+// Put uploads a file.
+func (h *File) Put(source string) (r *api.File, err error) {
+	r = &api.File{}
+	path := Params{api.ID: pathlib.Base(source)}.inject(api.FileRoot)
+	err = h.client.FilePut(path, source, r)
+	return
+}
+
+//
+// Delete a file.
+func (h *File) Delete(id uint) (err error) {
+	path := Params{api.ID: id}.inject(api.FileRoot)
+	err = h.client.Delete(path)
+	return
+}

--- a/api/bucket.go
+++ b/api/bucket.go
@@ -46,7 +46,7 @@ func (h *BucketHandler) serveBucketUpload(ctx *gin.Context, owner *model.BucketO
 
 func (h *BucketHandler) uploadDirArchive(ctx *gin.Context, dir string) {
 	// Prepare to uncompress the uploaded data, report 4xx errors
-	file, err := ctx.FormFile(File)
+	file, err := ctx.FormFile(FileField)
 	if err != nil {
 		ctx.Status(http.StatusBadRequest)
 		return
@@ -228,7 +228,7 @@ func (h *BucketHandler) upload(ctx *gin.Context, owner *model.BucketOwner) {
 	path := pathlib.Join(
 		owner.Bucket,
 		rPath)
-	input, err := ctx.FormFile(File)
+	input, err := ctx.FormFile(FileField)
 	if err != nil {
 		ctx.Status(http.StatusBadRequest)
 		return

--- a/api/file.go
+++ b/api/file.go
@@ -3,7 +3,7 @@ package api
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/konveyor/tackle2-hub/auth"
-	"github.com/konveyor/tackle2-hub/migration/v3/model"
+	"github.com/konveyor/tackle2-hub/model"
 	"io"
 	"mime"
 	"net/http"

--- a/api/file.go
+++ b/api/file.go
@@ -5,8 +5,10 @@ import (
 	"github.com/konveyor/tackle2-hub/auth"
 	"github.com/konveyor/tackle2-hub/migration/v3/model"
 	"io"
+	"mime"
 	"net/http"
 	"os"
+	pathlib "path"
 	"time"
 )
 
@@ -133,6 +135,10 @@ func (h FileHandler) Get(ctx *gin.Context) {
 	if result.Error != nil {
 		h.reportError(ctx, result.Error)
 		return
+	}
+	header := ctx.Writer.Header()
+	header[ContentType] = []string{
+		mime.TypeByExtension(pathlib.Ext(m.Name)),
 	}
 	ctx.File(m.Path)
 }

--- a/api/file.go
+++ b/api/file.go
@@ -43,7 +43,7 @@ func (h FileHandler) AddRoutes(e *gin.Engine) {
 // @description List all files.
 // @tags get
 // @produce json
-// @success 200 {object} []api.FileField
+// @success 200 {object} []api.File
 // @router /files [get]
 func (h FileHandler) List(ctx *gin.Context) {
 	var list []model.File
@@ -68,9 +68,9 @@ func (h FileHandler) List(ctx *gin.Context) {
 // @tags create
 // @accept json
 // @produce json
-// @success 201 {object} api.FileField
+// @success 201 {object} api.File
 // @router /files [post]
-// @param name path string true "FileField name"
+// @param name path string true "File name"
 func (h FileHandler) Create(ctx *gin.Context) {
 	var err error
 	input, err := ctx.FormFile(FileField)
@@ -127,7 +127,7 @@ func (h FileHandler) Create(ctx *gin.Context) {
 // @produce octet-stream
 // @success 200
 // @router /files/{id} [get]
-// @param id path string true "FileField ID"
+// @param id path string true "File ID"
 func (h FileHandler) Get(ctx *gin.Context) {
 	m := &model.File{}
 	id := h.pk(ctx)
@@ -149,7 +149,7 @@ func (h FileHandler) Get(ctx *gin.Context) {
 // @tags delete
 // @success 204
 // @router /files/{id} [delete]
-// @param id path string true "FileField ID"
+// @param id path string true "File ID"
 func (h FileHandler) Delete(ctx *gin.Context) {
 	m := &model.File{}
 	id := h.pk(ctx)

--- a/api/file.go
+++ b/api/file.go
@@ -122,10 +122,10 @@ func (h FileHandler) Create(ctx *gin.Context) {
 
 // Get godoc
 // @summary Get a file by ID.
-// @description Get a file by ID.
+// @description Get a file by ID. Returns api.File when Accept=application/json else the file content.
 // @tags get
-// @produce octet-stream
-// @success 200
+// @produce json octet-stream
+// @success 200 {object} api.File
 // @router /files/{id} [get]
 // @param id path string true "File ID"
 func (h FileHandler) Get(ctx *gin.Context) {
@@ -136,11 +136,18 @@ func (h FileHandler) Get(ctx *gin.Context) {
 		h.reportError(ctx, result.Error)
 		return
 	}
-	header := ctx.Writer.Header()
-	header[ContentType] = []string{
-		mime.TypeByExtension(pathlib.Ext(m.Name)),
+	switch ctx.GetHeader(Accept) {
+	case AppJson:
+		r := File{}
+		r.With(m)
+		ctx.JSON(http.StatusOK, r)
+	default:
+		header := ctx.Writer.Header()
+		header[ContentType] = []string{
+			mime.TypeByExtension(pathlib.Ext(m.Name)),
+		}
+		ctx.File(m.Path)
 	}
-	ctx.File(m.Path)
 }
 
 // Delete godoc

--- a/api/file.go
+++ b/api/file.go
@@ -1,0 +1,197 @@
+package api
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/konveyor/tackle2-hub/auth"
+	"github.com/konveyor/tackle2-hub/migration/v3/model"
+	"io"
+	"net/http"
+	"os"
+	"time"
+)
+
+//
+// Routes
+const (
+	FilesRoot = "/files"
+	FileRoot  = FilesRoot + "/:" + ID
+)
+
+//
+// FileHandler handles file routes.
+type FileHandler struct {
+	BaseHandler
+}
+
+//
+// AddRoutes adds routes.
+func (h FileHandler) AddRoutes(e *gin.Engine) {
+	routeGroup := e.Group("/")
+	routeGroup.Use(auth.Required("files"))
+	routeGroup.GET(FilesRoot, h.List)
+	routeGroup.GET(FilesRoot+"/", h.List)
+	routeGroup.POST(FileRoot, h.Create)
+	routeGroup.PUT(FileRoot, h.Create)
+	routeGroup.GET(FileRoot, h.Get)
+	routeGroup.DELETE(FileRoot, h.Delete)
+}
+
+// List godoc
+// @summary List all files.
+// @description List all files.
+// @tags get
+// @produce json
+// @success 200 {object} []api.FileField
+// @router /files [get]
+func (h FileHandler) List(ctx *gin.Context) {
+	var list []model.File
+	result := h.DB.Find(&list)
+	if result.Error != nil {
+		h.reportError(ctx, result.Error)
+		return
+	}
+	resources := []File{}
+	for i := range list {
+		r := File{}
+		r.With(&list[i])
+		resources = append(resources, r)
+	}
+
+	ctx.JSON(http.StatusOK, resources)
+}
+
+// Create godoc
+// @summary Create a file.
+// @description Create a file.
+// @tags create
+// @accept json
+// @produce json
+// @success 201 {object} api.FileField
+// @router /files [post]
+// @param name path string true "FileField name"
+func (h FileHandler) Create(ctx *gin.Context) {
+	var err error
+	input, err := ctx.FormFile(FileField)
+	if err != nil {
+		ctx.Status(http.StatusBadRequest)
+		return
+	}
+	m := &model.File{}
+	m.Name = ctx.Param(ID)
+	m.CreateUser = h.BaseHandler.CurrentUser(ctx)
+	result := h.DB.Create(&m)
+	if result.Error != nil {
+		h.reportError(ctx, result.Error)
+		return
+	}
+	defer func() {
+		if err != nil {
+			ctx.Status(http.StatusInternalServerError)
+			_ = h.DB.Delete(&m)
+			return
+		}
+	}()
+	reader, err := input.Open()
+	if err != nil {
+		return
+	}
+	defer func() {
+		_ = reader.Close()
+	}()
+	writer, err := os.Create(m.Path)
+	if err != nil {
+		return
+	}
+	defer func() {
+		_ = writer.Close()
+	}()
+	_, err = io.Copy(writer, reader)
+	if err != nil {
+		return
+	}
+	err = os.Chmod(m.Path, 0666)
+	if err != nil {
+		return
+	}
+	r := File{}
+	r.With(m)
+	ctx.JSON(http.StatusCreated, r)
+}
+
+// Get godoc
+// @summary Get a file by ID.
+// @description Get a file by ID.
+// @tags get
+// @produce octet-stream
+// @success 200
+// @router /files/{id} [get]
+// @param id path string true "FileField ID"
+func (h FileHandler) Get(ctx *gin.Context) {
+	m := &model.File{}
+	id := h.pk(ctx)
+	result := h.DB.First(m, id)
+	if result.Error != nil {
+		h.reportError(ctx, result.Error)
+		return
+	}
+	ctx.File(m.Path)
+}
+
+// Delete godoc
+// @summary Delete a file.
+// @description Delete a file.
+// @tags delete
+// @success 204
+// @router /files/{id} [delete]
+// @param id path string true "FileField ID"
+func (h FileHandler) Delete(ctx *gin.Context) {
+	m := &model.File{}
+	id := h.pk(ctx)
+	err := h.DB.First(m, id).Error
+	if err != nil {
+		h.reportError(ctx, err)
+		return
+	}
+	err = os.Remove(m.Path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			h.reportError(ctx, err)
+			return
+		}
+	}
+	err = h.DB.Delete(m).Error
+	if err != nil {
+		h.reportError(ctx, err)
+		return
+	}
+
+	ctx.Status(http.StatusNoContent)
+}
+
+//
+// File REST resource.
+type File struct {
+	Resource
+	Name       string     `json:"name"`
+	Path       string     `json:"path"`
+	Expiration *time.Time `json:"expiration,omitempty"`
+}
+
+//
+// With updates the resource with the model.
+func (r *File) With(m *model.File) {
+	r.Resource.With(&m.Model)
+	r.Name = m.Name
+	r.Path = m.Path
+	r.Expiration = m.Expiration
+}
+
+//
+// Model builds a model.
+func (r *File) Model() (m *model.File) {
+	m = &model.File{
+		Name: r.Name,
+		Path: r.Path,
+	}
+	return
+}

--- a/api/file.go
+++ b/api/file.go
@@ -185,13 +185,3 @@ func (r *File) With(m *model.File) {
 	r.Path = m.Path
 	r.Expiration = m.Expiration
 }
-
-//
-// Model builds a model.
-func (r *File) Model() (m *model.File) {
-	m = &model.File{
-		Name: r.Name,
-		Path: r.Path,
-	}
-	return
-}

--- a/api/import.go
+++ b/api/import.go
@@ -212,7 +212,7 @@ func (h ImportHandler) UploadCSV(ctx *gin.Context) {
 	if !ok {
 		ctx.Status(http.StatusBadRequest)
 	}
-	file, err := ctx.FormFile(File)
+	file, err := ctx.FormFile(FileField)
 	if err != nil {
 		ctx.Status(http.StatusBadRequest)
 	}

--- a/api/pkg.go
+++ b/api/pkg.go
@@ -16,12 +16,12 @@ var (
 //
 // Params
 const (
-	ID       = "id"
-	ID2      = "id2"
-	Key      = "key"
-	Name     = "name"
-	Wildcard = "wildcard"
-	File     = "file"
+	ID        = "id"
+	ID2       = "id2"
+	Key       = "key"
+	Name      = "name"
+	Wildcard  = "wildcard"
+	FileField = "file"
 )
 
 //
@@ -67,6 +67,7 @@ func All() []Handler {
 		&PathfinderHandler{},
 		&TicketHandler{},
 		&TrackerHandler{},
+		&FileHandler{},
 	}
 }
 

--- a/api/pkg.go
+++ b/api/pkg.go
@@ -27,10 +27,18 @@ const (
 //
 // Headers
 const (
+	Accept        = "Accept"
 	Authorization = "Authorization"
 	ContentLength = "Content-Length"
 	ContentType   = "Content-Type"
 	Directory     = "X-Directory"
+)
+
+//
+// Accepted (mime)
+const (
+	AppJson  = "application/json"
+	AppOctet = "application/octet-stream"
 )
 
 //

--- a/auth/role.go
+++ b/auth/role.go
@@ -26,6 +26,7 @@ var AddonRole = []string{
 	"tasks:get",
 	"tasks.report:*",
 	"tasks.bucket:get",
+	"files:*",
 }
 
 //

--- a/auth/roles.yaml
+++ b/auth/roles.yaml
@@ -134,6 +134,12 @@
       verbs:
         - get
         - delete
+    - name: files
+      verbs:
+        - delete
+        - get
+        - post
+        - put
 - role: tackle-architect
   resources:
     - name: addons
@@ -257,6 +263,12 @@
     - name: cache
       verbs:
         - get
+    - name: files
+      verbs:
+        - delete
+        - get
+        - post
+        - put
 - role: tackle-migrator
   resources:
     - name: addons
@@ -338,5 +350,8 @@
       verbs:
         - get
     - name: cache
+      verbs:
+        - get
+    - name: files
       verbs:
         - get

--- a/hack/add/file.sh
+++ b/hack/add/file.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+host="${HOST:-localhost:8080}"
+
+path="/etc/hosts"
+
+curl -F 'file=@/etc/hosts' http://${host}/files/hosts | jq .
+

--- a/hack/add/file.sh
+++ b/hack/add/file.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 host="${HOST:-localhost:8080}"
+path="${1:-/etc/hosts}"
+name=$(basename ${path})
 
-path="/etc/hosts"
-
-curl -F 'file=@/etc/hosts' http://${host}/files/hosts | jq .
+curl -F 'file=@/etc/hosts' http://${host}/files/${name} | jq .
 

--- a/hack/cmd/addon/main.go
+++ b/hack/cmd/addon/main.go
@@ -141,6 +141,12 @@ func listDir(d *Data, application *api.Application, paths []string) (err error) 
 		return
 	}
 	//
+	// play with files.
+	err = playWithFiles()
+	if err != nil {
+		return
+	}
+	//
 	// Task update: update the current addon activity.
 	addon.Activity("done")
 	return
@@ -285,6 +291,28 @@ func addTags(application *api.Application, names ...string) (err error) {
 		if err != nil {
 			return
 		}
+	}
+	return
+}
+
+//
+// Play with files.
+func playWithFiles() (err error) {
+	f, err := addon.File.Put("/etc/hosts")
+	if err != nil {
+		return
+	}
+	err = addon.File.Get(f.ID, "/tmp/hosts2")
+	if err != nil {
+		return
+	}
+	err = addon.File.Get(f.ID, "/tmp")
+	if err != nil {
+		return
+	}
+	err = addon.File.Delete(f.ID)
+	if err != nil {
+		return
 	}
 	return
 }

--- a/hack/update/file.sh
+++ b/hack/update/file.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+host="${HOST:-localhost:8080}"
+
+path="/etc/hosts"
+
+curl -F 'file=@/etc/hosts' http://${host}/files/hosts | jq .
+

--- a/migration/v3/model/file.go
+++ b/migration/v3/model/file.go
@@ -12,7 +12,7 @@ import (
 type File struct {
 	Model
 	Name       string
-	Path       string
+	Path       string `gorm:"<-:create;uniqueIndex"`
 	Expiration *time.Time
 }
 

--- a/migration/v3/model/file.go
+++ b/migration/v3/model/file.go
@@ -1,0 +1,33 @@
+package model
+
+import (
+	"github.com/google/uuid"
+	liberr "github.com/konveyor/controller/pkg/error"
+	"gorm.io/gorm"
+	"os"
+	"path"
+	"time"
+)
+
+type File struct {
+	Model
+	Name       string
+	Path       string
+	Expiration *time.Time
+}
+
+func (m *File) BeforeCreate(db *gorm.DB) (err error) {
+	uid := uuid.New()
+	m.Path = path.Join(
+		Settings.Hub.Bucket.Path,
+		".file",
+		uid.String())
+	err = os.MkdirAll(path.Dir(m.Path), 0777)
+	if err != nil {
+		err = liberr.Wrap(
+			err,
+			"path",
+			m.Path)
+	}
+	return
+}

--- a/migration/v3/model/pkg.go
+++ b/migration/v3/model/pkg.go
@@ -67,5 +67,6 @@ func All() []interface{} {
 		Proxy{},
 		Tracker{},
 		Ticket{},
+		File{},
 	}
 }

--- a/model/pkg.go
+++ b/model/pkg.go
@@ -16,6 +16,7 @@ type Application = model.Application
 type BucketOwner = model.BucketOwner
 type BusinessService = model.BusinessService
 type Dependency = model.Dependency
+type File = model.File
 type Identity = model.Identity
 type Import = model.Import
 type ImportSummary = model.ImportSummary

--- a/reaper/file.go
+++ b/reaper/file.go
@@ -1,0 +1,110 @@
+package reaper
+
+import (
+	liberr "github.com/konveyor/controller/pkg/error"
+	"github.com/konveyor/tackle2-hub/model"
+	"gorm.io/gorm"
+	"os"
+	"time"
+)
+
+//
+// FileReaper file reaper.
+type FileReaper struct {
+	// DB
+	DB *gorm.DB
+}
+
+//
+// Run Executes the reaper.
+// A file is deleted when it is no longer referenced and the TTL has expired.
+func (r *FileReaper) Run() {
+	Log.V(1).Info("Reaping files.")
+	list := []model.File{}
+	err := r.DB.Find(&list).Error
+	if err != nil {
+		Log.Trace(err)
+		return
+	}
+	for _, file := range list {
+		busy, err := r.busy(&file)
+		if err != nil {
+			Log.Trace(err)
+			continue
+		}
+		if busy {
+			if file.Expiration != nil {
+				file.Expiration = nil
+				err = r.DB.Save(&file).Error
+				Log.Trace(err)
+			}
+			continue
+		}
+		if file.Expiration == nil {
+			mark := time.Now().Add(time.Minute * time.Duration(Settings.File.TTL))
+			file.Expiration = &mark
+			err = r.DB.Save(&file).Error
+			Log.Trace(err)
+			continue
+		}
+		mark := time.Now()
+		if mark.After(*file.Expiration) {
+			err = r.delete(&file)
+			if err != nil {
+				Log.Trace(err)
+				continue
+			}
+		}
+	}
+}
+
+//
+// busy determines if anything references the file.
+func (r *FileReaper) busy(file *model.File) (busy bool, err error) {
+	nRef := int64(0)
+	var n int64
+	ref := RefCounter{DB: r.DB}
+	for _, m := range []interface{}{
+		// ADD MODELS HERE
+	} {
+		n, err = ref.Count(m, "file", file.ID)
+		if err != nil {
+			Log.Trace(err)
+			continue
+		}
+		nRef += n
+	}
+	busy = nRef > 0
+	return
+}
+
+//
+// Delete file.
+func (r *FileReaper) delete(file *model.File) (err error) {
+	err = os.Remove(file.Path)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			err = liberr.Wrap(
+				err,
+				"id",
+				file.ID,
+				"path",
+				file.Path)
+			return
+		} else {
+			err = nil
+		}
+	}
+	err = r.DB.Delete(file).Error
+	if err != nil {
+		err = liberr.Wrap(
+			err,
+			"id",
+			file.ID,
+			"path",
+			file.Path)
+		return
+	}
+	Log.Info("File deleted.", "id", file.ID, "path", file.Path)
+	return
+}

--- a/reaper/manager.go
+++ b/reaper/manager.go
@@ -53,6 +53,9 @@ func (m *Manager) Run(ctx context.Context) {
 		&BucketReaper{
 			DB: m.DB,
 		},
+		&FileReaper{
+			DB: m.DB,
+		},
 	}
 	go func() {
 		Log.Info("Started.")

--- a/reaper/ref.go
+++ b/reaper/ref.go
@@ -1,0 +1,62 @@
+package reaper
+
+import (
+	liberr "github.com/konveyor/controller/pkg/error"
+	"gorm.io/gorm"
+	"reflect"
+)
+
+//
+// RefCounter provides model inspection for files
+// tagged with: ref:<kind>.
+type RefCounter struct {
+	// DB
+	DB *gorm.DB
+}
+
+//
+// Count find & count references.
+func (r *RefCounter) Count(m interface{}, kind string, pk uint) (nRef int64, err error) {
+	mt := reflect.TypeOf(m)
+	mv := reflect.ValueOf(m)
+	if mt.Kind() == reflect.Ptr {
+		mt = mt.Elem()
+		mv = mv.Elem()
+	}
+	if mv.Kind() != reflect.Struct {
+		err = liberr.New("Must be object.")
+		return
+	}
+	db := r.DB.Model(m)
+	fields := 0
+	for i := 0; i < mt.NumField(); i++ {
+		ft := mt.Field(i)
+		fv := mv.Field(i)
+		if !fv.CanSet() {
+			continue
+		}
+		switch fv.Kind() {
+		case reflect.Uint:
+			tag, found := ft.Tag.Lookup("ref")
+			if !found || tag != kind {
+				continue
+			}
+			db = db.Or(ft.Name, pk)
+			fields++
+		}
+	}
+	if fields == 0 {
+		return
+	}
+	err = db.Count(&nRef).Error
+	if err != nil {
+		err = liberr.Wrap(
+			err,
+			"object",
+			mt.Name(),
+		)
+	}
+
+	return
+}
+

--- a/settings/hub.go
+++ b/settings/hub.go
@@ -22,6 +22,7 @@ const (
 	EnvFrequencyTask     = "FREQUENCY_TASK"
 	EnvFrequencyReaper   = "FREQUENCY_REAPER"
 	EnvDevelopment       = "DEVELOPMENT"
+	EnvFileTTL           = "FILE_TTL"
 )
 
 type Hub struct {
@@ -35,6 +36,10 @@ type Hub struct {
 	// Bucket settings.
 	Bucket struct {
 		Path string
+	}
+	// File settings.
+	File struct {
+		TTL int
 	}
 	// Cache settings.
 	Cache struct {
@@ -156,6 +161,14 @@ func (r *Hub) Load() (err error) {
 	} else {
 		r.Development = false
 	}
+	s, found = os.LookupEnv(EnvFileTTL)
+	if found {
+		n, _ := strconv.Atoi(s)
+		r.File.TTL = n
+	} else {
+		r.File.TTL = 720 // 12 hours.
+	}
+
 	return
 }
 


### PR DESCRIPTION
Support uploading and storing files independently of buckets.

Resource:
```
//
// File REST resource.
type File struct {
    Resource
    Name       string     `json:"name"`
    Path       string     `json:"path"`
    Expiration *time.Time `json:"expiration,omitempty"`
}
```

API:
- POST|PUT /files/_name_  - Create|update file. Returns `File`
- GET /files - List files. Returns `[]File`
- GET /files/:id - Get file content.  Accept=json returns `File`, else returns file stream.
- DELETE /files/:id - Delete a file.

Binding:
- File.Get(id uint, destination) - Get (downlaod) a file written to `destination`.
- File.Put(source) - Put (uploads) a file. Returns a `File`.
- File.Delete(id uint) - Delete a file.

Files with Zero reference count are reaped after 12 hours. **Q: Is this too long?**

---

Use case.  The upcoming `RuleSet` needs to have an associated image file.  The anticipated workflow is:

1. Update an Image.
2. Create the RuleSet with RuleSet.Image = File ID returned by the POST on /files.

Should the flow be interrupted between 1 & 2, the orphaned file will be reaped.

Example:
```
type RuleSet struct {
    Model
    ImageID uint `ref:"file"`
    Image   *File
}
```