### PR TITLE
:bug: Don't omit BucketID when creating tasks

### DIFF
--- a/api/task.go
+++ b/api/task.go
@@ -149,8 +149,7 @@ func (h TaskHandler) Create(ctx *gin.Context) {
 	}
 	m := r.Model()
 	m.CreateUser = h.BaseHandler.CurrentUser(ctx)
-	db := h.omitted(h.DB)
-	result := db.Create(&m)
+	result := h.DB.Create(&m)
 	if result.Error != nil {
 		h.reportError(ctx, result.Error)
 		return
@@ -559,7 +558,6 @@ func (r *Task) Model() (m *model.Task) {
 		Priority:      r.Priority,
 		Policy:        r.Policy,
 		State:         r.State,
-		Retries:       r.Retries,
 		ApplicationID: r.idPtr(r.Application),
 	}
 	m.Data, _ = json.Marshal(r.Data)


### PR DESCRIPTION
Don't use `TaskHandler.omitted()` when creating a Task through the API. Doing so was causing the `BucketID` that was being set by the `BeforeCreate` hook to not be persisted on the new Task row in the database. (The in-memory ID for the orphaned bucket was being returned in the response to the `POST`, but subsequent `GET`s would not not include it and the bucket would be reaped.)

`omitted()` is to ensure that fields that are not allowed to be updated through the API (and are thus not propagated from the resource to the model) are not zeroed out when the task is updated.