### PR TITLE
:seedling: Update CLI export with TagCategories

### DIFF
--- a/hack/tool/tackle
+++ b/hack/tool/tackle
@@ -711,7 +711,7 @@ class TackleTool:
         # Compatibility checks
         # TagCategories on Hub API
         if apiJSON(self.tackle2Url + "/hub/tagcategories", self.tackle2Token, ignoreErrors=True) is None:
-            print("ERROR: The API doesn't know TagCategories, use older version of this tool (before mta-6.1 branch).")
+            print("ERROR: The API doesn't know TagCategories, use older version of this tool.")
             exit(1)
 
         # TagCategories in the data directory


### PR DESCRIPTION
Updating CLI tool to use TagCategories instead of TagTypes. This update doesn't cover all new resources and Hub API changes - only fixes original export/import actions to work with current Hub API.