### PR TITLE
:ghost: auth.Validator must use DB passed in the gin context.

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -71,6 +71,7 @@ func Required(scope string) func(*gin.Context) {
 			Token:  token,
 			Scope:  scope,
 			Method: ctx.Request.Method,
+			DB:     rtx.DB,
 		}
 		result, err := request.Permit()
 		if err != nil {

--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -11,7 +11,7 @@ type _TestProvider struct {
 	NoAuth
 }
 
-func (p *_TestProvider) Authenticate(token string) (jwToken *jwt.Token, err error) {
+func (p *_TestProvider) Authenticate(_ *Request) (jwToken *jwt.Token, err error) {
 	err = p.err
 	return
 }
@@ -32,7 +32,7 @@ func TestValid(t *testing.T) {
 	g.Expect(len(signed) > 0).To(gomega.BeTrue())
 	//
 	// Authenticate
-	jwToken, err := p.Authenticate(signed)
+	jwToken, err := p.Authenticate(&Request{Token: signed})
 	g.Expect(err).To(gomega.BeNil())
 	g.Expect(jwToken != nil).To(gomega.BeTrue())
 	//
@@ -66,13 +66,13 @@ func TestNotValid(t *testing.T) {
 	g.Expect(len(signed) > 0).To(gomega.BeTrue())
 	//
 	// Valid
-	jwToken, err := p.Authenticate(signed)
+	jwToken, err := p.Authenticate(&Request{Token: signed})
 	g.Expect(err).To(gomega.BeNil())
 	g.Expect(jwToken != nil).To(gomega.BeTrue())
 	//
 	// Not valid.
 	Settings.Auth.Token.Key = "NotMyKey"
-	jwToken, err = p.Authenticate(signed)
+	jwToken, err = p.Authenticate(&Request{Token: signed})
 	g.Expect(err != nil).To(gomega.BeTrue())
 }
 

--- a/auth/keycloak.go
+++ b/auth/keycloak.go
@@ -55,9 +55,10 @@ func (r *Keycloak) Login(user, password string) (token string, err error) {
 
 //
 // Authenticate the token
-func (r *Keycloak) Authenticate(token string) (jwToken *jwt.Token, err error) {
+func (r *Keycloak) Authenticate(request *Request) (jwToken *jwt.Token, err error) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*30)
 	defer cancel()
+	token := request.Token
 	jwToken, _, err = r.client.DecodeAccessToken(ctx, token, r.realm)
 	if err != nil || !jwToken.Valid {
 		err = liberr.Wrap(&NotAuthenticated{Token: token})

--- a/auth/provider.go
+++ b/auth/provider.go
@@ -27,7 +27,7 @@ type Provider interface {
 	// NewToken creates a signed token.
 	NewToken(user string, scopes []string, claims jwt.MapClaims) (signed string, err error)
 	// Authenticate authenticates and validates the token.
-	Authenticate(token string) (jwToken *jwt.Token, err error)
+	Authenticate(r *Request) (jwToken *jwt.Token, err error)
 	// Scopes extracts a list of scopes from the token.
 	Scopes(jwToken *jwt.Token) []Scope
 	// User extracts the user from token.

--- a/auth/request.go
+++ b/auth/request.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"errors"
 	"github.com/golang-jwt/jwt/v4"
+	"gorm.io/gorm"
 )
 
 //
@@ -11,6 +12,7 @@ type Request struct {
 	Token  string
 	Scope  string
 	Method string
+	DB     *gorm.DB
 }
 
 //
@@ -22,7 +24,7 @@ func (r *Request) Permit() (result Result, err error) {
 	)
 	for _, p = range []Provider{Hub, Remote} {
 		var pErr error
-		jwToken, pErr = p.Authenticate(r.Token)
+		jwToken, pErr = p.Authenticate(r)
 		if pErr == nil {
 			result.Authenticated = true
 			break

--- a/task/auth.go
+++ b/task/auth.go
@@ -15,8 +15,6 @@ import (
 type Validator struct {
 	// k8s client.
 	Client k8s.Client
-	// DB client.
-	DB *gorm.DB
 }
 
 //
@@ -24,7 +22,7 @@ type Validator struct {
 //  - The token references a task.
 //  - The task is valid and running.
 //  - The task pod valid and pending|running.
-func (r *Validator) Valid(token *jwt.Token) (valid bool) {
+func (r *Validator) Valid(token *jwt.Token, db *gorm.DB) (valid bool) {
 	var err error
 	claims := token.Claims.(jwt.MapClaims)
 	v, found := claims["task"]
@@ -34,7 +32,7 @@ func (r *Validator) Valid(token *jwt.Token) (valid bool) {
 		return
 	}
 	task := &model.Task{}
-	err = r.DB.First(task, id).Error
+	err = db.First(task, id).Error
 	if err != nil {
 		Log.Info("Task referenced by token: not found.")
 		return

--- a/task/manager.go
+++ b/task/manager.go
@@ -83,7 +83,6 @@ func (m *Manager) Run(ctx context.Context) {
 		auth.Validators,
 		&Validator{
 			Client: m.Client,
-			DB:     m.DB,
 		})
 	go func() {
 		Log.Info("Started.")


### PR DESCRIPTION
The auth.Request enhanced to include a `*gom.DB` to ensure the `auth` package uses the DB (or Tx) passed in the gin context instead of the global (main) DB client.  This protects against deadlock caused when the global (main) DB client is used after a transaction has started.