### PR TITLE
:bug: Limit Multi-Arch Build Concurrency

### DIFF
--- a/.github/workflows/march-image-build-push.yml
+++ b/.github/workflows/march-image-build-push.yml
@@ -9,6 +9,10 @@ on:
     tags:
       - 'v*'
 
+concurrency:
+  group: march-build-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   push-quay:
     name: Build and Push Manifest


### PR DESCRIPTION
Multiple rapid merges can result in more than one build being triggered and there is no guarantee which will finish first. Yesterday we saw two image builds complete at nearly the same time with UI leading to uncertainty as to whether the latest image reflected the latest merge.