### PR TITLE
:bug: Fix PUT settings not updating the value.

### DIFF
--- a/api/base.go
+++ b/api/base.go
@@ -140,7 +140,7 @@ func (h *BaseHandler) fields(m interface{}) (mp map[string]interface{}) {
 				continue
 			}
 			switch fv.Kind() {
-			case reflect.Pointer:
+			case reflect.Ptr:
 				pt := ft.Type.Elem()
 				switch pt.Kind() {
 				case reflect.Struct, reflect.Slice, reflect.Array:
@@ -152,8 +152,14 @@ func (h *BaseHandler) fields(m interface{}) (mp map[string]interface{}) {
 				if ft.Anonymous {
 					inspect(fv.Addr().Interface())
 				}
-			case reflect.Array, reflect.Slice:
+			case reflect.Array:
 				continue
+			case reflect.Slice:
+				inst := fv.Interface()
+				switch inst.(type) {
+				case []byte:
+					mp[ft.Name] = fv.Interface()
+				}
 			default:
 				mp[ft.Name] = fv.Interface()
 			}


### PR DESCRIPTION
Fix BaseHandler.fields() not including json fields []byte.
Fixes PUT on:
- tasks, taskgroups
- applications (facts & repository)
- applications/facts
- settings

Fixes docker build.  The reflect.Ptr was renamed to reflect.Pointer in 1.18. The dockerfile includes [go-toolset:latest](https://catalog.redhat.com/software/containers/ubi9/go-toolset/5ce8713aac3db925c03774d1?container-tabs=overview) which includes 1.18.9. The patch to use (deprecated) reflect.Ptr should not be necessary.  But, the docker build fails without it.

```
# github.com/konveyor/tackle2-hub/api
api/base.go:143:9: undefined: reflect.Pointer
make: *** [Makefile:30: vet] Error 2

```

Regression introduced in pull/255 [here](https://github.com/konveyor/tackle2-hub/pull/255/files#diff-b3ac3832e61047a1ffffe16d97019d06999f7c9653bc29f35212efbe18f88210R155).