### PR TITLE
:sparkles: Update login endpoint to return token in JSON

### DIFF
--- a/addon/adapter.go
+++ b/addon/adapter.go
@@ -9,7 +9,6 @@ import (
 	"github.com/konveyor/controller/pkg/logging"
 	"github.com/konveyor/tackle2-hub/settings"
 	"golang.org/x/sys/unix"
-	"net/http"
 	"os"
 	"strings"
 )
@@ -112,7 +111,6 @@ func newAdapter() (adapter *Adapter) {
 	// Build REST client.
 	client := &Client{
 		baseURL: Settings.Addon.Hub.URL,
-		http:    &http.Client{},
 		token:   Settings.Addon.Hub.Token,
 	}
 	//

--- a/addon/client.go
+++ b/addon/client.go
@@ -40,12 +40,25 @@ type Param struct {
 type Client struct {
 	// baseURL for the nub.
 	baseURL string
-	// http client.
-	http *http.Client
 	// addon API token
 	token string
 	// transport
 	transport http.RoundTripper
+}
+
+//
+// Construct a new client
+func NewClient(url, token string) *Client {
+	return &Client{
+		baseURL: url,
+		token:   token,
+	}
+}
+
+//
+// Set hub token on client
+func (r *Client) SetToken(token string) {
+	r.token = token
 }
 
 //

--- a/api/auth.go
+++ b/api/auth.go
@@ -30,17 +30,16 @@ func (h AuthHandler) AddRoutes(e *gin.Engine) {
 // @description Login and obtain a bearer token.
 // @tags post
 // @produce json
-// @success 201 {string} token
+// @success 201 {object} api.Login
 // @router /auth/login [post]
 func (h AuthHandler) Login(ctx *gin.Context) {
-	token := ""
 	r := &Login{}
 	err := ctx.BindJSON(r)
 	if err != nil {
 		h.reportError(ctx, err)
 		return
 	}
-	token, err = auth.Remote.Login(r.User, r.Password)
+	r.Token, err = auth.Remote.Login(r.User, r.Password)
 	if err != nil {
 		ctx.JSON(
 			http.StatusUnauthorized,
@@ -49,12 +48,14 @@ func (h AuthHandler) Login(ctx *gin.Context) {
 			})
 		return
 	}
-	ctx.JSON(http.StatusCreated, token)
+	r.Password = "" // Clear out password from response
+	ctx.JSON(http.StatusCreated, r)
 }
 
 //
 // Login REST resource.
 type Login struct {
 	User     string `json:"user"`
-	Password string `json:"password"`
+	Password string `json:"password,omitempty"`
+	Token    string `json:"token"`
 }


### PR DESCRIPTION
After changes:
```
[galt@desktop ~]$ curl  http://$(minikube ip)/hub/auth/login -X POST -H "Content-Type: application/json" -d "@login.json" | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  3361    0  3321  100    40  43893    528 --:--:-- --:--:-- --:--:-- 44813
{
  "user": "admin",
  "token": "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICItTWxjMU9wSUNXUjUxMUh..."
}
```

Also includes helpers for using the addon client