### PR TITLE
:seedling: make start-minikube + install-tackle

### DIFF
--- a/.github/workflows/test-addons.yml
+++ b/.github/workflows/test-addons.yml
@@ -11,18 +11,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: start-minikube
+      - name: Start minikube
         uses: konveyor/tackle2-operator/.github/actions/start-minikube@main
       - name: Build image in minikube
         run: |
           export SHELL=/bin/bash
           eval $(minikube -p minikube docker-env)
           make docker-build
-      - name: install-tackle
+      - name: Install Tackle
         uses: konveyor/tackle2-operator/.github/actions/install-tackle@main
         with:
           tackle-hub-image: tackle2-hub:latest
           tackle-image-pull-policy: IfNotPresent
-
-      - name: test windup addon
+      - name: Set host and namespace
+        run: |
+          echo "host=$(minikube ip)/hub" >> $GITHUB_ENV
+          echo "namespace=$(kubectl get tackles.tackle.konveyor.io --all-namespaces --no-headers | awk '{print $1}')" >> $GITHUB_ENV
+      - name: Test windup
         uses: konveyor/tackle2-addon-windup/.github/actions/test-e2e-windup@main
+        with:
+          host: ${{ env.host }}
+          namespace: ${{ env.namespace }}

--- a/Makefile
+++ b/Makefile
@@ -86,3 +86,29 @@ docs-swagger:
 # Build binding doc.
 docs-binding:
 	go doc --all addon > docs/binding.txt
+
+.PHONY: start-minikube
+START_MINIKUBE_SH = ./bin/start-minikube.sh
+start-minikube:
+ifeq (,$(wildcard $(START_MINIKUBE_SH)))
+	@{ \
+	set -e ;\
+	mkdir -p $(dir $(START_MINIKUBE_SH)) ;\
+	curl -sSLo $(START_MINIKUBE_SH) https://raw.githubusercontent.com/konveyor/tackle2-operator/main/hack/start-minikube.sh ;\
+	chmod +x $(START_MINIKUBE_SH) ;\
+	}
+endif
+	$(START_MINIKUBE_SH);
+
+.PHONY: install-tackle
+INSTALL_TACKLE_SH = ./bin/install-tackle.sh
+install-tackle:
+ifeq (,$(wildcard $(INSTALL_TACKLE_SH)))
+	@{ \
+	set -e ;\
+	mkdir -p $(dir $(INSTALL_TACKLE_SH)) ;\
+	curl -sSLo $(INSTALL_TACKLE_SH) https://raw.githubusercontent.com/konveyor/tackle2-operator/main/hack/install-tackle.sh ;\
+	chmod +x $(INSTALL_TACKLE_SH) ;\
+	}
+endif
+	$(INSTALL_TACKLE_SH);


### PR DESCRIPTION
Add the start-minikube and install-tackle targets to Makefile. Additionally, update the addons workflow to populate the HOST.

Signed-off-by: David Zager <david.j.zager@gmail.com>