### PR TITLE
:sparkles: Add support: pagination, sorting, YAML bindings.

### DIFF
--- a/addon/client.go
+++ b/addon/client.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/gin-gonic/gin/binding"
 	liberr "github.com/konveyor/controller/pkg/error"
 	"github.com/konveyor/tackle2-hub/api"
 	"io"
@@ -20,12 +21,6 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
-)
-
-const (
-	Accept   = api.Accept
-	AppJson  = api.AppJson
-	AppOctet = api.AppOctet
 )
 
 const (
@@ -112,7 +107,7 @@ func (r *Client) Get(path string, object interface{}, params ...Param) (err erro
 			Method: http.MethodGet,
 			URL:    r.join(path),
 		}
-		request.Header.Set(Accept, AppJson)
+		request.Header.Set(api.Accept, binding.MIMEJSON)
 		if len(params) > 0 {
 			q := request.URL.Query()
 			for _, p := range params {
@@ -168,7 +163,7 @@ func (r *Client) Post(path string, object interface{}) (err error) {
 			Body:   io.NopCloser(reader),
 			URL:    r.join(path),
 		}
-		request.Header.Set(Accept, AppJson)
+		request.Header.Set(api.Accept, binding.MIMEJSON)
 		return
 	}
 	reply, err := r.send(request)
@@ -215,7 +210,7 @@ func (r *Client) Put(path string, object interface{}, params ...Param) (err erro
 			Body:   io.NopCloser(reader),
 			URL:    r.join(path),
 		}
-		request.Header.Set(Accept, AppJson)
+		request.Header.Set(api.Accept, binding.MIMEJSON)
 		if len(params) > 0 {
 			q := request.URL.Query()
 			for _, p := range params {
@@ -263,7 +258,7 @@ func (r *Client) Delete(path string, params ...Param) (err error) {
 			Method: http.MethodDelete,
 			URL:    r.join(path),
 		}
-		request.Header.Set(Accept, "")
+		request.Header.Set(api.Accept, binding.MIMEJSON)
 		if len(params) > 0 {
 			q := request.URL.Query()
 			for _, p := range params {
@@ -303,7 +298,7 @@ func (r *Client) BucketGet(source, destination string) (err error) {
 			Method: http.MethodGet,
 			URL:    r.join(source),
 		}
-		request.Header.Set(Accept, AppOctet)
+		request.Header.Set(api.Accept, api.MIMEOCTETSTREAM)
 		return
 	}
 	reply, err := r.send(request)
@@ -347,7 +342,7 @@ func (r *Client) BucketPut(source, destination string) (err error) {
 			Body:   io.NopCloser(buf),
 			URL:    r.join(destination),
 		}
-		request.Header.Set(Accept, AppOctet)
+		request.Header.Set(api.Accept, api.MIMEOCTETSTREAM)
 		writer := multipart.NewWriter(buf)
 		defer func() {
 			_ = writer.Close()
@@ -395,7 +390,7 @@ func (r *Client) FileGet(path, destination string) (err error) {
 			Method: http.MethodGet,
 			URL:    r.join(path),
 		}
-		request.Header.Set(Accept, AppOctet)
+		request.Header.Set(api.Accept, api.MIMEOCTETSTREAM)
 		return
 	}
 	reply, err := r.send(request)
@@ -439,7 +434,7 @@ func (r *Client) FilePut(path, source string, object interface{}) (err error) {
 			Body:   io.NopCloser(buf),
 			URL:    r.join(path),
 		}
-		request.Header.Set(Accept, AppJson)
+		request.Header.Set(api.Accept, binding.MIMEJSON)
 		writer := multipart.NewWriter(buf)
 		defer func() {
 			_ = writer.Close()

--- a/api/addon.go
+++ b/api/addon.go
@@ -62,7 +62,7 @@ func (h AddonHandler) Get(ctx *gin.Context) {
 	r := Addon{}
 	r.With(addon)
 
-	ctx.JSON(http.StatusOK, r)
+	h.Render(ctx, http.StatusOK, r)
 }
 
 // List godoc
@@ -91,7 +91,7 @@ func (h AddonHandler) List(ctx *gin.Context) {
 		content = append(content, addon)
 	}
 
-	ctx.JSON(http.StatusOK, content)
+	h.Render(ctx, http.StatusOK, content)
 }
 
 //

--- a/api/adoptionplan.go
+++ b/api/adoptionplan.go
@@ -50,7 +50,7 @@ func (h AdoptionPlanHandler) Graph(ctx *gin.Context) {
 		ApplicationID uint `json:"applicationId"`
 	}
 
-	err := ctx.BindJSON(&requestedApps)
+	err := h.Bind(ctx, &requestedApps)
 	if err != nil {
 		_ = ctx.Error(err)
 	}
@@ -99,7 +99,7 @@ func (h AdoptionPlanHandler) Graph(ctx *gin.Context) {
 
 	sorted, ok := graph.TopologicalSort()
 	if !ok {
-		ctx.JSON(
+		h.Render(ctx,
 			http.StatusBadRequest,
 			gin.H{
 				"error": "dependency cycle detected",
@@ -107,7 +107,7 @@ func (h AdoptionPlanHandler) Graph(ctx *gin.Context) {
 		return
 	}
 
-	ctx.JSON(http.StatusOK, sorted)
+	h.Render(ctx, http.StatusOK, sorted)
 }
 
 //

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/onsi/gomega"
+	"net/http"
+	"testing"
+)
+
+func TestAccepted(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	h := BaseHandler{}
+	ctx := &gin.Context{
+		Request: &http.Request{
+			Header: http.Header{},
+		},
+	}
+	// plain
+	ctx.Request.Header[Accept] = []string{"a/b"}
+	g.Expect(h.Accepted(ctx, "a/b")).To(gomega.BeTrue())
+	ctx.Request.Header[Accept] = []string{"a/b"}
+	g.Expect(h.Accepted(ctx, "x/y")).To(gomega.BeFalse())
+	// Empty.
+	ctx.Request.Header[Accept] = []string{""}
+	g.Expect(h.Accepted(ctx, "x/y")).To(gomega.BeFalse())
+	ctx.Request.Header[Accept] = []string{""}
+	g.Expect(h.Accepted(ctx, "")).To(gomega.BeFalse())
+	ctx.Request.Header[Accept] = []string{"a/b"}
+	g.Expect(h.Accepted(ctx, "")).To(gomega.BeFalse())
+	// Multiple with spaces.
+	ctx.Request.Header[Accept] = []string{"x/y, a/b, c/d"}
+	g.Expect(h.Accepted(ctx, "a/b")).To(gomega.BeTrue())
+	// Multiple and parameters.
+	ctx.Request.Header[Accept] = []string{"x/y,a/b;q=1.0"}
+	g.Expect(h.Accepted(ctx, "a/b")).To(gomega.BeTrue())
+	// wildcards
+	ctx.Request.Header[Accept] = []string{"*/b"}
+	g.Expect(h.Accepted(ctx, "a/b")).To(gomega.BeTrue())
+	ctx.Request.Header[Accept] = []string{"*/b"}
+	g.Expect(h.Accepted(ctx, "a/b")).To(gomega.BeTrue())
+	ctx.Request.Header[Accept] = []string{"*/*"}
+	g.Expect(h.Accepted(ctx, "a/b")).To(gomega.BeTrue())
+}
+
+func TestAcceptedAny(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	h := BaseHandler{}
+	ctx := &gin.Context{
+		Request: &http.Request{
+			Header: http.Header{},
+		},
+	}
+	ctx.Request.Header[Accept] = []string{"a/b"}
+	g.Expect(h.Accepted(ctx, "a/b", "c/d")).To(gomega.BeTrue())
+	ctx.Request.Header[Accept] = []string{"a/b,c/d"}
+	g.Expect(h.Accepted(ctx, "a/b", "c/d")).To(gomega.BeTrue())
+	ctx.Request.Header[Accept] = []string{"a/b,c/d"}
+	g.Expect(h.Accepted(ctx, "e/f", "x/y")).To(gomega.BeFalse())
+}

--- a/api/application.go
+++ b/api/application.go
@@ -108,7 +108,7 @@ func (h ApplicationHandler) Get(ctx *gin.Context) {
 	r := Application{}
 	r.With(m, tags)
 
-	ctx.JSON(http.StatusOK, r)
+	h.Render(ctx, http.StatusOK, r)
 }
 
 // List godoc
@@ -141,7 +141,7 @@ func (h ApplicationHandler) List(ctx *gin.Context) {
 		resources = append(resources, r)
 	}
 
-	ctx.JSON(http.StatusOK, resources)
+	h.Render(ctx, http.StatusOK, resources)
 }
 
 // Create godoc
@@ -155,7 +155,7 @@ func (h ApplicationHandler) List(ctx *gin.Context) {
 // @param application body api.Application true "Application data"
 func (h ApplicationHandler) Create(ctx *gin.Context) {
 	r := &Application{}
-	err := ctx.BindJSON(r)
+	err := h.Bind(ctx, r)
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -182,7 +182,7 @@ func (h ApplicationHandler) Create(ctx *gin.Context) {
 
 	r.With(m, tags)
 
-	ctx.JSON(http.StatusCreated, r)
+	h.Render(ctx, http.StatusCreated, r)
 }
 
 // Delete godoc
@@ -224,7 +224,7 @@ func (h ApplicationHandler) Delete(ctx *gin.Context) {
 // @param application body []uint true "List of id"
 func (h ApplicationHandler) DeleteList(ctx *gin.Context) {
 	ids := []uint{}
-	err := ctx.BindJSON(&ids)
+	err := h.Bind(ctx, &ids)
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -259,7 +259,7 @@ func (h ApplicationHandler) DeleteList(ctx *gin.Context) {
 func (h ApplicationHandler) Update(ctx *gin.Context) {
 	id := h.pk(ctx)
 	r := &Application{}
-	err := ctx.BindJSON(r)
+	err := h.Bind(ctx, r)
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -456,7 +456,7 @@ func (h ApplicationHandler) TagList(ctx *gin.Context) {
 		r.With(list[i].Tag.ID, list[i].Tag.Name, list[i].Source)
 		resources = append(resources, r)
 	}
-	ctx.JSON(http.StatusOK, resources)
+	h.Render(ctx, http.StatusOK, resources)
 }
 
 // TagAdd godoc
@@ -471,7 +471,7 @@ func (h ApplicationHandler) TagList(ctx *gin.Context) {
 func (h ApplicationHandler) TagAdd(ctx *gin.Context) {
 	id := h.pk(ctx)
 	ref := &TagRef{}
-	err := ctx.BindJSON(ref)
+	err := h.Bind(ctx, ref)
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -492,7 +492,7 @@ func (h ApplicationHandler) TagAdd(ctx *gin.Context) {
 		_ = ctx.Error(err)
 		return
 	}
-	ctx.JSON(http.StatusCreated, ref)
+	h.Render(ctx, http.StatusCreated, ref)
 }
 
 // TagReplace godoc
@@ -508,7 +508,7 @@ func (h ApplicationHandler) TagAdd(ctx *gin.Context) {
 func (h ApplicationHandler) TagReplace(ctx *gin.Context) {
 	id := h.pk(ctx)
 	refs := []TagRef{}
-	err := ctx.BindJSON(&refs)
+	err := h.Bind(ctx, &refs)
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -610,7 +610,7 @@ func (h ApplicationHandler) FactList(ctx *gin.Context) {
 		r.With(&list[i])
 		resources = append(resources, r)
 	}
-	ctx.JSON(http.StatusOK, resources)
+	h.Render(ctx, http.StatusOK, resources)
 }
 
 // FactGet godoc
@@ -643,7 +643,7 @@ func (h ApplicationHandler) FactGet(ctx *gin.Context) {
 	}
 	r := Fact{}
 	r.With(&list[0])
-	ctx.JSON(http.StatusOK, r)
+	h.Render(ctx, http.StatusOK, r)
 }
 
 // FactCreate godoc
@@ -660,7 +660,7 @@ func (h ApplicationHandler) FactGet(ctx *gin.Context) {
 func (h ApplicationHandler) FactCreate(ctx *gin.Context) {
 	id := h.pk(ctx)
 	var v interface{}
-	err := ctx.BindJSON(&v)
+	err := h.Bind(ctx, &v)
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -683,7 +683,7 @@ func (h ApplicationHandler) FactCreate(ctx *gin.Context) {
 	}
 	r := &Fact{}
 	r.With(m)
-	ctx.JSON(http.StatusCreated, r)
+	h.Render(ctx, http.StatusCreated, r)
 }
 
 // FactPut godoc
@@ -700,7 +700,7 @@ func (h ApplicationHandler) FactCreate(ctx *gin.Context) {
 func (h ApplicationHandler) FactPut(ctx *gin.Context) {
 	id := h.pk(ctx)
 	var v interface{}
-	err := ctx.BindJSON(&v)
+	err := h.Bind(ctx, &v)
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -786,7 +786,7 @@ func (h ApplicationHandler) StakeholdersUpdate(ctx *gin.Context) {
 	}
 
 	r := &Stakeholders{}
-	err := ctx.BindJSON(r)
+	err := h.Bind(ctx, r)
 	if err != nil {
 		_ = ctx.Error(err)
 		return

--- a/api/auth.go
+++ b/api/auth.go
@@ -34,14 +34,14 @@ func (h AuthHandler) AddRoutes(e *gin.Engine) {
 // @router /auth/login [post]
 func (h AuthHandler) Login(ctx *gin.Context) {
 	r := &Login{}
-	err := ctx.BindJSON(r)
+	err := h.Bind(ctx, r)
 	if err != nil {
 		_ = ctx.Error(err)
 		return
 	}
 	r.Token, err = auth.Remote.Login(r.User, r.Password)
 	if err != nil {
-		ctx.JSON(
+		h.Render(ctx,
 			http.StatusUnauthorized,
 			gin.H{
 				"error": err.Error(),
@@ -49,7 +49,7 @@ func (h AuthHandler) Login(ctx *gin.Context) {
 		return
 	}
 	r.Password = "" // Clear out password from response
-	ctx.JSON(http.StatusCreated, r)
+	h.Render(ctx, http.StatusCreated, r)
 }
 
 //

--- a/api/base.go
+++ b/api/base.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin/binding"
 	"github.com/konveyor/controller/pkg/logging"
 	"github.com/konveyor/tackle2-hub/auth"
 	"github.com/konveyor/tackle2-hub/model"
@@ -12,6 +13,7 @@ import (
 	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -34,7 +36,29 @@ func (h *BaseHandler) With(client client.Client) {
 // DB return db client associated with the context.
 func (h *BaseHandler) DB(ctx *gin.Context) (db *gorm.DB) {
 	rtx := WithContext(ctx)
-	db = rtx.DB
+	db = rtx.DB.Debug()
+	return
+}
+
+//
+// Paginated returns a paginated & sorted DB client.
+func (h *BaseHandler) Paginated(ctx *gin.Context) (db *gorm.DB) {
+	p := Page{}
+	p.With(ctx)
+	db = h.DB(ctx)
+	db = p.Paginated(db)
+	sort := Sort{}
+	sort.With(ctx)
+	db = sort.Sorted(db)
+	return
+}
+
+//
+// Sorted returns a sorted DB client.
+func (h *BaseHandler) Sorted(ctx *gin.Context) (db *gorm.DB) {
+	sort := Sort{}
+	sort.With(ctx)
+	db = sort.Sorted(h.DB(ctx))
 	return
 }
 
@@ -119,7 +143,7 @@ func (h *BaseHandler) modBody(
 	withBody := false
 	if ctx.Request.ContentLength > 0 {
 		withBody = true
-		err = ctx.BindJSON(r)
+		err = h.Bind(ctx, r)
 		if err != nil {
 			return
 		}
@@ -155,6 +179,66 @@ func (h *BaseHandler) HasScope(ctx *gin.Context, scope string) (b bool) {
 	for _, s := range rtx.Scopes {
 		b = s.Match(in.Resource, in.Method)
 		if b {
+			return
+		}
+	}
+	return
+}
+
+//
+// Bind based on Content-Type header.
+// Opinionated towards json.
+func (h *BaseHandler) Bind(ctx *gin.Context, r interface{}) (err error) {
+	switch ctx.ContentType() {
+	case "",
+		binding.MIMEPOSTForm,
+		binding.MIMEJSON:
+		err = ctx.BindJSON(r)
+	case binding.MIMEYAML:
+		err = ctx.BindYAML(r)
+	default:
+		err = &BadRequestError{"Bind: MIME not supported."}
+	}
+	if err != nil {
+		err = &BadRequestError{err.Error()}
+	}
+	return
+}
+
+//
+// Render renders based the Accept: header.
+// Opinionated towards json.
+func (h *BaseHandler) Render(ctx *gin.Context, code int, r interface{}) {
+	ctx.Negotiate(
+		code,
+		gin.Negotiate{
+			Offered: BindMIMEs,
+			Data:    r})
+}
+
+//
+// Accepted determines if the mime is accepted.
+func (h *BaseHandler) Accepted(ctx *gin.Context, wanted ...string) (b bool) {
+	accept := ctx.GetHeader(Accept)
+	for _, m := range strings.Split(accept, ",") {
+		m = strings.TrimSpace(m)
+		m = strings.Split(m, ";")[0]
+		mp := strings.SplitN(m, "/", 2)
+		if len(mp) != 2 {
+			continue
+		}
+		for _, w := range wanted {
+			wp := strings.SplitN(w, "/", 2)
+			if len(wp) != 2 {
+				continue
+			}
+			if !(mp[0] == "*" || mp[0] == wp[0]) {
+				continue
+			}
+			if !(mp[1] == "*" || mp[1] == wp[1]) {
+				continue
+			}
+			b = true
 			return
 		}
 	}
@@ -263,4 +347,76 @@ func (r *TagRef) With(id uint, name string, source string) {
 	r.ID = id
 	r.Name = name
 	r.Source = source
+}
+
+//
+// Page provides pagination.
+type Page struct {
+	Offset int
+	Limit  int
+}
+
+//
+// With context.
+func (p *Page) With(ctx *gin.Context) {
+	s := ctx.Query("offset")
+	if s != "" {
+		p.Offset, _ = strconv.Atoi(s)
+	}
+	s = ctx.Query("limit")
+	if s != "" {
+		p.Limit, _ = strconv.Atoi(s)
+	}
+	return
+}
+
+//
+// Paginated returns a paginated DB.
+func (p *Page) Paginated(in *gorm.DB) (out *gorm.DB) {
+	out = in
+	if p.Offset > 0 {
+		out = out.Offset(p.Offset)
+	}
+	if p.Limit > 0 {
+		out = out.Limit(p.Limit)
+	}
+	return
+}
+
+//
+// Sort provides sorting.
+type Sort struct {
+	Descending bool
+	Field      string
+}
+
+//
+// With context.
+func (p *Sort) With(ctx *gin.Context) {
+	s := ctx.Query("sort")
+	if s == "" {
+		return
+	}
+	part := strings.SplitN(s, ":", 2)
+	if len(part) == 2 {
+		p.Descending = strings.ToLower(part[0])[0] == 'd'
+		p.Field = part[1]
+	} else {
+		p.Field = part[0]
+	}
+}
+
+//
+// Sorted returns sorted DB.
+func (p *Sort) Sorted(in *gorm.DB) (out *gorm.DB) {
+	out = in
+	if p.Field == "" {
+		return
+	}
+	sort := p.Field
+	if p.Descending {
+		sort += " DESC"
+	}
+	out = out.Order(sort)
+	return
 }

--- a/api/bucket.go
+++ b/api/bucket.go
@@ -7,6 +7,7 @@ import (
 	"compress/gzip"
 	"fmt"
 	"github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin/binding"
 	liberr "github.com/konveyor/controller/pkg/error"
 	"github.com/konveyor/tackle2-hub/model"
 	"github.com/konveyor/tackle2-hub/nas"
@@ -76,7 +77,7 @@ func (h BucketHandler) List(ctx *gin.Context) {
 		resources = append(resources, r)
 	}
 
-	ctx.JSON(http.StatusOK, resources)
+	h.Render(ctx, http.StatusOK, resources)
 }
 
 // Create godoc
@@ -98,7 +99,7 @@ func (h BucketHandler) Create(ctx *gin.Context) {
 	}
 	r := Bucket{}
 	r.With(m)
-	ctx.JSON(http.StatusCreated, r)
+	h.Render(ctx, http.StatusCreated, r)
 }
 
 // Get godoc
@@ -120,10 +121,10 @@ func (h BucketHandler) Get(ctx *gin.Context) {
 		_ = ctx.Error(result.Error)
 		return
 	}
-	if h.accepted(ctx, AppJson) {
+	if h.Accepted(ctx, BindMIMEs...) {
 		r := Bucket{}
 		r.With(m)
-		ctx.JSON(http.StatusOK, r)
+		h.Render(ctx, http.StatusOK, r)
 		return
 	}
 	h.bucketGet(ctx, id)
@@ -247,7 +248,7 @@ func (h *BucketOwner) bucketGet(ctx *gin.Context, id uint) {
 			pattern: ctx.Query(Filter),
 			root:    path,
 		}
-		if h.accepted(ctx, TextHTML) {
+		if h.Accepted(ctx, binding.MIMEHTML) {
 			err = h.getFile(ctx, m)
 			if err != nil {
 				_ = ctx.Error(err)
@@ -499,19 +500,6 @@ func (h *BucketOwner) putFile(ctx *gin.Context, m *model.Bucket) (err error) {
 		return
 	}
 	err = os.Chmod(path, 0666)
-	return
-}
-
-//
-// accepted determines if the mime is accepted.
-func (h *BucketOwner) accepted(ctx *gin.Context, mime string) (b bool) {
-	accept := ctx.Request.Header.Get(Accept)
-	for _, s := range strings.Split(accept, ",") {
-		if s == mime {
-			b = true
-			break
-		}
-	}
 	return
 }
 

--- a/api/businessservice.go
+++ b/api/businessservice.go
@@ -53,7 +53,7 @@ func (h BusinessServiceHandler) Get(ctx *gin.Context) {
 
 	resource := BusinessService{}
 	resource.With(m)
-	ctx.JSON(http.StatusOK, resource)
+	h.Render(ctx, http.StatusOK, resource)
 }
 
 // List godoc
@@ -78,7 +78,7 @@ func (h BusinessServiceHandler) List(ctx *gin.Context) {
 		resources = append(resources, r)
 	}
 
-	ctx.JSON(http.StatusOK, resources)
+	h.Render(ctx, http.StatusOK, resources)
 }
 
 // Create godoc
@@ -92,7 +92,7 @@ func (h BusinessServiceHandler) List(ctx *gin.Context) {
 // @param business_service body api.BusinessService true "Business service data"
 func (h BusinessServiceHandler) Create(ctx *gin.Context) {
 	r := &BusinessService{}
-	err := ctx.BindJSON(r)
+	err := h.Bind(ctx, r)
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -106,7 +106,7 @@ func (h BusinessServiceHandler) Create(ctx *gin.Context) {
 	}
 	r.With(m)
 
-	ctx.JSON(http.StatusCreated, r)
+	h.Render(ctx, http.StatusCreated, r)
 }
 
 // Delete godoc
@@ -145,7 +145,7 @@ func (h BusinessServiceHandler) Delete(ctx *gin.Context) {
 func (h BusinessServiceHandler) Update(ctx *gin.Context) {
 	id := h.pk(ctx)
 	r := &BusinessService{}
-	err := ctx.BindJSON(r)
+	err := h.Bind(ctx, r)
 	if err != nil {
 		_ = ctx.Error(err)
 		return

--- a/api/cache.go
+++ b/api/cache.go
@@ -54,7 +54,7 @@ func (h CacheHandler) Get(ctx *gin.Context) {
 		return
 	}
 
-	ctx.JSON(http.StatusOK, r)
+	h.Render(ctx, http.StatusOK, r)
 }
 
 // Delete godoc

--- a/api/dependency.go
+++ b/api/dependency.go
@@ -52,7 +52,7 @@ func (h DependencyHandler) Get(ctx *gin.Context) {
 	r := Dependency{}
 	r.With(m)
 
-	ctx.JSON(http.StatusOK, r)
+	h.Render(ctx, http.StatusOK, r)
 }
 
 //
@@ -89,7 +89,7 @@ func (h DependencyHandler) List(ctx *gin.Context) {
 		resources = append(resources, r)
 	}
 
-	ctx.JSON(http.StatusOK, resources)
+	h.Render(ctx, http.StatusOK, resources)
 }
 
 // Create godoc
@@ -103,7 +103,7 @@ func (h DependencyHandler) List(ctx *gin.Context) {
 // @param applications_dependency body Dependency true "Dependency data"
 func (h DependencyHandler) Create(ctx *gin.Context) {
 	r := Dependency{}
-	err := ctx.BindJSON(&r)
+	err := h.Bind(ctx, &r)
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -116,7 +116,7 @@ func (h DependencyHandler) Create(ctx *gin.Context) {
 		return
 	}
 
-	ctx.JSON(http.StatusCreated, r)
+	h.Render(ctx, http.StatusCreated, r)
 }
 
 // Delete godoc

--- a/api/error.go
+++ b/api/error.go
@@ -11,6 +11,21 @@ import (
 	"os"
 )
 
+//
+// BadRequestError reports bad request errors.
+type BadRequestError struct {
+	Reason string
+}
+
+func (r *BadRequestError) Error() string {
+	return r.Reason
+}
+
+func (r *BadRequestError) Is(err error) (matched bool) {
+	_, matched = err.(*BadRequestError)
+	return
+}
+
 func ErrorHandler() gin.HandlerFunc {
 	return func(ctx *gin.Context) {
 		ctx.Next()
@@ -30,7 +45,7 @@ func ErrorHandler() gin.HandlerFunc {
 
 		err := ctx.Errors[0]
 
-		if errors.Is(err, validator.ValidationErrors{}) {
+		if errors.Is(err, &BadRequestError{}) || errors.Is(err, validator.ValidationErrors{}) {
 			ctx.JSON(
 				http.StatusBadRequest,
 				gin.H{

--- a/api/file.go
+++ b/api/file.go
@@ -58,7 +58,7 @@ func (h FileHandler) List(ctx *gin.Context) {
 		resources = append(resources, r)
 	}
 
-	ctx.JSON(http.StatusOK, resources)
+	h.Render(ctx, http.StatusOK, resources)
 }
 
 // Create godoc
@@ -116,7 +116,7 @@ func (h FileHandler) Create(ctx *gin.Context) {
 	}
 	r := File{}
 	r.With(m)
-	ctx.JSON(http.StatusCreated, r)
+	h.Render(ctx, http.StatusCreated, r)
 }
 
 // Get godoc
@@ -135,12 +135,11 @@ func (h FileHandler) Get(ctx *gin.Context) {
 		_ = ctx.Error(result.Error)
 		return
 	}
-	switch ctx.GetHeader(Accept) {
-	case AppJson:
+	if h.Accepted(ctx, BindMIMEs...) {
 		r := File{}
 		r.With(m)
-		ctx.JSON(http.StatusOK, r)
-	default:
+		h.Render(ctx, http.StatusOK, r)
+	} else {
 		header := ctx.Writer.Header()
 		header[ContentType] = []string{
 			mime.TypeByExtension(pathlib.Ext(m.Name)),

--- a/api/group.go
+++ b/api/group.go
@@ -53,7 +53,7 @@ func (h StakeholderGroupHandler) Get(ctx *gin.Context) {
 	r := StakeholderGroup{}
 	r.With(m)
 
-	ctx.JSON(http.StatusOK, m)
+	h.Render(ctx, http.StatusOK, m)
 }
 
 // List godoc
@@ -78,7 +78,7 @@ func (h StakeholderGroupHandler) List(ctx *gin.Context) {
 		resources = append(resources, r)
 	}
 
-	ctx.JSON(http.StatusOK, resources)
+	h.Render(ctx, http.StatusOK, resources)
 }
 
 // Create godoc
@@ -92,7 +92,7 @@ func (h StakeholderGroupHandler) List(ctx *gin.Context) {
 // @param stakeholder_group body api.StakeholderGroup true "Stakeholder Group data"
 func (h StakeholderGroupHandler) Create(ctx *gin.Context) {
 	r := &StakeholderGroup{}
-	err := ctx.BindJSON(r)
+	err := h.Bind(ctx, r)
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -106,7 +106,7 @@ func (h StakeholderGroupHandler) Create(ctx *gin.Context) {
 	}
 	r.With(m)
 
-	ctx.JSON(http.StatusCreated, r)
+	h.Render(ctx, http.StatusCreated, r)
 }
 
 // Delete godoc
@@ -145,7 +145,7 @@ func (h StakeholderGroupHandler) Delete(ctx *gin.Context) {
 func (h StakeholderGroupHandler) Update(ctx *gin.Context) {
 	id := h.pk(ctx)
 	r := &StakeholderGroup{}
-	err := ctx.BindJSON(r)
+	err := h.Bind(ctx, r)
 	if err != nil {
 		_ = ctx.Error(err)
 		return

--- a/api/identity.go
+++ b/api/identity.go
@@ -65,7 +65,7 @@ func (h IdentityHandler) Get(ctx *gin.Context) {
 	}
 	r.With(m)
 
-	ctx.JSON(http.StatusOK, r)
+	h.Render(ctx, http.StatusOK, r)
 }
 
 // List godoc
@@ -109,7 +109,7 @@ func (h IdentityHandler) List(ctx *gin.Context) {
 		resources = append(resources, r)
 	}
 
-	ctx.JSON(http.StatusOK, resources)
+	h.Render(ctx, http.StatusOK, resources)
 }
 
 // Create godoc
@@ -123,7 +123,7 @@ func (h IdentityHandler) List(ctx *gin.Context) {
 // @param identity body Identity true "Identity data"
 func (h IdentityHandler) Create(ctx *gin.Context) {
 	r := &Identity{}
-	err := ctx.BindJSON(r)
+	err := h.Bind(ctx, r)
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -143,7 +143,7 @@ func (h IdentityHandler) Create(ctx *gin.Context) {
 	}
 	r.With(m)
 
-	ctx.JSON(http.StatusCreated, r)
+	h.Render(ctx, http.StatusCreated, r)
 }
 
 // Delete godoc
@@ -182,7 +182,7 @@ func (h IdentityHandler) Delete(ctx *gin.Context) {
 func (h IdentityHandler) Update(ctx *gin.Context) {
 	id := h.pk(ctx)
 	r := &Identity{}
-	err := ctx.BindJSON(r)
+	err := h.Bind(ctx, r)
 	if err != nil {
 		_ = ctx.Error(err)
 		return

--- a/api/import.go
+++ b/api/import.go
@@ -78,7 +78,7 @@ func (h ImportHandler) GetImport(ctx *gin.Context) {
 		_ = ctx.Error(result.Error)
 		return
 	}
-	ctx.JSON(http.StatusOK, m.AsMap())
+	h.Render(ctx, http.StatusOK, m.AsMap())
 }
 
 //
@@ -113,7 +113,7 @@ func (h ImportHandler) ListImports(ctx *gin.Context) {
 		resources = append(resources, list[i].AsMap())
 	}
 
-	ctx.JSON(http.StatusOK, resources)
+	h.Render(ctx, http.StatusOK, resources)
 }
 
 //
@@ -153,7 +153,7 @@ func (h ImportHandler) GetSummary(ctx *gin.Context) {
 		_ = ctx.Error(result.Error)
 		return
 	}
-	ctx.JSON(http.StatusOK, m)
+	h.Render(ctx, http.StatusOK, m)
 }
 
 //
@@ -179,7 +179,7 @@ func (h ImportHandler) ListSummaries(ctx *gin.Context) {
 		resources = append(resources, r)
 	}
 
-	ctx.JSON(http.StatusOK, resources)
+	h.Render(ctx, http.StatusOK, resources)
 }
 
 //
@@ -273,7 +273,7 @@ func (h ImportHandler) UploadCSV(ctx *gin.Context) {
 		case RecordTypeApplication:
 			// Check row format - length, expecting 15 fields + tags
 			if len(row) < 15 {
-				ctx.JSON(http.StatusBadRequest, gin.H{"errorMessage": "Invalid Application Import CSV format."})
+				h.Render(ctx, http.StatusBadRequest, gin.H{"errorMessage": "Invalid Application Import CSV format."})
 				return
 			}
 			imp = h.applicationFromRow(fileName, row)
@@ -295,7 +295,7 @@ func (h ImportHandler) UploadCSV(ctx *gin.Context) {
 
 	summary := ImportSummary{}
 	summary.With(&m)
-	ctx.JSON(http.StatusCreated, summary)
+	h.Render(ctx, http.StatusCreated, summary)
 }
 
 //

--- a/api/jobfunction.go
+++ b/api/jobfunction.go
@@ -53,7 +53,7 @@ func (h JobFunctionHandler) Get(ctx *gin.Context) {
 	r := JobFunction{}
 	r.With(m)
 
-	ctx.JSON(http.StatusOK, r)
+	h.Render(ctx, http.StatusOK, r)
 }
 
 // List godoc
@@ -78,7 +78,7 @@ func (h JobFunctionHandler) List(ctx *gin.Context) {
 		resources = append(resources, r)
 	}
 
-	ctx.JSON(http.StatusOK, resources)
+	h.Render(ctx, http.StatusOK, resources)
 }
 
 // Create godoc
@@ -92,7 +92,7 @@ func (h JobFunctionHandler) List(ctx *gin.Context) {
 // @param job_function body api.JobFunction true "Job Function data"
 func (h JobFunctionHandler) Create(ctx *gin.Context) {
 	r := &JobFunction{}
-	err := ctx.BindJSON(r)
+	err := h.Bind(ctx, r)
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -106,7 +106,7 @@ func (h JobFunctionHandler) Create(ctx *gin.Context) {
 	}
 	r.With(m)
 
-	ctx.JSON(http.StatusCreated, r)
+	h.Render(ctx, http.StatusCreated, r)
 }
 
 // Delete godoc
@@ -145,7 +145,7 @@ func (h JobFunctionHandler) Delete(ctx *gin.Context) {
 func (h JobFunctionHandler) Update(ctx *gin.Context) {
 	id := h.pk(ctx)
 	r := &JobFunction{}
-	err := ctx.BindJSON(r)
+	err := h.Bind(ctx, r)
 	if err != nil {
 		_ = ctx.Error(err)
 		return

--- a/api/migrationwave.go
+++ b/api/migrationwave.go
@@ -54,7 +54,7 @@ func (h MigrationWaveHandler) Get(ctx *gin.Context) {
 	r := MigrationWave{}
 	r.With(m)
 
-	ctx.JSON(http.StatusOK, r)
+	h.Render(ctx, http.StatusOK, r)
 }
 
 // List godoc
@@ -79,7 +79,7 @@ func (h MigrationWaveHandler) List(ctx *gin.Context) {
 		resources = append(resources, r)
 	}
 
-	ctx.JSON(http.StatusOK, resources)
+	h.Render(ctx, http.StatusOK, resources)
 }
 
 // Create godoc
@@ -93,7 +93,7 @@ func (h MigrationWaveHandler) List(ctx *gin.Context) {
 // @param migrationwave body api.MigrationWave true "Migration Wave data"
 func (h MigrationWaveHandler) Create(ctx *gin.Context) {
 	r := &MigrationWave{}
-	err := ctx.BindJSON(r)
+	err := h.Bind(ctx, r)
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -107,7 +107,7 @@ func (h MigrationWaveHandler) Create(ctx *gin.Context) {
 	}
 	r.With(m)
 
-	ctx.JSON(http.StatusCreated, r)
+	h.Render(ctx, http.StatusCreated, r)
 }
 
 // Update godoc
@@ -122,7 +122,7 @@ func (h MigrationWaveHandler) Create(ctx *gin.Context) {
 func (h MigrationWaveHandler) Update(ctx *gin.Context) {
 	id := h.pk(ctx)
 	r := &MigrationWave{}
-	err := ctx.BindJSON(r)
+	err := h.Bind(ctx, r)
 	if err != nil {
 		_ = ctx.Error(err)
 		return

--- a/api/pathfinder.go
+++ b/api/pathfinder.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin/binding"
 	liberr "github.com/konveyor/controller/pkg/error"
 	"io"
 	"net/http"
@@ -70,7 +71,7 @@ func (r *Pathfinder) DeleteAssessment(ids []uint, ctx *gin.Context) (err error) 
 	header := http.Header{
 		Authorization: ctx.Request.Header[Authorization],
 		ContentLength: []string{strconv.Itoa(len(b))},
-		ContentType:   []string{"application/json"},
+		ContentType:   []string{binding.MIMEJSON},
 	}
 	request := r.request(
 		http.MethodDelete,

--- a/api/pkg.go
+++ b/api/pkg.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin/binding"
 	"github.com/konveyor/controller/pkg/logging"
 	"github.com/konveyor/tackle2-hub/settings"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -34,12 +35,14 @@ const (
 )
 
 //
-// Accepted (mime)
+// MIME Types.
 const (
-	AppJson  = "application/json"
-	AppOctet = "application/octet-stream"
-	TextHTML = "text/html"
+	MIMEOCTETSTREAM = "application/octet-stream"
 )
+
+//
+// BindMIMEs supported binding MIME types.
+var BindMIMEs = []string{binding.MIMEJSON, binding.MIMEYAML}
 
 //
 // Header Values

--- a/api/proxy.go
+++ b/api/proxy.go
@@ -56,7 +56,7 @@ func (h ProxyHandler) Get(ctx *gin.Context) {
 	r := Proxy{}
 	r.With(proxy)
 
-	ctx.JSON(http.StatusOK, r)
+	h.Render(ctx, http.StatusOK, r)
 }
 
 // List godoc
@@ -85,7 +85,7 @@ func (h ProxyHandler) List(ctx *gin.Context) {
 		resources = append(resources, r)
 	}
 
-	ctx.JSON(http.StatusOK, resources)
+	h.Render(ctx, http.StatusOK, resources)
 }
 
 // Create godoc
@@ -99,7 +99,7 @@ func (h ProxyHandler) List(ctx *gin.Context) {
 // @param proxy body Proxy true "Proxy data"
 func (h ProxyHandler) Create(ctx *gin.Context) {
 	proxy := &Proxy{}
-	err := ctx.BindJSON(proxy)
+	err := h.Bind(ctx, proxy)
 	if err != nil {
 		return
 	}
@@ -112,7 +112,7 @@ func (h ProxyHandler) Create(ctx *gin.Context) {
 	}
 	proxy.With(m)
 
-	ctx.JSON(http.StatusCreated, proxy)
+	h.Render(ctx, http.StatusCreated, proxy)
 }
 
 // Delete godoc
@@ -151,7 +151,7 @@ func (h ProxyHandler) Delete(ctx *gin.Context) {
 func (h ProxyHandler) Update(ctx *gin.Context) {
 	id := h.pk(ctx)
 	r := &Proxy{}
-	err := ctx.BindJSON(r)
+	err := h.Bind(ctx, r)
 	if err != nil {
 		_ = ctx.Error(err)
 		return

--- a/api/review.go
+++ b/api/review.go
@@ -55,7 +55,7 @@ func (h ReviewHandler) Get(ctx *gin.Context) {
 	r := Review{}
 	r.With(m)
 
-	ctx.JSON(http.StatusOK, r)
+	h.Render(ctx, http.StatusOK, r)
 }
 
 // List godoc
@@ -80,7 +80,7 @@ func (h ReviewHandler) List(ctx *gin.Context) {
 		resources = append(resources, r)
 	}
 
-	ctx.JSON(http.StatusOK, resources)
+	h.Render(ctx, http.StatusOK, resources)
 }
 
 // Create godoc
@@ -94,7 +94,7 @@ func (h ReviewHandler) List(ctx *gin.Context) {
 // @param review body api.Review true "Review data"
 func (h ReviewHandler) Create(ctx *gin.Context) {
 	review := Review{}
-	err := ctx.BindJSON(&review)
+	err := h.Bind(ctx, &review)
 	if err != nil {
 		return
 	}
@@ -107,7 +107,7 @@ func (h ReviewHandler) Create(ctx *gin.Context) {
 	}
 	review.With(m)
 
-	ctx.JSON(http.StatusCreated, review)
+	h.Render(ctx, http.StatusCreated, review)
 }
 
 // Delete godoc
@@ -146,7 +146,7 @@ func (h ReviewHandler) Delete(ctx *gin.Context) {
 func (h ReviewHandler) Update(ctx *gin.Context) {
 	id := h.pk(ctx)
 	r := &Review{}
-	err := ctx.BindJSON(r)
+	err := h.Bind(ctx, r)
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -175,7 +175,7 @@ func (h ReviewHandler) Update(ctx *gin.Context) {
 // @param copy_request body api.CopyRequest true "Review copy request data"
 func (h ReviewHandler) CopyReview(ctx *gin.Context) {
 	c := CopyRequest{}
-	err := ctx.BindJSON(&c)
+	err := h.Bind(ctx, &c)
 	if err != nil {
 		return
 	}

--- a/api/rulebundle.go
+++ b/api/rulebundle.go
@@ -55,7 +55,7 @@ func (h RuleBundleHandler) Get(ctx *gin.Context) {
 	r := RuleBundle{}
 	r.With(bundle)
 
-	ctx.JSON(http.StatusOK, r)
+	h.Render(ctx, http.StatusOK, r)
 }
 
 // List godoc
@@ -83,7 +83,7 @@ func (h RuleBundleHandler) List(ctx *gin.Context) {
 		resources = append(resources, r)
 	}
 
-	ctx.JSON(http.StatusOK, resources)
+	h.Render(ctx, http.StatusOK, resources)
 }
 
 // Create godoc
@@ -97,7 +97,7 @@ func (h RuleBundleHandler) List(ctx *gin.Context) {
 // @param ruleBundle body RuleBundle true "RuleBundle data"
 func (h RuleBundleHandler) Create(ctx *gin.Context) {
 	bundle := &RuleBundle{}
-	err := ctx.BindJSON(bundle)
+	err := h.Bind(ctx, bundle)
 	if err != nil {
 		return
 	}
@@ -119,7 +119,7 @@ func (h RuleBundleHandler) Create(ctx *gin.Context) {
 	}
 	bundle.With(m)
 
-	ctx.JSON(http.StatusCreated, bundle)
+	h.Render(ctx, http.StatusCreated, bundle)
 }
 
 // Delete godoc
@@ -158,7 +158,7 @@ func (h RuleBundleHandler) Delete(ctx *gin.Context) {
 func (h RuleBundleHandler) Update(ctx *gin.Context) {
 	id := h.pk(ctx)
 	r := &RuleBundle{}
-	err := ctx.BindJSON(r)
+	err := h.Bind(ctx, r)
 	if err != nil {
 		_ = ctx.Error(err)
 		return

--- a/api/schema.go
+++ b/api/schema.go
@@ -40,7 +40,7 @@ func (h *SchemaHandler) Get(ctx *gin.Context) {
 		schema.Paths = append(schema.Paths, rte.Path)
 	}
 
-	ctx.JSON(http.StatusOK, schema)
+	h.Render(ctx, http.StatusOK, schema)
 }
 
 type Schema struct {

--- a/api/setting.go
+++ b/api/setting.go
@@ -55,7 +55,7 @@ func (h SettingHandler) Get(ctx *gin.Context) {
 	r := Setting{}
 	r.With(setting)
 
-	ctx.JSON(http.StatusOK, r.Value)
+	h.Render(ctx, http.StatusOK, r.Value)
 }
 
 // List godoc
@@ -79,7 +79,7 @@ func (h SettingHandler) List(ctx *gin.Context) {
 		resources = append(resources, r)
 	}
 
-	ctx.JSON(http.StatusOK, resources)
+	h.Render(ctx, http.StatusOK, resources)
 }
 
 // Create godoc
@@ -93,14 +93,14 @@ func (h SettingHandler) List(ctx *gin.Context) {
 // @param setting body api.Setting true "Setting data"
 func (h SettingHandler) Create(ctx *gin.Context) {
 	setting := Setting{}
-	err := ctx.BindJSON(&setting)
+	err := h.Bind(ctx, &setting)
 	if err != nil {
 		_ = ctx.Error(err)
 		return
 	}
 
 	if strings.HasPrefix(setting.Key, ".") {
-		ctx.JSON(
+		h.Render(ctx,
 			http.StatusForbidden,
 			gin.H{
 				"error": fmt.Sprintf("%s is read-only.", setting.Key),
@@ -118,7 +118,7 @@ func (h SettingHandler) Create(ctx *gin.Context) {
 	}
 	setting.With(m)
 
-	ctx.JSON(http.StatusCreated, setting)
+	h.Render(ctx, http.StatusCreated, setting)
 }
 
 // CreateByKey godoc
@@ -132,7 +132,7 @@ func (h SettingHandler) Create(ctx *gin.Context) {
 func (h SettingHandler) CreateByKey(ctx *gin.Context) {
 	key := ctx.Param(Key)
 	if strings.HasPrefix(key, ".") {
-		ctx.JSON(
+		h.Render(ctx,
 			http.StatusForbidden,
 			gin.H{
 				"error": fmt.Sprintf("%s is read-only.", key),
@@ -143,7 +143,7 @@ func (h SettingHandler) CreateByKey(ctx *gin.Context) {
 
 	setting := Setting{}
 	setting.Key = key
-	err := ctx.BindJSON(&setting.Value)
+	err := h.Bind(ctx, &setting.Value)
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -171,7 +171,7 @@ func (h SettingHandler) CreateByKey(ctx *gin.Context) {
 func (h SettingHandler) Update(ctx *gin.Context) {
 	key := ctx.Param(Key)
 	if strings.HasPrefix(key, ".") {
-		ctx.JSON(
+		h.Render(ctx,
 			http.StatusForbidden,
 			gin.H{
 				"error": fmt.Sprintf("%s is read-only.", key),
@@ -182,7 +182,7 @@ func (h SettingHandler) Update(ctx *gin.Context) {
 
 	updates := Setting{}
 	updates.Key = key
-	err := ctx.BindJSON(&updates.Value)
+	err := h.Bind(ctx, &updates.Value)
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -210,7 +210,7 @@ func (h SettingHandler) Update(ctx *gin.Context) {
 func (h SettingHandler) Delete(ctx *gin.Context) {
 	key := ctx.Param(Key)
 	if strings.HasPrefix(key, ".") {
-		ctx.JSON(
+		h.Render(ctx,
 			http.StatusForbidden,
 			gin.H{
 				"error": fmt.Sprintf("%s is read-only.", key),

--- a/api/stakeholder.go
+++ b/api/stakeholder.go
@@ -53,7 +53,7 @@ func (h StakeholderHandler) Get(ctx *gin.Context) {
 
 	resource := Stakeholder{}
 	resource.With(m)
-	ctx.JSON(http.StatusOK, resource)
+	h.Render(ctx, http.StatusOK, resource)
 }
 
 // List godoc
@@ -78,7 +78,7 @@ func (h StakeholderHandler) List(ctx *gin.Context) {
 		resources = append(resources, r)
 	}
 
-	ctx.JSON(http.StatusOK, resources)
+	h.Render(ctx, http.StatusOK, resources)
 }
 
 // Create godoc
@@ -92,7 +92,7 @@ func (h StakeholderHandler) List(ctx *gin.Context) {
 // @param stakeholder body api.Stakeholder true "Stakeholder data"
 func (h StakeholderHandler) Create(ctx *gin.Context) {
 	r := &Stakeholder{}
-	err := ctx.BindJSON(r)
+	err := h.Bind(ctx, r)
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -106,7 +106,7 @@ func (h StakeholderHandler) Create(ctx *gin.Context) {
 	}
 	r.With(m)
 
-	ctx.JSON(http.StatusCreated, r)
+	h.Render(ctx, http.StatusCreated, r)
 }
 
 // Delete godoc
@@ -145,7 +145,7 @@ func (h StakeholderHandler) Delete(ctx *gin.Context) {
 func (h StakeholderHandler) Update(ctx *gin.Context) {
 	id := h.pk(ctx)
 	r := &Stakeholder{}
-	err := ctx.BindJSON(r)
+	err := h.Bind(ctx, r)
 	if err != nil {
 		_ = ctx.Error(err)
 		return

--- a/api/tag.go
+++ b/api/tag.go
@@ -53,7 +53,7 @@ func (h TagHandler) Get(ctx *gin.Context) {
 
 	resource := Tag{}
 	resource.With(m)
-	ctx.JSON(http.StatusOK, resource)
+	h.Render(ctx, http.StatusOK, resource)
 }
 
 // List godoc
@@ -78,7 +78,7 @@ func (h TagHandler) List(ctx *gin.Context) {
 		resources = append(resources, r)
 	}
 
-	ctx.JSON(http.StatusOK, resources)
+	h.Render(ctx, http.StatusOK, resources)
 }
 
 // Create godoc
@@ -92,7 +92,7 @@ func (h TagHandler) List(ctx *gin.Context) {
 // @param tag body Tag true "Tag data"
 func (h TagHandler) Create(ctx *gin.Context) {
 	r := &Tag{}
-	err := ctx.BindJSON(r)
+	err := h.Bind(ctx, r)
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -106,7 +106,7 @@ func (h TagHandler) Create(ctx *gin.Context) {
 	}
 	r.With(m)
 
-	ctx.JSON(http.StatusCreated, r)
+	h.Render(ctx, http.StatusCreated, r)
 }
 
 // Delete godoc
@@ -145,7 +145,7 @@ func (h TagHandler) Delete(ctx *gin.Context) {
 func (h TagHandler) Update(ctx *gin.Context) {
 	id := h.pk(ctx)
 	r := &Tag{}
-	err := ctx.BindJSON(r)
+	err := h.Bind(ctx, r)
 	if err != nil {
 		_ = ctx.Error(err)
 		return

--- a/api/tagcategory.go
+++ b/api/tagcategory.go
@@ -53,7 +53,7 @@ func (h TagCategoryHandler) Get(ctx *gin.Context) {
 
 	resource := TagCategory{}
 	resource.With(m)
-	ctx.JSON(http.StatusOK, resource)
+	h.Render(ctx, http.StatusOK, resource)
 }
 
 // List godoc
@@ -78,7 +78,7 @@ func (h TagCategoryHandler) List(ctx *gin.Context) {
 		resources = append(resources, r)
 	}
 
-	ctx.JSON(http.StatusOK, resources)
+	h.Render(ctx, http.StatusOK, resources)
 }
 
 // Create godoc
@@ -92,7 +92,7 @@ func (h TagCategoryHandler) List(ctx *gin.Context) {
 // @param tag_type body api.TagCategory true "Tag Category data"
 func (h TagCategoryHandler) Create(ctx *gin.Context) {
 	r := TagCategory{}
-	err := ctx.BindJSON(&r)
+	err := h.Bind(ctx, &r)
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -106,7 +106,7 @@ func (h TagCategoryHandler) Create(ctx *gin.Context) {
 	}
 	r.With(m)
 
-	ctx.JSON(http.StatusCreated, r)
+	h.Render(ctx, http.StatusCreated, r)
 }
 
 // Delete godoc
@@ -145,7 +145,7 @@ func (h TagCategoryHandler) Delete(ctx *gin.Context) {
 func (h TagCategoryHandler) Update(ctx *gin.Context) {
 	id := h.pk(ctx)
 	r := &TagCategory{}
-	err := ctx.BindJSON(r)
+	err := h.Bind(ctx, r)
 	if err != nil {
 		_ = ctx.Error(err)
 		return

--- a/api/task.go
+++ b/api/task.go
@@ -84,7 +84,7 @@ func (h TaskHandler) Get(ctx *gin.Context) {
 	r := Task{}
 	r.With(task)
 
-	ctx.JSON(http.StatusOK, r)
+	h.Render(ctx, http.StatusOK, r)
 }
 
 // List godoc
@@ -114,7 +114,7 @@ func (h TaskHandler) List(ctx *gin.Context) {
 		resources = append(resources, r)
 	}
 
-	ctx.JSON(http.StatusOK, resources)
+	h.Render(ctx, http.StatusOK, resources)
 }
 
 // Create godoc
@@ -128,7 +128,7 @@ func (h TaskHandler) List(ctx *gin.Context) {
 // @param task body api.Task true "Task data"
 func (h TaskHandler) Create(ctx *gin.Context) {
 	r := Task{}
-	err := ctx.BindJSON(&r)
+	err := h.Bind(ctx, &r)
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -139,7 +139,7 @@ func (h TaskHandler) Create(ctx *gin.Context) {
 	case tasking.Created,
 		tasking.Ready:
 	default:
-		ctx.JSON(
+		h.Render(ctx,
 			http.StatusBadRequest,
 			gin.H{
 				"error": "state must be (''|Created|Ready)",
@@ -155,7 +155,7 @@ func (h TaskHandler) Create(ctx *gin.Context) {
 	}
 	r.With(m)
 
-	ctx.JSON(http.StatusCreated, r)
+	h.Render(ctx, http.StatusCreated, r)
 }
 
 // Delete godoc
@@ -202,7 +202,7 @@ func (h TaskHandler) Delete(ctx *gin.Context) {
 func (h TaskHandler) Update(ctx *gin.Context) {
 	id := h.pk(ctx)
 	r := &Task{}
-	err := ctx.BindJSON(r)
+	err := h.Bind(ctx, r)
 	if err != nil {
 		return
 	}
@@ -210,7 +210,7 @@ func (h TaskHandler) Update(ctx *gin.Context) {
 	case tasking.Created,
 		tasking.Ready:
 	default:
-		ctx.JSON(
+		h.Render(ctx,
 			http.StatusBadRequest,
 			gin.H{
 				"error": "state must be (Created|Ready)",
@@ -283,7 +283,7 @@ func (h TaskHandler) Cancel(ctx *gin.Context) {
 	case tasking.Succeeded,
 		tasking.Failed,
 		tasking.Canceled:
-		ctx.JSON(
+		h.Render(ctx,
 			http.StatusBadRequest,
 			gin.H{
 				"error": "state must not be (Succeeded|Failed|Canceled)",
@@ -396,7 +396,7 @@ func (h TaskHandler) BucketDelete(ctx *gin.Context) {
 func (h TaskHandler) CreateReport(ctx *gin.Context) {
 	id := h.pk(ctx)
 	report := &TaskReport{}
-	err := ctx.BindJSON(report)
+	err := h.Bind(ctx, report)
 	if err != nil {
 		return
 	}
@@ -409,7 +409,7 @@ func (h TaskHandler) CreateReport(ctx *gin.Context) {
 	}
 	report.With(m)
 
-	ctx.JSON(http.StatusCreated, report)
+	h.Render(ctx, http.StatusCreated, report)
 }
 
 // UpdateReport godoc
@@ -425,7 +425,7 @@ func (h TaskHandler) CreateReport(ctx *gin.Context) {
 func (h TaskHandler) UpdateReport(ctx *gin.Context) {
 	id := h.pk(ctx)
 	report := &TaskReport{}
-	err := ctx.BindJSON(report)
+	err := h.Bind(ctx, report)
 	if err != nil {
 		return
 	}
@@ -440,7 +440,7 @@ func (h TaskHandler) UpdateReport(ctx *gin.Context) {
 	}
 	report.With(m)
 
-	ctx.JSON(http.StatusOK, report)
+	h.Render(ctx, http.StatusOK, report)
 }
 
 // DeleteReport godoc

--- a/api/taskgroup.go
+++ b/api/taskgroup.go
@@ -68,7 +68,7 @@ func (h TaskGroupHandler) Get(ctx *gin.Context) {
 	r := TaskGroup{}
 	r.With(m)
 
-	ctx.JSON(http.StatusOK, r)
+	h.Render(ctx, http.StatusOK, r)
 }
 
 // List godoc
@@ -93,7 +93,7 @@ func (h TaskGroupHandler) List(ctx *gin.Context) {
 		resources = append(resources, r)
 	}
 
-	ctx.JSON(http.StatusOK, resources)
+	h.Render(ctx, http.StatusOK, resources)
 }
 
 // Create godoc
@@ -107,7 +107,7 @@ func (h TaskGroupHandler) List(ctx *gin.Context) {
 // @param taskgroup body api.TaskGroup true "TaskGroup data"
 func (h TaskGroupHandler) Create(ctx *gin.Context) {
 	r := &TaskGroup{}
-	err := ctx.BindJSON(r)
+	err := h.Bind(ctx, r)
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -126,7 +126,7 @@ func (h TaskGroupHandler) Create(ctx *gin.Context) {
 			return
 		}
 	default:
-		ctx.JSON(
+		h.Render(ctx,
 			http.StatusBadRequest,
 			gin.H{
 				"error": "state must be ('''|Created|Ready)",
@@ -142,7 +142,7 @@ func (h TaskGroupHandler) Create(ctx *gin.Context) {
 
 	r.With(m)
 
-	ctx.JSON(http.StatusCreated, r)
+	h.Render(ctx, http.StatusCreated, r)
 }
 
 // Update godoc
@@ -157,7 +157,7 @@ func (h TaskGroupHandler) Create(ctx *gin.Context) {
 func (h TaskGroupHandler) Update(ctx *gin.Context) {
 	id := h.pk(ctx)
 	updated := &TaskGroup{}
-	err := ctx.BindJSON(updated)
+	err := h.Bind(ctx, updated)
 	if err != nil {
 		return
 	}
@@ -182,7 +182,7 @@ func (h TaskGroupHandler) Update(ctx *gin.Context) {
 			return
 		}
 	default:
-		ctx.JSON(
+		h.Render(ctx,
 			http.StatusBadRequest,
 			gin.H{
 				"error": "state must be (Created|Ready)",

--- a/api/ticket.go
+++ b/api/ticket.go
@@ -56,7 +56,7 @@ func (h TicketHandler) Get(ctx *gin.Context) {
 
 	resource := Ticket{}
 	resource.With(m)
-	ctx.JSON(http.StatusOK, resource)
+	h.Render(ctx, http.StatusOK, resource)
 }
 
 // List godoc
@@ -89,7 +89,7 @@ func (h TicketHandler) List(ctx *gin.Context) {
 		resources = append(resources, r)
 	}
 
-	ctx.JSON(http.StatusOK, resources)
+	h.Render(ctx, http.StatusOK, resources)
 }
 
 // Create godoc
@@ -103,7 +103,7 @@ func (h TicketHandler) List(ctx *gin.Context) {
 // @param ticket body api.Ticket true "Ticket data"
 func (h TicketHandler) Create(ctx *gin.Context) {
 	r := &Ticket{}
-	err := ctx.BindJSON(r)
+	err := h.Bind(ctx, r)
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -117,7 +117,7 @@ func (h TicketHandler) Create(ctx *gin.Context) {
 	}
 	r.With(m)
 
-	ctx.JSON(http.StatusCreated, r)
+	h.Render(ctx, http.StatusCreated, r)
 }
 
 // Delete godoc

--- a/api/tracker.go
+++ b/api/tracker.go
@@ -58,7 +58,7 @@ func (h TrackerHandler) Get(ctx *gin.Context) {
 
 	resource := Tracker{}
 	resource.With(m)
-	ctx.JSON(http.StatusOK, resource)
+	h.Render(ctx, http.StatusOK, resource)
 }
 
 // List godoc
@@ -96,7 +96,7 @@ func (h TrackerHandler) List(ctx *gin.Context) {
 		resources = append(resources, r)
 	}
 
-	ctx.JSON(http.StatusOK, resources)
+	h.Render(ctx, http.StatusOK, resources)
 }
 
 // Create godoc
@@ -110,7 +110,7 @@ func (h TrackerHandler) List(ctx *gin.Context) {
 // @param tracker body api.Tracker true "Tracker data"
 func (h TrackerHandler) Create(ctx *gin.Context) {
 	r := &Tracker{}
-	err := ctx.BindJSON(r)
+	err := h.Bind(ctx, r)
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -124,7 +124,7 @@ func (h TrackerHandler) Create(ctx *gin.Context) {
 	}
 	r.With(m)
 
-	ctx.JSON(http.StatusCreated, r)
+	h.Render(ctx, http.StatusCreated, r)
 }
 
 // Delete godoc
@@ -163,7 +163,7 @@ func (h TrackerHandler) Delete(ctx *gin.Context) {
 func (h TrackerHandler) Update(ctx *gin.Context) {
 	id := h.pk(ctx)
 	r := &Tracker{}
-	err := ctx.BindJSON(r)
+	err := h.Bind(ctx, r)
 	if err != nil {
 		_ = ctx.Error(err)
 		return


### PR DESCRIPTION
POST/PUT/PATCH body format _bind_ based on Content-Type (header) supporting both JSON and YAML.
GET body format rendered based on Accept (header) supporting both JSON and YAML. Defaults to JSON. Other MIMEs specified will be coerced to JSON.

Improves support for `Accept` header matching.

[1] https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html