### PR TITLE
:ghost: Ensure that model association updates are applied correctly

### DIFF
--- a/api/application.go
+++ b/api/application.go
@@ -279,10 +279,10 @@ func (h ApplicationHandler) Update(ctx *gin.Context) {
 	//
 	// Update the application.
 	m = r.Model()
-	m.Tags = nil
 	m.ID = id
 	m.UpdateUser = h.BaseHandler.CurrentUser(ctx)
-	db = h.DB.Model(m)
+	a := &model.Application{Model: model.Model{ID: id}}
+	db = h.DB.Model(a)
 	db = db.Omit(clause.Associations)
 	db = db.Omit("BucketID")
 	result = db.Updates(h.fields(m))
@@ -290,13 +290,13 @@ func (h ApplicationHandler) Update(ctx *gin.Context) {
 		h.reportError(ctx, result.Error)
 		return
 	}
-	db = h.DB.Model(m)
+	db = h.DB.Model(a)
 	err = db.Association("Identities").Replace(m.Identities)
 	if err != nil {
 		h.reportError(ctx, err)
 		return
 	}
-	db = h.DB.Model(m)
+	db = h.DB.Model(a)
 	err = db.Association("Facts").Replace(m.Facts)
 	if err != nil {
 		h.reportError(ctx, err)
@@ -323,7 +323,7 @@ func (h ApplicationHandler) Update(ctx *gin.Context) {
 	if len(r.Tags) > 0 {
 		tags := []model.ApplicationTag{}
 		for _, t := range r.Tags {
-			tags = append(tags, model.ApplicationTag{TagID: t.ID, ApplicationID: m.ID, Source: t.Source})
+			tags = append(tags, model.ApplicationTag{TagID: t.ID, ApplicationID: id, Source: t.Source})
 		}
 		result = h.DB.Create(&tags)
 		if result.Error != nil {

--- a/api/base.go
+++ b/api/base.go
@@ -147,6 +147,8 @@ func (h *BaseHandler) fields(m interface{}) (mp map[string]interface{}) {
 				if ft.Anonymous {
 					inspect(fv.Addr().Interface())
 				}
+			case reflect.Array, reflect.Slice:
+				continue
 			default:
 				mp[ft.Name] = fv.Interface()
 			}

--- a/api/businessservice.go
+++ b/api/businessservice.go
@@ -154,7 +154,7 @@ func (h BusinessServiceHandler) Update(ctx *gin.Context) {
 	m := r.Model()
 	m.ID = id
 	m.UpdateUser = h.BaseHandler.CurrentUser(ctx)
-	db := h.DB.Model(m)
+	db := h.DB.Model(&model.BusinessService{Model: model.Model{ID: id}})
 	db = db.Omit(clause.Associations)
 	result := db.Updates(h.fields(m))
 	if result.Error != nil {

--- a/api/group.go
+++ b/api/group.go
@@ -154,14 +154,15 @@ func (h StakeholderGroupHandler) Update(ctx *gin.Context) {
 	m := r.Model()
 	m.ID = id
 	m.UpdateUser = h.BaseHandler.CurrentUser(ctx)
-	db := h.DB.Model(m)
+	g := &model.StakeholderGroup{Model: model.Model{ID: id}}
+	db := h.DB.Model(g)
 	db = db.Omit(clause.Associations)
 	result := db.Updates(h.fields(m))
 	if result.Error != nil {
 		h.reportError(ctx, result.Error)
 		return
 	}
-	db = h.DB.Model(m)
+	db = h.DB.Model(g)
 	err = db.Association("Stakeholders").Replace(m.Stakeholders)
 	if err != nil {
 		h.reportError(ctx, err)

--- a/api/identity.go
+++ b/api/identity.go
@@ -202,7 +202,7 @@ func (h IdentityHandler) Update(ctx *gin.Context) {
 	}
 	m.ID = id
 	m.UpdateUser = h.BaseHandler.CurrentUser(ctx)
-	db := h.DB.Model(m)
+	db := h.DB.Model(&model.Identity{Model: model.Model{ID: id}})
 	err = db.Updates(h.fields(m)).Error
 	if err != nil {
 		h.reportError(ctx, err)

--- a/api/jobfunction.go
+++ b/api/jobfunction.go
@@ -154,7 +154,7 @@ func (h JobFunctionHandler) Update(ctx *gin.Context) {
 	m := r.Model()
 	m.ID = id
 	m.UpdateUser = h.BaseHandler.CurrentUser(ctx)
-	db := h.DB.Model(m)
+	db := h.DB.Model(&model.JobFunction{Model: model.Model{ID: id}})
 	db = db.Omit(clause.Associations)
 	result := db.Updates(h.fields(m))
 	if result.Error != nil {

--- a/api/proxy.go
+++ b/api/proxy.go
@@ -160,7 +160,7 @@ func (h ProxyHandler) Update(ctx *gin.Context) {
 	m := r.Model()
 	m.ID = id
 	m.UpdateUser = h.BaseHandler.CurrentUser(ctx)
-	db := h.DB.Model(m)
+	db := h.DB.Model(&model.Proxy{Model: model.Model{ID: id}})
 	db = db.Omit(clause.Associations)
 	result := db.Updates(h.fields(m))
 	if result.Error != nil {

--- a/api/review.go
+++ b/api/review.go
@@ -155,7 +155,7 @@ func (h ReviewHandler) Update(ctx *gin.Context) {
 	m := r.Model()
 	m.ID = id
 	m.UpdateUser = h.BaseHandler.CurrentUser(ctx)
-	db := h.DB.Model(m)
+	db := h.DB.Model(&model.Review{Model: model.Model{ID: id}})
 	db.Omit(clause.Associations)
 	result := db.Updates(h.fields(m))
 	if result.Error != nil {

--- a/api/rulebundle.go
+++ b/api/rulebundle.go
@@ -187,14 +187,15 @@ func (h RuleBundleHandler) Update(ctx *gin.Context) {
 	m = r.Model()
 	m.ID = id
 	m.UpdateUser = h.BaseHandler.CurrentUser(ctx)
-	db = h.DB.Model(m)
+	rb := &model.RuleBundle{Model: model.Model{ID: id}}
+	db = h.DB.Model(rb)
 	db = db.Omit(clause.Associations)
 	result = db.Updates(h.fields(m))
 	if result.Error != nil {
 		h.reportError(ctx, result.Error)
 		return
 	}
-	err = h.DB.Model(m).Association("RuleSets").Replace(m.RuleSets)
+	err = h.DB.Model(rb).Association("RuleSets").Replace(m.RuleSets)
 	if err != nil {
 		h.reportError(ctx, err)
 		return
@@ -203,7 +204,7 @@ func (h RuleBundleHandler) Update(ctx *gin.Context) {
 	// Update ruleSets.
 	for i := range m.RuleSets {
 		m := &m.RuleSets[i]
-		db = h.DB.Model(m)
+		db = h.DB.Model(&model.RuleSet{Model: model.Model{ID: m.ID}})
 		err = db.Updates(h.fields(m)).Error
 		if err != nil {
 			h.reportError(ctx, err)

--- a/api/stakeholder.go
+++ b/api/stakeholder.go
@@ -154,14 +154,15 @@ func (h StakeholderHandler) Update(ctx *gin.Context) {
 	m := r.Model()
 	m.ID = id
 	m.UpdateUser = h.BaseHandler.CurrentUser(ctx)
-	db := h.DB.Model(m)
+	s := &model.Stakeholder{Model: model.Model{ID: id}}
+	db := h.DB.Model(s)
 	db = db.Omit(clause.Associations)
 	result := db.Updates(h.fields(m))
 	if result.Error != nil {
 		h.reportError(ctx, result.Error)
 		return
 	}
-	db = h.DB.Model(m)
+	db = h.DB.Model(s)
 	err = db.Association("Groups").Replace(m.Groups)
 	if err != nil {
 		h.reportError(ctx, err)

--- a/api/tag.go
+++ b/api/tag.go
@@ -154,7 +154,7 @@ func (h TagHandler) Update(ctx *gin.Context) {
 	m := r.Model()
 	m.ID = id
 	m.UpdateUser = h.BaseHandler.CurrentUser(ctx)
-	db := h.DB.Model(m)
+	db := h.DB.Model(&model.Tag{Model: model.Model{ID: id}})
 	db = db.Omit(clause.Associations)
 	result := db.Updates(h.fields(m))
 	if result.Error != nil {

--- a/api/tagcategory.go
+++ b/api/tagcategory.go
@@ -154,7 +154,7 @@ func (h TagCategoryHandler) Update(ctx *gin.Context) {
 	m := r.Model()
 	m.ID = id
 	m.UpdateUser = h.BaseHandler.CurrentUser(ctx)
-	db := h.DB.Model(m)
+	db := h.DB.Model(&model.TagCategory{Model: model.Model{ID: id}})
 	db = db.Omit(clause.Associations)
 	result := db.Updates(h.fields(m))
 	if result.Error != nil {

--- a/api/tracker.go
+++ b/api/tracker.go
@@ -172,7 +172,7 @@ func (h TrackerHandler) Update(ctx *gin.Context) {
 	m := r.Model()
 	m.ID = id
 	m.UpdateUser = h.BaseHandler.CurrentUser(ctx)
-	db := h.DB.Model(m)
+	db := h.DB.Model(&model.Tracker{Model: model.Model{ID: id}})
 	db = db.Omit(clause.Associations)
 	result := db.Updates(h.fields(m))
 	if result.Error != nil {


### PR DESCRIPTION
* Excludes slices and arrays from `BaseHandler.fields`
* Replaces the use of full models in `db.Model(m)` calls with a model containing only the primary key.

It appears that GORM requires that the model that is passed to `db.Model()` be empty (if using a where clause) or have only a primary key set. Using a fully populated model in calls to `db.Model(m)` results in the fields set on that model getting merged with whatever was provided in the `Update` or association-mode methods. `Omit()` also does not appear to work properly with associations, so we need to be careful about ensuring they are excluded from calls to `Update`.