### PR TITLE
:sparkles: Push multi-arch builds to quay

### DIFF
--- a/.github/workflows/march-image-build-push.yml
+++ b/.github/workflows/march-image-build-push.yml
@@ -1,0 +1,29 @@
+name: 'Build and Push Multi-Arch Image'
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'main'
+      - 'release-*'
+    tags:
+      - 'v*'
+
+jobs:
+  push-quay:
+    name: Build and Push Manifest
+    runs-on: ubuntu-20.04
+    strategy:
+      fail-fast: false
+    steps:
+    - name: Checkout Push to Registry action
+      uses: konveyor/release-tools/build-push-quay@main
+      with:
+        architectures: "amd64, arm64, ppc64le, s390x"
+        containerfile: "./Dockerfile"
+        image_name: "tackle2-hub"
+        image_namespace: "konveyor"
+        image_registry: "quay.io"
+        quay_robot: ${{ secrets.QUAY_PUBLISH_ROBOT }}
+        quay_token: ${{ secrets.QUAY_PUBLISH_TOKEN }}
+        ref: ${{ github.ref }}


### PR DESCRIPTION
Signed-off-by: Jason Montleon <jmontleo@redhat.com>

As a first step to automating releases I'd like to merge to each of the tackle repos a GitHub action to build multi-arch images for the main branch and tags. I've opened up a commit here for review and once we agree I will submit a PR to each of the tackle repos.

For a preview of what this looks like on quay see: https://quay.io/repository/jmontleon/tackle2-hub?tab=tags

Once those are up and they're approved we can turn off the quay auto builds, ensure the robot env vars are in the org, and the account is privileged to push to each repo.

Future improvements from here will include using manifest SHAs in the tag version CSVs and automating the release, ensuring we push a no arch bundle in our quay org, an updated index in our quay org, and auto generating a PR against community operators.

Things we should decide on:
Branch names: do we want to use branches like `release-x.y`, `tackle-x.y`, something else.  
Tag names: Are we good with `vx.y.z` or do we want something else like `x.y.z`, or other. 