### PR TITLE
:bug: Fix analysis pagination; cannot use offset > 0 with count.

### DIFF
--- a/api/analysis.go
+++ b/api/analysis.go
@@ -235,7 +235,8 @@ func (h AnalysisHandler) AppDeps(ctx *gin.Context) {
 	// Latest.
 	id := h.pk(ctx)
 	analysis := &model.Analysis{}
-	db := h.DB(ctx).Where("ApplicationID = ?", id)
+	db := h.DB(ctx)
+	db = db.Where("ApplicationID = ?", id)
 	result := db.Last(analysis)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)
@@ -255,7 +256,7 @@ func (h AnalysisHandler) AppDeps(ctx *gin.Context) {
 		_ = ctx.Error(err)
 		return
 	}
-	db = h.Paginated(ctx)
+	db = h.DB(ctx)
 	db = db.Where("AnalysisID = ?", analysis.ID)
 	db = filter.Where(db)
 	// Count.
@@ -276,6 +277,7 @@ func (h AnalysisHandler) AppDeps(ctx *gin.Context) {
 	}
 	// Find.
 	list := []model.AnalysisDependency{}
+	db = h.paginated(ctx, db)
 	result = db.Find(&list)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)
@@ -328,7 +330,7 @@ func (h AnalysisHandler) AppIssues(ctx *gin.Context) {
 		_ = ctx.Error(err)
 		return
 	}
-	db = h.Paginated(ctx)
+	db = h.DB(ctx)
 	ruleSet := h.DB(ctx)
 	ruleSet = ruleSet.Model(&model.AnalysisRuleSet{})
 	ruleSet = ruleSet.Select("ID")
@@ -353,6 +355,7 @@ func (h AnalysisHandler) AppIssues(ctx *gin.Context) {
 	}
 	// Find.
 	list := []model.AnalysisIssue{}
+	db = h.paginated(ctx, db)
 	result = db.Find(&list)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)
@@ -405,7 +408,7 @@ func (h AnalysisHandler) Issues(ctx *gin.Context) {
 		_ = ctx.Error(err)
 		return
 	}
-	db := h.Paginated(ctx)
+	db := h.DB(ctx)
 	db = db.Table("AnalysisIssue i,")
 	db = db.Joins("AnalysisRuleSet r,")
 	db = db.Joins("Analysis a")
@@ -429,10 +432,13 @@ func (h AnalysisHandler) Issues(ctx *gin.Context) {
 		_ = ctx.Error(err)
 		return
 	}
+	//
+	// Find.
 	type M struct {
 		model.AnalysisIssue
 		ApplicationID uint
 	}
+	db = h.paginated(ctx, db)
 	db = db.Select(
 		"i.*",
 		"a.ApplicationID")
@@ -647,7 +653,7 @@ func (h AnalysisHandler) Deps(ctx *gin.Context) {
 		_ = ctx.Error(err)
 		return
 	}
-	db := h.Paginated(ctx)
+	db := h.DB(ctx)
 	db = db.Where("AnalysisID IN (?)", h.analysisIDs(ctx, &filter))
 	db = filter.Where(db)
 	// Count.
@@ -667,6 +673,7 @@ func (h AnalysisHandler) Deps(ctx *gin.Context) {
 		return
 	}
 	// Find.
+	db = h.paginated(ctx, db)
 	list := []model.AnalysisDependency{}
 	result = db.Find(&list)
 	if result.Error != nil {
@@ -715,7 +722,7 @@ func (h AnalysisHandler) DepComposites(ctx *gin.Context) {
 		_ = ctx.Error(err)
 		return
 	}
-	db := h.Paginated(ctx)
+	db := h.DB(ctx)
 	db = db.Where("AnalysisID IN (?)", h.analysisIDs(ctx, &filter))
 	db = filter.Where(db)
 	db = db.Select(
@@ -750,6 +757,7 @@ func (h AnalysisHandler) DepComposites(ctx *gin.Context) {
 		return
 	}
 	// Find.
+	db = h.paginated(ctx, db)
 	result = db.Find(&resources)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)

--- a/api/base.go
+++ b/api/base.go
@@ -41,15 +41,9 @@ func (h *BaseHandler) Client(ctx *gin.Context) (client client.Client) {
 }
 
 //
-// Paginated returns a paginated & sorted DB client.
+// Paginated returns a paginated AND sorted DB client.
 func (h *BaseHandler) Paginated(ctx *gin.Context) (db *gorm.DB) {
-	p := Page{}
-	p.With(ctx)
-	db = h.DB(ctx)
-	db = p.Paginated(db)
-	sort := Sort{}
-	sort.With(ctx)
-	db = sort.Sorted(db)
+	db = h.paginated(ctx, h.DB(ctx))
 	return
 }
 
@@ -86,6 +80,18 @@ func (h *BaseHandler) WithCount(ctx *gin.Context, count int64) (err error) {
 	mp[Total] = []string{
 		strconv.Itoa(int(count)),
 	}
+	return
+}
+
+//
+// Paginated returns a paginated AND sorted DB client.
+func (h *BaseHandler) paginated(ctx *gin.Context, in *gorm.DB) (db *gorm.DB) {
+	p := Page{}
+	p.With(ctx)
+	db = p.Paginated(in)
+	sort := Sort{}
+	sort.With(ctx)
+	db = sort.Sorted(db)
 	return
 }
 


### PR DESCRIPTION
Fix analysis pagination; cannot use offset > 0 with count (face-palm).
For each of the 6 methods, the DB used for count must not be paginated.
Seems this pattern will not be limited to only the analysis endpoints:
1. db := h.DB()
2. count = db.Count()
3. WithCount(count)  // checks the total and sets x-total header.
4. db = h.paginated(db)
5. db.Find()

We'll likely never use the h.Paginated() method but leaving it for now.