### PR TITLE
:ghost: Skip Pathfinder calls when disconnected

### DIFF
--- a/api/application.go
+++ b/api/application.go
@@ -200,7 +200,6 @@ func (h ApplicationHandler) Delete(ctx *gin.Context) {
 		_ = ctx.Error(err)
 		return
 	}
-
 	result = h.DB(ctx).Delete(m)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)


### PR DESCRIPTION
Updating application delete action that calls Pathfinder API to not do that when running as Disconnected (e.g. for fast API tests).

Otherwise gets ```$ curl -X DELETE http://localhost:8080/applications/1
{"error":"Delete \"/pathfinder/assessments/bulkDelete\": unsupported protocol scheme \"\""}```

Follow-up on https://github.com/konveyor/tackle2-hub/pull/242