### PR TITLE
:ghost: fix null issues relating to tag associations

### DIFF
--- a/api/application.go
+++ b/api/application.go
@@ -279,6 +279,7 @@ func (h ApplicationHandler) Update(ctx *gin.Context) {
 	//
 	// Update the application.
 	m = r.Model()
+	m.Tags = nil
 	m.ID = id
 	m.UpdateUser = h.BaseHandler.CurrentUser(ctx)
 	db = h.DB.Model(m)

--- a/hack/update/application.sh
+++ b/hack/update/application.sh
@@ -17,6 +17,7 @@ curl -X PUT ${host}/applications/1 -d \
     },
     "tags":[
       {"id":1},
-      {"id":2}
+      {"id":2},
+      {"id":3}
     ]
 }' | jq -M .

--- a/migration/v3/model/application.go
+++ b/migration/v3/model/application.go
@@ -10,10 +10,9 @@ type Application struct {
 	Binary            string
 	Facts             []Fact `gorm:"constraint:OnDelete:CASCADE"`
 	Comments          string
-	Tasks             []Task           `gorm:"constraint:OnDelete:CASCADE"`
-	Tags              []Tag            `gorm:"many2many:ApplicationTags;constraint:OnDelete:CASCADE"`
-	ApplicationTags   []ApplicationTag `gorm:"constraint:OnDelete:CASCADE"`
-	Identities        []Identity       `gorm:"many2many:ApplicationIdentity;constraint:OnDelete:CASCADE"`
-	BusinessServiceID *uint            `gorm:"index"`
+	Tasks             []Task     `gorm:"constraint:OnDelete:CASCADE"`
+	Tags              []Tag      `gorm:"many2many:ApplicationTags"`
+	Identities        []Identity `gorm:"many2many:ApplicationIdentity;constraint:OnDelete:CASCADE"`
+	BusinessServiceID *uint      `gorm:"index"`
 	BusinessService   *BusinessService
 }

--- a/migration/v3/model/applicationtag.go
+++ b/migration/v3/model/applicationtag.go
@@ -4,11 +4,11 @@ package model
 // ApplicationTag represents a row in the join table for the
 // many-to-many relationship between Applications and Tags.
 type ApplicationTag struct {
-	ApplicationID uint   `gorm:"primaryKey"`
-	TagID         uint   `gorm:"primaryKey"`
-	Source        string `gorm:"primaryKey;not null"`
-	Application   *Application
-	Tag           *Tag
+	ApplicationID uint        `gorm:"primaryKey"`
+	TagID         uint        `gorm:"primaryKey"`
+	Source        string      `gorm:"primaryKey;not null"`
+	Application   Application `gorm:"constraint:OnDelete:CASCADE"`
+	Tag           Tag         `gorm:"constraint:OnDelete:CASCADE"`
 }
 
 //

--- a/migration/v3/model/tag.go
+++ b/migration/v3/model/tag.go
@@ -2,9 +2,8 @@ package model
 
 type Tag struct {
 	Model
-	Name            string `gorm:"uniqueIndex:tagA;not null"`
-	Username        string
-	CategoryID      uint `gorm:"uniqueIndex:tagA;index;not null"`
-	Category        TagCategory
-	ApplicationTags []ApplicationTag `gorm:"constraint:OnDelete:CASCADE"`
+	Name       string `gorm:"uniqueIndex:tagA;not null"`
+	Username   string
+	CategoryID uint `gorm:"uniqueIndex:tagA;index;not null"`
+	Category   TagCategory
 }


### PR DESCRIPTION
*Fixes a null pointer while generating the list of tag refs for the resource to be returned from an Application create.
*Fixes a null constraint violation caused by GORM not omitting associations properly while updating.