### PR TITLE
:seedling: Add identity, proxy bindings and enable API tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,18 +46,18 @@ jobs:
           go-version: '1.19'
       - run: make test
 
-  #test-api:
-  #  runs-on: ubuntu-latest
-  #  steps:
-  #    - uses: actions/checkout@v3
-  #    - uses: actions/setup-go@v3
-  #      with:
-  #        go-version: '1.19'
-  #    - run: |
-  #        make vet
-  #        make run &
-  #        sleep 15  # probably a dirty solution
-  #        HUB_BASE_URL=http://localhost:8080 make test-api
+  test-api:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.19'
+      - run: |
+          make vet
+          DISCONNECTED=1 make run &
+          sleep 15  # probably a dirty solution
+          HUB_BASE_URL=http://localhost:8080 make test-api
 
   test-e2e:
     runs-on: ubuntu-latest

--- a/binding/identity.go
+++ b/binding/identity.go
@@ -1,0 +1,51 @@
+package binding
+
+import (
+	"github.com/konveyor/tackle2-hub/api"
+)
+
+//
+// Identity API.
+type Identity struct {
+	// hub API client.
+	client *Client
+}
+
+//
+// Create a Identity.
+func (h *Identity) Create(r *api.Identity) (err error) {
+	err = h.client.Post(api.IdentitiesRoot, &r)
+	return
+}
+
+//
+// Get a Identity by ID.
+func (h *Identity) Get(id uint) (r *api.Identity, err error) {
+	r = &api.Identity{}
+	path := Path(api.IdentityRoot).Inject(Params{api.ID: id})
+	err = h.client.Get(path, r)
+	return
+}
+
+//
+// List Identities.
+func (h *Identity) List() (list []api.Identity, err error) {
+	list = []api.Identity{}
+	err = h.client.Get(api.IdentitiesRoot, &list)
+	return
+}
+
+//
+// Update a Identity.
+func (h *Identity) Update(r *api.Identity) (err error) {
+	path := Path(api.IdentityRoot).Inject(Params{api.ID: r.ID})
+	err = h.client.Put(path, r)
+	return
+}
+
+//
+// Delete a Identity.
+func (h *Identity) Delete(id uint) (err error) {
+	err = h.client.Delete(Path(api.IdentityRoot).Inject(Params{api.ID: id}))
+	return
+}

--- a/binding/proxy.go
+++ b/binding/proxy.go
@@ -1,0 +1,51 @@
+package binding
+
+import (
+	"github.com/konveyor/tackle2-hub/api"
+)
+
+//
+// Proxy API.
+type Proxy struct {
+	// hub API client.
+	client *Client
+}
+
+//
+// Create a Proxy.
+func (h *Proxy) Create(r *api.Proxy) (err error) {
+	err = h.client.Post(api.ProxiesRoot, &r)
+	return
+}
+
+//
+// Get a Proxy by ID.
+func (h *Proxy) Get(id uint) (r *api.Proxy, err error) {
+	r = &api.Proxy{}
+	path := Path(api.ProxyRoot).Inject(Params{api.ID: id})
+	err = h.client.Get(path, r)
+	return
+}
+
+//
+// List Proxies.
+func (h *Proxy) List() (list []api.Proxy, err error) {
+	list = []api.Proxy{}
+	err = h.client.Get(api.ProxiesRoot, &list)
+	return
+}
+
+//
+// Update a Proxy.
+func (h *Proxy) Update(r *api.Proxy) (err error) {
+	path := Path(api.ProxyRoot).Inject(Params{api.ID: r.ID})
+	err = h.client.Put(path, r)
+	return
+}
+
+//
+// Delete a Proxy.
+func (h *Proxy) Delete(id uint) (err error) {
+	err = h.client.Delete(Path(api.ProxyRoot).Inject(Params{api.ID: id}))
+	return
+}

--- a/binding/richclient.go
+++ b/binding/richclient.go
@@ -23,7 +23,9 @@ type RichClient struct {
 	// Resources APIs.
 	Application      Application
 	BusinessService  BusinessService
+	Identity         Identity
 	JobFunction      JobFunction
+	Proxy            Proxy
 	Stakeholder      Stakeholder
 	StakeholderGroup StakeholderGroup
 	Tag              Tag
@@ -54,7 +56,13 @@ func New(baseUrl string) (r *RichClient) {
 		BusinessService: BusinessService{
 			client: client,
 		},
+		Identity: Identity{
+			client: client,
+		},
 		JobFunction: JobFunction{
+			client: client,
+		},
+		Proxy: Proxy{
 			client: client,
 		},
 		Stakeholder: Stakeholder{


### PR DESCRIPTION
Adding identity and proxy methods to binding package. Enabling Hub API test execution on PRs ```Build Hub / test-api (pull_request)``` (in disconnected mode).

Follow-up on https://github.com/konveyor/tackle2-hub/pull/268