### PR TITLE
:bug: Adjusted addon binding retry.

### DIFF
--- a/addon/adapter.go
+++ b/addon/adapter.go
@@ -80,7 +80,9 @@ func (h *Adapter) Run(addon func() error) {
 			if _, soft := err.(interface{ Soft() *SoftError }); !soft {
 				Log.Error(err, "Addon failed.")
 			}
-			h.Failed(err.Error())
+			if h.client.Error == nil {
+				h.Failed(err.Error())
+			}
 			os.Exit(1)
 		}
 	}()
@@ -109,10 +111,7 @@ func (h *Adapter) Client() *Client {
 func newAdapter() (adapter *Adapter) {
 	//
 	// Build REST client.
-	client := &Client{
-		baseURL: Settings.Addon.Hub.URL,
-		token:   Settings.Addon.Hub.Token,
-	}
+	client := NewClient(Settings.Addon.Hub.URL, Settings.Addon.Hub.Token)
 	//
 	// Build Adapter.
 	adapter = &Adapter{


### PR DESCRIPTION
PROBLEM:

The addon (binding) is designed to detect and deal with temporary hub unavailability. The primary use case is a hub pod restart. It is intended to retry requests for 10 min.  In reality, this ends up being 20 min (2 x 10).  This is because in the adapter Run(), a caught error/panic is reported to the hub which results in entering the retry logic a 2nd time.

SOLUTION:

Maintain the error state on the client so subsequent requests will fail immediately.


