### PR TITLE
Extend api.Addon to includes entire specification.

### DIFF
--- a/addon/task.go
+++ b/addon/task.go
@@ -34,6 +34,18 @@ func (h *Task) Load() {
 }
 
 //
+// Addon returns the addon referenced by the task.
+func (h *Task) Addon() (r *api.Addon) {
+	r = &api.Addon{}
+	path := Path(api.AddonRoot).Inject(Params{api.Name: h.task.Addon})
+	err := h.client.Get(path, r)
+	if err != nil {
+		panic(err)
+	}
+	return
+}
+
+//
 // Application returns the application associated with the task.
 func (h *Task) Application() (r *api.Application, err error) {
 	appRef := h.task.Application

--- a/api/addon.go
+++ b/api/addon.go
@@ -97,13 +97,24 @@ func (h AddonHandler) List(ctx *gin.Context) {
 //
 // Addon REST resource.
 type Addon struct {
-	Name  string `json:"name"`
-	Image string `json:"image"`
+	crd.AddonSpec
+	Name string `json:"name"`
 }
 
 //
 // With model.
 func (r *Addon) With(m *crd.Addon) {
+	r.AddonSpec = m.Spec
 	r.Name = m.Name
-	r.Image = m.Spec.Image
+}
+
+//
+// MaxMemory returns max memory (0=unlimited).
+func (r *Addon) MaxMemory() (n int64) {
+	if r.Resources.Limits == nil || r.Resources.Limits.Memory() == nil {
+		return
+	}
+	q := r.Resources.Limits.Memory()
+	n, _ = q.AsInt64()
+	return
 }


### PR DESCRIPTION
Extend api.Addon to include entire specification. 
Extend the `Task` in the addon binding to provide a method to fetch the `Addon` referenced by the task.
This is generally more complete and helpful for addons to limit memory usage.

Example usage for windup:
```
n := addon.Addon().MaxMemory()
if n > 0 {
	_ = os.Setenv(
        "MAX_MEMORY",
        strconv.FormatInt(n/2, 10))
}
```

Example:
```
[
  {
    "image": "quay.io/jortel/tackle2-addon:latest",
    "imagePullPolicy": "IfNotPresent",
    "resources": {},
    "name": "test"
  },
  {
    "image": "quay.io/jortel/tackle2-addon-windup:latest",
    "imagePullPolicy": "Always",
    "resources": {
      "limits": {
        "cpu": "1",
        "memory": "6Gi"
      },
      "requests": {
        "cpu": "1",
        "memory": "4Gi"
      }
    },
    "name": "windup"
```