### PR TITLE
:bug: Fix issues with updating models that have associations

### DIFF
--- a/api/application.go
+++ b/api/application.go
@@ -283,8 +283,7 @@ func (h ApplicationHandler) Update(ctx *gin.Context) {
 	m.ID = id
 	m.UpdateUser = h.BaseHandler.CurrentUser(ctx)
 	db = h.DB.Model(m)
-	db = db.Omit(clause.Associations)
-	db = db.Omit("BucketID")
+	db = db.Omit(clause.Associations, "BucketID")
 	result = db.Updates(h.fields(m))
 	if result.Error != nil {
 		h.reportError(ctx, result.Error)

--- a/api/task.go
+++ b/api/task.go
@@ -473,8 +473,7 @@ func (h TaskHandler) DeleteReport(ctx *gin.Context) {
 //   - Create
 //   - Update.
 func (h *TaskHandler) omitted(db *gorm.DB) (out *gorm.DB) {
-	out = db
-	for _, f := range []string{
+	out = db.Omit([]string{
 		"BucketID",
 		"Bucket",
 		"Image",
@@ -484,9 +483,7 @@ func (h *TaskHandler) omitted(db *gorm.DB) (out *gorm.DB) {
 		"Canceled",
 		"Error",
 		"Retries",
-	} {
-		out = out.Omit(f)
-	}
+	}...)
 	return
 }
 

--- a/api/taskgroup.go
+++ b/api/taskgroup.go
@@ -172,9 +172,11 @@ func (h TaskGroupHandler) Update(ctx *gin.Context) {
 	m.ID = current.ID
 	m.UpdateUser = h.BaseHandler.CurrentUser(ctx)
 	db := h.DB.Model(m)
+
+	omit := []string{"BucketID", "Bucket"}
 	switch updated.State {
 	case "", tasking.Created:
-		db = db.Omit(clause.Associations)
+		omit = append(omit, clause.Associations)
 	case tasking.Ready:
 		err := m.Propagate()
 		if err != nil {
@@ -188,8 +190,7 @@ func (h TaskGroupHandler) Update(ctx *gin.Context) {
 			})
 		return
 	}
-	db = db.Omit("BucketID")
-	db = db.Omit("Bucket")
+	db = db.Omit(omit...)
 	db = db.Where("state IN ?", []string{"", tasking.Created})
 	err = db.Updates(h.fields(m)).Error
 	if err != nil {


### PR DESCRIPTION
Only the last call to `Omit` is honored when building a query, so change all multiple uses to a single use with multiple parameters.

Also, exclude more fields from `BaseHandler.fields`, which is used when determining which fields to updaate:
* Pointers to struct
* Arrays and slices
* Pointers to arrays and slices