### PR TITLE
:bug: Add Auth Require to Import API

### DIFF
--- a/api/import.go
+++ b/api/import.go
@@ -46,6 +46,7 @@ type ImportHandler struct {
 //
 // AddRoutes adds routes.
 func (h ImportHandler) AddRoutes(e *gin.Engine) {
+	e.Use(Required("imports"), Transaction)
 	e.GET(SummariesRoot, h.ListSummaries)
 	e.GET(SummariesRoot+"/", h.ListSummaries)
 	e.GET(SummaryRoot, h.GetSummary)

--- a/api/import.go
+++ b/api/import.go
@@ -47,7 +47,7 @@ type ImportHandler struct {
 // AddRoutes adds routes.
 func (h ImportHandler) AddRoutes(e *gin.Engine) {
 	routeGroup := e.Group("/")
-	routeGroup.Use(Required("imports"), Transaction)
+	routeGroup.Use(Required("applications"))
 	routeGroup.GET(SummariesRoot, h.ListSummaries)
 	routeGroup.GET(SummariesRoot+"/", h.ListSummaries)
 	routeGroup.GET(SummaryRoot, h.GetSummary)

--- a/api/import.go
+++ b/api/import.go
@@ -46,17 +46,18 @@ type ImportHandler struct {
 //
 // AddRoutes adds routes.
 func (h ImportHandler) AddRoutes(e *gin.Engine) {
-	e.Use(Required("imports"), Transaction)
-	e.GET(SummariesRoot, h.ListSummaries)
-	e.GET(SummariesRoot+"/", h.ListSummaries)
-	e.GET(SummaryRoot, h.GetSummary)
-	e.DELETE(SummaryRoot, h.DeleteSummary)
-	e.GET(ImportsRoot, h.ListImports)
-	e.GET(ImportsRoot+"/", h.ListImports)
-	e.GET(ImportRoot, h.GetImport)
-	e.DELETE(ImportRoot, h.DeleteImport)
-	e.GET(DownloadRoot, h.DownloadCSV)
-	e.POST(UploadRoot, h.UploadCSV)
+	routeGroup := e.Group("/")
+	routeGroup.Use(Required("imports"), Transaction)
+	routeGroup.GET(SummariesRoot, h.ListSummaries)
+	routeGroup.GET(SummariesRoot+"/", h.ListSummaries)
+	routeGroup.GET(SummaryRoot, h.GetSummary)
+	routeGroup.DELETE(SummaryRoot, h.DeleteSummary)
+	routeGroup.GET(ImportsRoot, h.ListImports)
+	routeGroup.GET(ImportsRoot+"/", h.ListImports)
+	routeGroup.GET(ImportRoot, h.GetImport)
+	routeGroup.DELETE(ImportRoot, h.DeleteImport)
+	routeGroup.GET(DownloadRoot, h.DownloadCSV)
+	routeGroup.POST(UploadRoot, h.UploadCSV)
 }
 
 //

--- a/api/import.go
+++ b/api/import.go
@@ -47,7 +47,7 @@ type ImportHandler struct {
 // AddRoutes adds routes.
 func (h ImportHandler) AddRoutes(e *gin.Engine) {
 	routeGroup := e.Group("/")
-	routeGroup.Use(Required("applications"))
+	routeGroup.Use(Required("imports"))
 	routeGroup.GET(SummariesRoot, h.ListSummaries)
 	routeGroup.GET(SummariesRoot+"/", h.ListSummaries)
 	routeGroup.GET(SummaryRoot, h.GetSummary)


### PR DESCRIPTION
CreateUser field was empty for ImportSummaries, it turned out that there is missing Auth middleware for Import-related API endpoints.

Adding the Required("imports") middleware to the Imports endpoint.

API returns non-empty user field now:
```
$ curl -F "file=@import.csv" http://localhost:8080/importsummaries/upload
{"id":16,"createUser":"admin.noauth","updateUser":"","createTime":"2023-04-04T18:46:45.588499423+02:00","filename":"","importStatus":"Completed","importTime":"2023-04-04T18:46:45.588499423+02:00","validCount":0,"invalidCount":0,"createEntities":true}
```

Fixes: https://issues.redhat.com/browse/MTA-129