### PR TITLE
:sparkles: Bucket GET on directory using accept header.

### DIFF
--- a/addon/client.go
+++ b/addon/client.go
@@ -229,7 +229,6 @@ func (r *Client) BucketGet(source, destination string) (err error) {
 			Method: http.MethodGet,
 			URL:    r.join(source),
 		}
-		request.Header.Set(api.Directory, api.DirectoryArchive)
 		request.Header.Set(Accept, AppOctet)
 		return
 	}

--- a/api/application.go
+++ b/api/application.go
@@ -248,6 +248,7 @@ func (h ApplicationHandler) Update(ctx *gin.Context) {
 // BucketGet godoc
 // @summary Get bucket content by ID and path.
 // @description Get bucket content by ID and path.
+// @description Returns index.html for directories when Accept=text/html else a tarball.
 // @tags get
 // @produce octet-stream
 // @success 200

--- a/api/bucket.go
+++ b/api/bucket.go
@@ -29,11 +29,16 @@ func (h *BucketHandler) serveBucketGet(ctx *gin.Context, owner *model.BucketOwne
 		ctx.Status(http.StatusNotFound)
 		return
 	}
-	if st.IsDir() && ctx.Request.Header.Get(Directory) == DirectoryArchive {
-		h.getDirArchive(ctx, path)
-	} else {
-		h.content(ctx, owner)
+	if st.IsDir() {
+		if h.accepted(ctx, TextHTML) {
+			h.content(ctx, owner)
+		} else {
+			h.getDirArchive(ctx, path)
+		}
+		return
 	}
+
+	h.content(ctx, owner)
 }
 
 func (h *BucketHandler) serveBucketUpload(ctx *gin.Context, owner *model.BucketOwner) {
@@ -287,4 +292,17 @@ func (h *BucketHandler) delete(ctx *gin.Context, owner *model.BucketOwner) {
 	}
 
 	ctx.Status(http.StatusNoContent)
+}
+
+//
+// accepted determines if the mime is accepted.
+func (h *BucketHandler) accepted(ctx *gin.Context, mime string) (b bool) {
+	accept := ctx.Request.Header.Get(Accept)
+	for _, s := range strings.Split(accept, ",") {
+		if s == mime {
+			b = true
+			break
+		}
+	}
+	return
 }

--- a/api/pkg.go
+++ b/api/pkg.go
@@ -39,6 +39,7 @@ const (
 const (
 	AppJson  = "application/json"
 	AppOctet = "application/octet-stream"
+	TextHTML = "text/html"
 )
 
 //

--- a/api/task.go
+++ b/api/task.go
@@ -309,6 +309,7 @@ func (h TaskHandler) Cancel(ctx *gin.Context) {
 // BucketGet godoc
 // @summary Get bucket content by ID and path.
 // @description Get bucket content by ID and path.
+// @description Returns index.html for directories when Accept=text/html else a tarball.
 // @tags get
 // @produce octet-stream
 // @success 200

--- a/api/taskgroup.go
+++ b/api/taskgroup.go
@@ -277,6 +277,7 @@ func (h TaskGroupHandler) Submit(ctx *gin.Context) {
 // BucketGet godoc
 // @summary Get bucket content by ID and path.
 // @description Get bucket content by ID and path.
+// @description Returns index.html for directories when Accept=text/html else a tarball.
 // @tags get
 // @produce octet-stream
 // @success 200


### PR DESCRIPTION
Signed-off-by: Jeff Ortel <jortel@redhat.com>

Update the bucket APIs to return tarball for directories based on `Accept` header instead of `X-Directory` header. This will be simpler for browsers and file download widgets.

When the path is a directory in the bucket a tarball will be returned unless the client explicitly accepts `text/html`.

This should not require any changes in API clients (Like the CLI).