### PR TITLE
:ghost: Fix file reaping of rulebundle images and ruleset files.

### DIFF
--- a/reaper/file.go
+++ b/reaper/file.go
@@ -41,6 +41,7 @@ func (r *FileReaper) Run() {
 			continue
 		}
 		if file.Expiration == nil {
+			Log.Info("File (orphan) found.", "id", file.ID, "path", file.Path)
 			mark := time.Now().Add(time.Minute * time.Duration(Settings.File.TTL))
 			file.Expiration = &mark
 			err = r.DB.Save(&file).Error
@@ -65,8 +66,8 @@ func (r *FileReaper) busy(file *model.File) (busy bool, err error) {
 	var n int64
 	ref := RefCounter{DB: r.DB}
 	for _, m := range []interface{}{
-		model.RuleBundle{},
-		model.RuleSet{},
+		&model.RuleBundle{},
+		&model.RuleSet{},
 	} {
 		n, err = ref.Count(m, "file", file.ID)
 		if err != nil {
@@ -106,6 +107,6 @@ func (r *FileReaper) delete(file *model.File) (err error) {
 			file.Path)
 		return
 	}
-	Log.Info("File deleted.", "id", file.ID, "path", file.Path)
+	Log.Info("File (orphan) deleted.", "id", file.ID, "path", file.Path)
 	return
 }

--- a/reaper/ref.go
+++ b/reaper/ref.go
@@ -32,7 +32,7 @@ func (r *RefCounter) Count(m interface{}, kind string, pk uint) (nRef int64, err
 	for i := 0; i < mt.NumField(); i++ {
 		ft := mt.Field(i)
 		fv := mv.Field(i)
-		if !fv.CanSet() {
+		if !ft.IsExported() {
 			continue
 		}
 		switch fv.Kind() {

--- a/settings/hub.go
+++ b/settings/hub.go
@@ -169,7 +169,7 @@ func (r *Hub) Load() (err error) {
 		n, _ := strconv.Atoi(s)
 		r.File.TTL = n
 	} else {
-		r.File.TTL = 720 // 12 hours.
+		r.File.TTL = 720 // minutes: 12 hours.
 	}
 	s, found = os.LookupEnv(EnvAppName)
 	if found {


### PR DESCRIPTION
Needed to use IsExported() instead of CanSet().
Other minor:
- passing model as pointer for efficiency.
- add/update logging.
- comments.