### PR TITLE
:sparkles: Add bucket directory download content filtering.

### DIFF
--- a/api/application.go
+++ b/api/application.go
@@ -338,11 +338,13 @@ func (h ApplicationHandler) Update(ctx *gin.Context) {
 // @summary Get bucket content by ID and path.
 // @description Get bucket content by ID and path.
 // @description Returns index.html for directories when Accept=text/html else a tarball.
+// @description ?filter=glob supports directory content filtering.
 // @tags get
 // @produce octet-stream
 // @success 200
 // @router /applications/{id}/bucket/{wildcard} [get]
 // @param id path string true "Application ID"
+// @param filter query string false "Filter"
 func (h ApplicationHandler) BucketGet(ctx *gin.Context) {
 	m := &model.Application{}
 	id := h.pk(ctx)

--- a/api/bucket.go
+++ b/api/bucket.go
@@ -29,6 +29,12 @@ const (
 )
 
 //
+// Params
+const (
+	Filter = "filter"
+)
+
+//
 // BucketHandler handles bucket routes.
 type BucketHandler struct {
 	BucketOwner
@@ -236,6 +242,10 @@ func (h *BucketOwner) bucketGet(ctx *gin.Context, id uint) {
 		return
 	}
 	if st.IsDir() {
+		filter := DirFilter{
+			pattern: ctx.Query(Filter),
+			root:    path,
+		}
 		if h.accepted(ctx, TextHTML) {
 			err = h.getFile(ctx, m)
 			if err != nil {
@@ -243,17 +253,12 @@ func (h *BucketOwner) bucketGet(ctx *gin.Context, id uint) {
 			}
 			return
 		} else {
-			n, err := h.getDir(ctx, path)
+			err := h.getDir(ctx, path, filter)
 			if err != nil {
 				h.reportError(ctx, err)
 				return
 			}
-			if n == 0 {
-				ctx.Status(http.StatusNoContent)
-				return
-			} else {
-				ctx.Status(http.StatusOK)
-			}
+			ctx.Status(http.StatusOK)
 		}
 	} else {
 		err = h.getFile(ctx, m)
@@ -380,7 +385,7 @@ func (h *BucketOwner) putDir(ctx *gin.Context, output string) (err error) {
 
 //
 // getDir reads a directory from the bucket.
-func (h *BucketOwner) getDir(ctx *gin.Context, input string) (entryCount int, err error) {
+func (h *BucketOwner) getDir(ctx *gin.Context, input string, filter DirFilter) (err error) {
 	var tarOutput bytes.Buffer
 	tarWriter := tar.NewWriter(&tarOutput)
 	err = filepath.Walk(
@@ -391,6 +396,9 @@ func (h *BucketOwner) getDir(ctx *gin.Context, input string) (entryCount int, er
 				return
 			}
 			if path == input {
+				return
+			}
+			if !filter.Match(path) {
 				return
 			}
 			header, err := tar.FileInfoHeader(info, path)
@@ -406,7 +414,6 @@ func (h *BucketOwner) getDir(ctx *gin.Context, input string) (entryCount int, er
 					err = liberr.Wrap(err)
 					return
 				}
-				entryCount += 1
 			case tar.TypeReg:
 				err = tarWriter.WriteHeader(header)
 				if err != nil {
@@ -426,7 +433,6 @@ func (h *BucketOwner) getDir(ctx *gin.Context, input string) (entryCount int, er
 					err = liberr.Wrap(err)
 					return
 				}
-				entryCount += 1
 			}
 			return
 		})
@@ -436,9 +442,6 @@ func (h *BucketOwner) getDir(ctx *gin.Context, input string) (entryCount int, er
 	err = tarWriter.Close()
 	if err != nil {
 		err = liberr.Wrap(err)
-		return
-	}
-	if entryCount < 1 {
 		return
 	}
 	ctx.Writer.Header().Set(
@@ -508,5 +511,31 @@ func (h *BucketOwner) accepted(ctx *gin.Context, mime string) (b bool) {
 			break
 		}
 	}
+	return
+}
+
+//
+// DirFilter supports glob-style filtering.
+type DirFilter struct {
+	root    string
+	pattern string
+	cache   map[string]bool
+}
+
+//
+// Match determines if path matches the filter.
+func (r *DirFilter) Match(path string) (b bool) {
+	if r.pattern == "" {
+		b = true
+		return
+	}
+	if r.cache == nil {
+		r.cache = map[string]bool{}
+		matches, _ := filepath.Glob(pathlib.Join(r.root, r.pattern))
+		for _, p := range matches {
+			r.cache[p] = true
+		}
+	}
+	_, b = r.cache[path]
 	return
 }

--- a/api/bucket.go
+++ b/api/bucket.go
@@ -166,12 +166,14 @@ func (h BucketHandler) Delete(ctx *gin.Context) {
 // @description Get bucket content by ID and path.
 // @description When path is FILE, returns file content.
 // @description When path is DIRECTORY and Accept=text/html returns index.html.
+// @description ?filter=glob supports directory content filtering.
 // @description Else returns a tarball.
 // @tags get
 // @produce octet-stream
 // @success 200
 // @router /buckets/{id}/{wildcard} [get]
 // @param id path string true "Task ID"
+// @param filter query string false "Filter"
 func (h BucketHandler) BucketGet(ctx *gin.Context) {
 	h.bucketGet(ctx, h.pk(ctx))
 }

--- a/api/task.go
+++ b/api/task.go
@@ -314,11 +314,13 @@ func (h TaskHandler) Cancel(ctx *gin.Context) {
 // @summary Get bucket content by ID and path.
 // @description Get bucket content by ID and path.
 // @description Returns index.html for directories when Accept=text/html else a tarball.
+// @description ?filter=glob supports directory content filtering.
 // @tags get
 // @produce octet-stream
 // @success 200
 // @router /tasks/{id}/bucket/{wildcard} [get]
 // @param id path string true "Task ID"
+// @param filter query string false "Filter"
 func (h TaskHandler) BucketGet(ctx *gin.Context) {
 	m := &model.Task{}
 	id := h.pk(ctx)

--- a/api/taskgroup.go
+++ b/api/taskgroup.go
@@ -280,11 +280,13 @@ func (h TaskGroupHandler) Submit(ctx *gin.Context) {
 // @summary Get bucket content by ID and path.
 // @description Get bucket content by ID and path.
 // @description Returns index.html for directories when Accept=text/html else a tarball.
+// @description ?filter=glob supports directory content filtering.
 // @tags get
 // @produce octet-stream
 // @success 200
 // @router /taskgroups/{id}/bucket/{wildcard} [get]
 // @param id path string true "TaskGroup ID"
+// @param filter query string false "Filter"
 func (h TaskGroupHandler) BucketGet(ctx *gin.Context) {
 	m := &model.TaskGroup{}
 	id := h.pk(ctx)


### PR DESCRIPTION
Add bucket directory download content filtering. Support optional `?filter=<glob>` query parameter.

Example:  /applications/1/buckets/windup/report?*.csv the tarball will only contain .csv files.

Removed the optimization of returning NoContent when the tarball is empty.  I think this complicates what the client needs to do for no real gain. 

closes #243 