### PR TITLE
:bug: [6.1 only] Fix Auth Required import

### DIFF
--- a/api/import.go
+++ b/api/import.go
@@ -47,7 +47,7 @@ type ImportHandler struct {
 // AddRoutes adds routes.
 func (h ImportHandler) AddRoutes(e *gin.Engine) {
 	routeGroup := e.Group("/")
-	routeGroup.Use(Required("imports"))
+	routeGroup.Use(auth.Required("imports"))
 	routeGroup.GET(SummariesRoot, h.ListSummaries)
 	routeGroup.GET(SummariesRoot+"/", h.ListSummaries)
 	routeGroup.GET(SummaryRoot, h.GetSummary)

--- a/api/import.go
+++ b/api/import.go
@@ -5,6 +5,7 @@ import (
 	"encoding/csv"
 	"fmt"
 	"github.com/gin-gonic/gin"
+	"github.com/konveyor/tackle2-hub/auth"
 	"github.com/konveyor/tackle2-hub/model"
 	"io"
 	"net/http"


### PR DESCRIPTION
Fix for 6.1 Auth Require in Imports. Not needed in main, needed in 6.1 only.

Tested locally and runs on mta-6.1 now.

Related to: https://github.com/konveyor/tackle2-hub/pull/286 and https://github.com/konveyor/tackle2-hub/pull/283