### PR TITLE
:ghost: Disable redundant post merge build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,6 @@
 name: Build Hub
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
     paths-ignore:


### PR DESCRIPTION
The purpose of this action is to test builds before merge. Multi-Arch builds take a long time, so we do a quicker amd64 build to catch pretty much anything but extreme corner cases and emulation bugs.

The multi-arch build runs to build and push images after merge so running this is unnecessary and probably confusing.