### PR TITLE
:bug: Update Swagger fix array/single, add analysis

### DIFF
--- a/api/analysis.go
+++ b/api/analysis.go
@@ -119,7 +119,7 @@ func (h AnalysisHandler) AppLatest(ctx *gin.Context) {
 // @description Resources do not include relations.
 // @tags analyses
 // @produce json
-// @success 200 {object} []api.Analyses
+// @success 200 {object} []api.Analysis
 // @router /analyses [get]
 func (h AnalysisHandler) AppList(ctx *gin.Context) {
 	resources := []Analysis{}
@@ -227,7 +227,7 @@ func (h AnalysisHandler) Delete(ctx *gin.Context) {
 // @description - indirect
 // @tags dependencies
 // @produce json
-// @success 200 {object} []api.AnalysesDependency
+// @success 200 {object} []api.AnalysisDependency
 // @router /application/{id}/analysis/dependencies [get]
 // @param id path string true "Application ID"
 func (h AnalysisHandler) AppDeps(ctx *gin.Context) {
@@ -303,7 +303,7 @@ func (h AnalysisHandler) AppDeps(ctx *gin.Context) {
 // @description - effort
 // @tags issues
 // @produce json
-// @success 200 {object} []api.AnalysesIssue
+// @success 200 {object} []api.AnalysisIssue
 // @router /application/{id}/analysis/issues [get]
 // @param id path string true "Application ID"
 func (h AnalysisHandler) AppIssues(ctx *gin.Context) {
@@ -385,7 +385,7 @@ func (h AnalysisHandler) AppIssues(ctx *gin.Context) {
 // @description - tag.id
 // @tags issues
 // @produce json
-// @success 200 {object} []api.AnalysesIssue
+// @success 200 {object} []api.AnalysisIssue
 // @router /analyses/issues [get]
 func (h AnalysisHandler) Issues(ctx *gin.Context) {
 	resources := []AnalysisIssue{}
@@ -633,7 +633,7 @@ func (h AnalysisHandler) IssueComposites(ctx *gin.Context) {
 // @description - tag.id
 // @tags dependencies
 // @produce json
-// @success 200 {object} []api.AnalysesDependency
+// @success 200 {object} []api.AnalysisDependency
 // @router /analyses/dependencies [get]
 func (h AnalysisHandler) Deps(ctx *gin.Context) {
 	resources := []AnalysisDependency{}
@@ -702,7 +702,7 @@ func (h AnalysisHandler) Deps(ctx *gin.Context) {
 // @description - tag.id
 // @tags dependencies
 // @produce json
-// @success 200 {object} []api.AnalysesDependency
+// @success 200 {object} []api.AnalysisDependency
 // @router /analyses/dependencies [get]
 func (h AnalysisHandler) DepComposites(ctx *gin.Context) {
 	resources := []DepComposite{}

--- a/api/group.go
+++ b/api/group.go
@@ -53,7 +53,7 @@ func (h StakeholderGroupHandler) Get(ctx *gin.Context) {
 	r := StakeholderGroup{}
 	r.With(m)
 
-	h.Respond(ctx, http.StatusOK, m)
+	h.Respond(ctx, http.StatusOK, r)
 }
 
 // List godoc

--- a/api/jobfunction.go
+++ b/api/jobfunction.go
@@ -38,7 +38,7 @@ func (h JobFunctionHandler) AddRoutes(e *gin.Engine) {
 // @description Get a job function by ID.
 // @tags jobfunctions
 // @produce json
-// @success 200 {object} []api.JobFunction
+// @success 200 {object} api.JobFunction
 // @router /jobfunctions/{id} [get]
 // @param id path string true "Job Function ID"
 func (h JobFunctionHandler) Get(ctx *gin.Context) {

--- a/api/review.go
+++ b/api/review.go
@@ -40,7 +40,7 @@ func (h ReviewHandler) AddRoutes(e *gin.Engine) {
 // @description Get a review by ID.
 // @tags reviews
 // @produce json
-// @success 200 {object} []api.Review
+// @success 200 {object} api.Review
 // @router /reviews/{id} [get]
 // @param id path string true "Review ID"
 func (h ReviewHandler) Get(ctx *gin.Context) {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -97,6 +97,223 @@ const docTemplate = `{
                 }
             }
         },
+        "/analyses": {
+            "get": {
+                "description": "List analyses for an application.\nResources do not include relations.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "analyses"
+                ],
+                "summary": "List analyses.",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/api.Analysis"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/analyses/dependencies": {
+            "get": {
+                "description": "List dependency composites.\nfilters:\n- name\n- version\n- type\n- sha\n- indirect\n- application.(id|name)\n- tag.id",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "dependencies"
+                ],
+                "summary": "List dependency composites.",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/api.AnalysisDependency"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/analyses/issues": {
+            "get": {
+                "description": "List issue composites.\nfilters:\n- category\n- effort\n- application.(id|name)\n- tech.(source|target)\n- tag.id",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "issuecomposites"
+                ],
+                "summary": "List issue composites.",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/api.IssueComposite"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/analyses/{id}": {
+            "get": {
+                "description": "Get an analysis (report) by ID.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "analyses"
+                ],
+                "summary": "Get an analysis (report) by ID.",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Analysis ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.Analysis"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Delete an analysis by ID.",
+                "tags": [
+                    "analyses"
+                ],
+                "summary": "Delete an analysis by ID.",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Analysis ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/application/{id}/analyses": {
+            "post": {
+                "description": "Create an analysis.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "analyses"
+                ],
+                "summary": "Create an analysis.",
+                "parameters": [
+                    {
+                        "description": "Analysis data",
+                        "name": "task",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.Analysis"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/api.Analysis"
+                        }
+                    }
+                }
+            }
+        },
+        "/application/{id}/analysis/dependencies": {
+            "get": {
+                "description": "List application dependencies.\nfilters:\n- id\n- name\n- version\n- type\n- sha\n- indirect",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "dependencies"
+                ],
+                "summary": "List application dependencies.",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Application ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/api.AnalysisDependency"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/application/{id}/analysis/issues": {
+            "get": {
+                "description": "List application issues.\nfilters:\n- id\n- ruleid\n- name\n- category\n- effort",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "issues"
+                ],
+                "summary": "List application issues.",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Application ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/api.AnalysisIssue"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/applications": {
             "get": {
                 "description": "List all applications.",
@@ -173,7 +390,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -235,7 +452,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -256,7 +473,36 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/applications/{id}/analysis": {
+            "get": {
+                "description": "Get the latest analysis for an application.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "analyses"
+                ],
+                "summary": "Get the latest analysis.",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Application ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.Analysis"
+                        }
                     }
                 }
             }
@@ -288,7 +534,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK"
+                        "description": ""
                     }
                 }
             },
@@ -312,7 +558,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -336,7 +582,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -402,7 +648,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -438,7 +684,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "201": {
-                        "description": "Created"
+                        "description": ""
                     }
                 }
             }
@@ -490,7 +736,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -527,7 +773,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -602,7 +848,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -678,7 +924,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -740,7 +986,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -959,7 +1205,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -991,7 +1237,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK"
+                        "description": ""
                     }
                 }
             },
@@ -1015,7 +1261,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -1039,7 +1285,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -1153,7 +1399,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -1174,7 +1420,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -1191,7 +1437,7 @@ const docTemplate = `{
                 "summary": "Delete a directory within the cache.",
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -1328,7 +1574,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -1431,7 +1677,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -1548,7 +1794,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -1569,7 +1815,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -1642,7 +1888,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -1764,7 +2010,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -1847,10 +2093,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/api.JobFunction"
-                            }
+                            "$ref": "#/definitions/api.JobFunction"
                         }
                     }
                 }
@@ -1884,7 +2127,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -1905,7 +2148,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -2022,7 +2265,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -2043,7 +2286,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -2160,7 +2403,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -2181,7 +2424,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -2264,7 +2507,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -2292,10 +2535,7 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/api.Review"
-                            }
+                            "$ref": "#/definitions/api.Review"
                         }
                     }
                 }
@@ -2329,7 +2569,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -2350,7 +2590,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -2467,7 +2707,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -2488,7 +2728,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -2619,7 +2859,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -2645,7 +2885,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "201": {
-                        "description": "Created"
+                        "description": ""
                     }
                 }
             },
@@ -2666,7 +2906,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -2783,7 +3023,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -2804,7 +3044,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -2921,7 +3161,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -2942,7 +3182,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -3067,7 +3307,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -3088,7 +3328,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -3243,7 +3483,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -3264,7 +3504,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -3381,7 +3621,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -3402,7 +3642,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -3434,7 +3674,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK"
+                        "description": ""
                     }
                 }
             },
@@ -3458,7 +3698,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -3482,7 +3722,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -3516,7 +3756,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -3633,7 +3873,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -3654,7 +3894,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -3686,7 +3926,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK"
+                        "description": ""
                     }
                 }
             },
@@ -3710,7 +3950,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -3734,7 +3974,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -3757,7 +3997,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -3864,7 +4104,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -3898,7 +4138,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -4003,7 +4243,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -4120,7 +4360,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -4141,7 +4381,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -4155,6 +4395,234 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.Analysis": {
+            "type": "object",
+            "properties": {
+                "createTime": {
+                    "type": "string"
+                },
+                "createUser": {
+                    "type": "string"
+                },
+                "dependencies": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.AnalysisDependency"
+                    }
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "ruleSets": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.AnalysisRuleSet"
+                    }
+                },
+                "updateUser": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.AnalysisDependency": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "createTime": {
+                    "type": "string"
+                },
+                "createUser": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "indirect": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "sha": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "updateUser": {
+                    "type": "string"
+                },
+                "version": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.AnalysisIncident": {
+            "type": "object",
+            "properties": {
+                "createTime": {
+                    "type": "string"
+                },
+                "createUser": {
+                    "type": "string"
+                },
+                "facts": {
+                    "$ref": "#/definitions/api.FactMap"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "updateUser": {
+                    "type": "string"
+                },
+                "uri": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.AnalysisIssue": {
+            "type": "object",
+            "required": [
+                "category",
+                "name"
+            ],
+            "properties": {
+                "application": {
+                    "type": "integer"
+                },
+                "category": {
+                    "type": "string"
+                },
+                "createTime": {
+                    "type": "string"
+                },
+                "createUser": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "effort": {
+                    "type": "integer"
+                },
+                "facts": {
+                    "$ref": "#/definitions/api.FactMap"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "incidents": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.AnalysisIncident"
+                    }
+                },
+                "labels": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "links": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.AnalysisLink"
+                    }
+                },
+                "name": {
+                    "type": "string"
+                },
+                "ruleId": {
+                    "type": "string"
+                },
+                "updateUser": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.AnalysisLink": {
+            "type": "object",
+            "properties": {
+                "title": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.AnalysisRuleSet": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "createTime": {
+                    "type": "string"
+                },
+                "createUser": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "issues": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.AnalysisIssue"
+                    }
+                },
+                "name": {
+                    "type": "string"
+                },
+                "technologies": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.AnalysisTechnology"
+                    }
+                },
+                "updateUser": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.AnalysisTechnology": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "createTime": {
+                    "type": "string"
+                },
+                "createUser": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "boolean"
+                },
+                "updateUser": {
+                    "type": "string"
+                },
+                "version": {
                     "type": "string"
                 }
             }
@@ -4352,6 +4820,10 @@ const docTemplate = `{
                 "value": {}
             }
         },
+        "api.FactMap": {
+            "type": "object",
+            "additionalProperties": true
+        },
         "api.Fields": {
             "type": "object",
             "additionalProperties": true
@@ -4460,6 +4932,41 @@ const docTemplate = `{
                 },
                 "validCount": {
                     "type": "integer"
+                }
+            }
+        },
+        "api.IssueComposite": {
+            "type": "object",
+            "properties": {
+                "affected": {
+                    "type": "integer"
+                },
+                "category": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "effort": {
+                    "type": "integer"
+                },
+                "labels": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "name": {
+                    "type": "string"
+                },
+                "ruleID": {
+                    "type": "string"
+                },
+                "technologies": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.AnalysisTechnology"
+                    }
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -85,6 +85,223 @@
                 }
             }
         },
+        "/analyses": {
+            "get": {
+                "description": "List analyses for an application.\nResources do not include relations.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "analyses"
+                ],
+                "summary": "List analyses.",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/api.Analysis"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/analyses/dependencies": {
+            "get": {
+                "description": "List dependency composites.\nfilters:\n- name\n- version\n- type\n- sha\n- indirect\n- application.(id|name)\n- tag.id",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "dependencies"
+                ],
+                "summary": "List dependency composites.",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/api.AnalysisDependency"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/analyses/issues": {
+            "get": {
+                "description": "List issue composites.\nfilters:\n- category\n- effort\n- application.(id|name)\n- tech.(source|target)\n- tag.id",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "issuecomposites"
+                ],
+                "summary": "List issue composites.",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/api.IssueComposite"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/analyses/{id}": {
+            "get": {
+                "description": "Get an analysis (report) by ID.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "analyses"
+                ],
+                "summary": "Get an analysis (report) by ID.",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Analysis ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.Analysis"
+                        }
+                    }
+                }
+            },
+            "delete": {
+                "description": "Delete an analysis by ID.",
+                "tags": [
+                    "analyses"
+                ],
+                "summary": "Delete an analysis by ID.",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Analysis ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/application/{id}/analyses": {
+            "post": {
+                "description": "Create an analysis.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "analyses"
+                ],
+                "summary": "Create an analysis.",
+                "parameters": [
+                    {
+                        "description": "Analysis data",
+                        "name": "task",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/api.Analysis"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/api.Analysis"
+                        }
+                    }
+                }
+            }
+        },
+        "/application/{id}/analysis/dependencies": {
+            "get": {
+                "description": "List application dependencies.\nfilters:\n- id\n- name\n- version\n- type\n- sha\n- indirect",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "dependencies"
+                ],
+                "summary": "List application dependencies.",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Application ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/api.AnalysisDependency"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/application/{id}/analysis/issues": {
+            "get": {
+                "description": "List application issues.\nfilters:\n- id\n- ruleid\n- name\n- category\n- effort",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "issues"
+                ],
+                "summary": "List application issues.",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Application ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/api.AnalysisIssue"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/applications": {
             "get": {
                 "description": "List all applications.",
@@ -161,7 +378,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -223,7 +440,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -244,7 +461,36 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/applications/{id}/analysis": {
+            "get": {
+                "description": "Get the latest analysis for an application.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "analyses"
+                ],
+                "summary": "Get the latest analysis.",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Application ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/api.Analysis"
+                        }
                     }
                 }
             }
@@ -276,7 +522,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK"
+                        "description": ""
                     }
                 }
             },
@@ -300,7 +546,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -324,7 +570,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -390,7 +636,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -426,7 +672,7 @@
                 ],
                 "responses": {
                     "201": {
-                        "description": "Created"
+                        "description": ""
                     }
                 }
             }
@@ -478,7 +724,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -515,7 +761,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -590,7 +836,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -666,7 +912,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -728,7 +974,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -947,7 +1193,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -979,7 +1225,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK"
+                        "description": ""
                     }
                 }
             },
@@ -1003,7 +1249,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -1027,7 +1273,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -1141,7 +1387,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -1162,7 +1408,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -1179,7 +1425,7 @@
                 "summary": "Delete a directory within the cache.",
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -1316,7 +1562,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -1419,7 +1665,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -1536,7 +1782,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -1557,7 +1803,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -1630,7 +1876,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -1752,7 +1998,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -1835,10 +2081,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/api.JobFunction"
-                            }
+                            "$ref": "#/definitions/api.JobFunction"
                         }
                     }
                 }
@@ -1872,7 +2115,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -1893,7 +2136,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -2010,7 +2253,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -2031,7 +2274,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -2148,7 +2391,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -2169,7 +2412,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -2252,7 +2495,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -2280,10 +2523,7 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/api.Review"
-                            }
+                            "$ref": "#/definitions/api.Review"
                         }
                     }
                 }
@@ -2317,7 +2557,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -2338,7 +2578,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -2455,7 +2695,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -2476,7 +2716,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -2607,7 +2847,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -2633,7 +2873,7 @@
                 ],
                 "responses": {
                     "201": {
-                        "description": "Created"
+                        "description": ""
                     }
                 }
             },
@@ -2654,7 +2894,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -2771,7 +3011,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -2792,7 +3032,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -2909,7 +3149,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -2930,7 +3170,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -3055,7 +3295,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -3076,7 +3316,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -3231,7 +3471,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -3252,7 +3492,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -3369,7 +3609,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -3390,7 +3630,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -3422,7 +3662,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK"
+                        "description": ""
                     }
                 }
             },
@@ -3446,7 +3686,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -3470,7 +3710,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -3504,7 +3744,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -3621,7 +3861,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -3642,7 +3882,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -3674,7 +3914,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK"
+                        "description": ""
                     }
                 }
             },
@@ -3698,7 +3938,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -3722,7 +3962,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -3745,7 +3985,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -3852,7 +4092,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -3886,7 +4126,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -3991,7 +4231,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -4108,7 +4348,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             },
@@ -4129,7 +4369,7 @@
                 ],
                 "responses": {
                     "204": {
-                        "description": "No Content"
+                        "description": ""
                     }
                 }
             }
@@ -4143,6 +4383,234 @@
                     "type": "string"
                 },
                 "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.Analysis": {
+            "type": "object",
+            "properties": {
+                "createTime": {
+                    "type": "string"
+                },
+                "createUser": {
+                    "type": "string"
+                },
+                "dependencies": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.AnalysisDependency"
+                    }
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "ruleSets": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.AnalysisRuleSet"
+                    }
+                },
+                "updateUser": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.AnalysisDependency": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "createTime": {
+                    "type": "string"
+                },
+                "createUser": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "indirect": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "sha": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                },
+                "updateUser": {
+                    "type": "string"
+                },
+                "version": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.AnalysisIncident": {
+            "type": "object",
+            "properties": {
+                "createTime": {
+                    "type": "string"
+                },
+                "createUser": {
+                    "type": "string"
+                },
+                "facts": {
+                    "$ref": "#/definitions/api.FactMap"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "updateUser": {
+                    "type": "string"
+                },
+                "uri": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.AnalysisIssue": {
+            "type": "object",
+            "required": [
+                "category",
+                "name"
+            ],
+            "properties": {
+                "application": {
+                    "type": "integer"
+                },
+                "category": {
+                    "type": "string"
+                },
+                "createTime": {
+                    "type": "string"
+                },
+                "createUser": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "effort": {
+                    "type": "integer"
+                },
+                "facts": {
+                    "$ref": "#/definitions/api.FactMap"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "incidents": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.AnalysisIncident"
+                    }
+                },
+                "labels": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "links": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.AnalysisLink"
+                    }
+                },
+                "name": {
+                    "type": "string"
+                },
+                "ruleId": {
+                    "type": "string"
+                },
+                "updateUser": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.AnalysisLink": {
+            "type": "object",
+            "properties": {
+                "title": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.AnalysisRuleSet": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "createTime": {
+                    "type": "string"
+                },
+                "createUser": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "issues": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.AnalysisIssue"
+                    }
+                },
+                "name": {
+                    "type": "string"
+                },
+                "technologies": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.AnalysisTechnology"
+                    }
+                },
+                "updateUser": {
+                    "type": "string"
+                }
+            }
+        },
+        "api.AnalysisTechnology": {
+            "type": "object",
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "createTime": {
+                    "type": "string"
+                },
+                "createUser": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "source": {
+                    "type": "boolean"
+                },
+                "updateUser": {
+                    "type": "string"
+                },
+                "version": {
                     "type": "string"
                 }
             }
@@ -4340,6 +4808,10 @@
                 "value": {}
             }
         },
+        "api.FactMap": {
+            "type": "object",
+            "additionalProperties": true
+        },
         "api.Fields": {
             "type": "object",
             "additionalProperties": true
@@ -4448,6 +4920,41 @@
                 },
                 "validCount": {
                     "type": "integer"
+                }
+            }
+        },
+        "api.IssueComposite": {
+            "type": "object",
+            "properties": {
+                "affected": {
+                    "type": "integer"
+                },
+                "category": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "effort": {
+                    "type": "integer"
+                },
+                "labels": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "name": {
+                    "type": "string"
+                },
+                "ruleID": {
+                    "type": "string"
+                },
+                "technologies": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/api.AnalysisTechnology"
+                    }
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -6,6 +6,156 @@ definitions:
       name:
         type: string
     type: object
+  api.Analysis:
+    properties:
+      createTime:
+        type: string
+      createUser:
+        type: string
+      dependencies:
+        items:
+          $ref: '#/definitions/api.AnalysisDependency'
+        type: array
+      id:
+        type: integer
+      ruleSets:
+        items:
+          $ref: '#/definitions/api.AnalysisRuleSet'
+        type: array
+      updateUser:
+        type: string
+    type: object
+  api.AnalysisDependency:
+    properties:
+      createTime:
+        type: string
+      createUser:
+        type: string
+      id:
+        type: integer
+      indirect:
+        type: boolean
+      name:
+        type: string
+      sha:
+        type: string
+      type:
+        type: string
+      updateUser:
+        type: string
+      version:
+        type: string
+    required:
+    - name
+    type: object
+  api.AnalysisIncident:
+    properties:
+      createTime:
+        type: string
+      createUser:
+        type: string
+      facts:
+        $ref: '#/definitions/api.FactMap'
+      id:
+        type: integer
+      message:
+        type: string
+      updateUser:
+        type: string
+      uri:
+        type: string
+    type: object
+  api.AnalysisIssue:
+    properties:
+      application:
+        type: integer
+      category:
+        type: string
+      createTime:
+        type: string
+      createUser:
+        type: string
+      description:
+        type: string
+      effort:
+        type: integer
+      facts:
+        $ref: '#/definitions/api.FactMap'
+      id:
+        type: integer
+      incidents:
+        items:
+          $ref: '#/definitions/api.AnalysisIncident'
+        type: array
+      labels:
+        items:
+          type: string
+        type: array
+      links:
+        items:
+          $ref: '#/definitions/api.AnalysisLink'
+        type: array
+      name:
+        type: string
+      ruleId:
+        type: string
+      updateUser:
+        type: string
+    required:
+    - category
+    - name
+    type: object
+  api.AnalysisLink:
+    properties:
+      title:
+        type: string
+      url:
+        type: string
+    type: object
+  api.AnalysisRuleSet:
+    properties:
+      createTime:
+        type: string
+      createUser:
+        type: string
+      description:
+        type: string
+      id:
+        type: integer
+      issues:
+        items:
+          $ref: '#/definitions/api.AnalysisIssue'
+        type: array
+      name:
+        type: string
+      technologies:
+        items:
+          $ref: '#/definitions/api.AnalysisTechnology'
+        type: array
+      updateUser:
+        type: string
+    required:
+    - name
+    type: object
+  api.AnalysisTechnology:
+    properties:
+      createTime:
+        type: string
+      createUser:
+        type: string
+      id:
+        type: integer
+      name:
+        type: string
+      source:
+        type: boolean
+      updateUser:
+        type: string
+      version:
+        type: string
+    required:
+    - name
+    type: object
   api.Application:
     properties:
       binary:
@@ -133,6 +283,9 @@ definitions:
         type: string
       value: {}
     type: object
+  api.FactMap:
+    additionalProperties: true
+    type: object
   api.Fields:
     additionalProperties: true
     type: object
@@ -206,6 +359,29 @@ definitions:
         type: string
       validCount:
         type: integer
+    type: object
+  api.IssueComposite:
+    properties:
+      affected:
+        type: integer
+      category:
+        type: string
+      description:
+        type: string
+      effort:
+        type: integer
+      labels:
+        items:
+          type: string
+        type: array
+      name:
+        type: string
+      ruleID:
+        type: string
+      technologies:
+        items:
+          $ref: '#/definitions/api.AnalysisTechnology'
+        type: array
     type: object
   api.JobFunction:
     properties:
@@ -792,6 +968,181 @@ paths:
       summary: Generate an application dependency graph arranged in topological order.
       tags:
       - adoptionplans
+  /analyses:
+    get:
+      description: |-
+        List analyses for an application.
+        Resources do not include relations.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/api.Analysis'
+            type: array
+      summary: List analyses.
+      tags:
+      - analyses
+  /analyses/{id}:
+    delete:
+      description: Delete an analysis by ID.
+      parameters:
+      - description: Analysis ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "204":
+          description: ""
+      summary: Delete an analysis by ID.
+      tags:
+      - analyses
+    get:
+      description: Get an analysis (report) by ID.
+      parameters:
+      - description: Analysis ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.Analysis'
+      summary: Get an analysis (report) by ID.
+      tags:
+      - analyses
+  /analyses/dependencies:
+    get:
+      description: |-
+        List dependency composites.
+        filters:
+        - name
+        - version
+        - type
+        - sha
+        - indirect
+        - application.(id|name)
+        - tag.id
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/api.AnalysisDependency'
+            type: array
+      summary: List dependency composites.
+      tags:
+      - dependencies
+  /analyses/issues:
+    get:
+      description: |-
+        List issue composites.
+        filters:
+        - category
+        - effort
+        - application.(id|name)
+        - tech.(source|target)
+        - tag.id
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/api.IssueComposite'
+            type: array
+      summary: List issue composites.
+      tags:
+      - issuecomposites
+  /application/{id}/analyses:
+    post:
+      consumes:
+      - application/json
+      description: Create an analysis.
+      parameters:
+      - description: Analysis data
+        in: body
+        name: task
+        required: true
+        schema:
+          $ref: '#/definitions/api.Analysis'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/api.Analysis'
+      summary: Create an analysis.
+      tags:
+      - analyses
+  /application/{id}/analysis/dependencies:
+    get:
+      description: |-
+        List application dependencies.
+        filters:
+        - id
+        - name
+        - version
+        - type
+        - sha
+        - indirect
+      parameters:
+      - description: Application ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/api.AnalysisDependency'
+            type: array
+      summary: List application dependencies.
+      tags:
+      - dependencies
+  /application/{id}/analysis/issues:
+    get:
+      description: |-
+        List application issues.
+        filters:
+        - id
+        - ruleid
+        - name
+        - category
+        - effort
+      parameters:
+      - description: Application ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/api.AnalysisIssue'
+            type: array
+      summary: List application issues.
+      tags:
+      - issues
   /applications:
     delete:
       description: Delete applications.
@@ -806,7 +1157,7 @@ paths:
           type: array
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Delete a applications.
       tags:
       - applications
@@ -856,7 +1207,7 @@ paths:
         type: integer
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Delete an application.
       tags:
       - applications
@@ -896,10 +1247,29 @@ paths:
           $ref: '#/definitions/api.Application'
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Update an application.
       tags:
       - applications
+  /applications/{id}/analysis:
+    get:
+      description: Get the latest analysis for an application.
+      parameters:
+      - description: Application ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/api.Analysis'
+      summary: Get the latest analysis.
+      tags:
+      - analyses
   /applications/{id}/bucket/{wildcard}:
     delete:
       description: Delete bucket content by ID and path.
@@ -913,7 +1283,7 @@ paths:
       - application/json
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Delete bucket content by ID and path.
       tags:
       - applications
@@ -936,7 +1306,7 @@ paths:
       - application/octet-stream
       responses:
         "200":
-          description: OK
+          description: ""
       summary: Get bucket content by ID and path.
       tags:
       - applications
@@ -953,7 +1323,7 @@ paths:
       - application/json
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Upload bucket content by ID and path.
       tags:
       - applications
@@ -1004,7 +1374,7 @@ paths:
       - application/json
       responses:
         "201":
-          description: Created
+          description: ""
       summary: Create a fact.
       tags:
       - applications
@@ -1023,7 +1393,7 @@ paths:
         type: string
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Replace all facts from a source.
       tags:
       - applications
@@ -1058,7 +1428,7 @@ paths:
       - application/json
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Update (or create) a fact.
       tags:
       - applications
@@ -1083,7 +1453,7 @@ paths:
         type: string
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Delete a fact.
       tags:
       - applications
@@ -1133,7 +1503,7 @@ paths:
           $ref: '#/definitions/api.Stakeholders'
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Update the owner and contributors of an Application.
       tags:
       - applications
@@ -1162,7 +1532,7 @@ paths:
           type: array
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Replace tag associations.
       tags:
       - applications
@@ -1203,7 +1573,7 @@ paths:
         type: string
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Delete tag association.
       tags:
       - applications
@@ -1350,7 +1720,7 @@ paths:
         type: string
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Delete a bucket.
       tags:
       - buckets
@@ -1389,7 +1759,7 @@ paths:
       - application/json
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Delete bucket content by ID and path.
       tags:
       - buckets
@@ -1414,7 +1784,7 @@ paths:
       - application/octet-stream
       responses:
         "200":
-          description: OK
+          description: ""
       summary: Get bucket content by ID and path.
       tags:
       - buckets
@@ -1431,7 +1801,7 @@ paths:
       - application/json
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Upload bucket content by ID and path.
       tags:
       - buckets
@@ -1480,7 +1850,7 @@ paths:
         type: string
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Delete a business service.
       tags:
       - businessservices
@@ -1520,7 +1890,7 @@ paths:
           $ref: '#/definitions/api.BusinessService'
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Update a business service.
       tags:
       - businessservices
@@ -1531,7 +1901,7 @@ paths:
       - application/json
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Delete a directory within the cache.
       tags:
       - cache
@@ -1603,7 +1973,7 @@ paths:
         type: string
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Delete a dependency.
       tags:
       - dependencies
@@ -1671,7 +2041,7 @@ paths:
         type: string
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Delete a file.
       tags:
       - file
@@ -1741,7 +2111,7 @@ paths:
         type: string
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Delete an identity.
       tags:
       - identities
@@ -1781,7 +2151,7 @@ paths:
           $ref: '#/definitions/api.Identity'
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Update an identity.
       tags:
       - identities
@@ -1811,7 +2181,7 @@ paths:
         type: string
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Delete an import.
       tags:
       - imports
@@ -1859,7 +2229,7 @@ paths:
         type: string
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Delete an import summary and associated import records.
       tags:
       - imports
@@ -1960,7 +2330,7 @@ paths:
         type: string
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Delete a job function.
       tags:
       - jobfunctions
@@ -1978,9 +2348,7 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              $ref: '#/definitions/api.JobFunction'
-            type: array
+            $ref: '#/definitions/api.JobFunction'
       summary: Get a job function by ID.
       tags:
       - jobfunctions
@@ -2002,7 +2370,7 @@ paths:
           $ref: '#/definitions/api.JobFunction'
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Update a job function.
       tags:
       - jobfunctions
@@ -2053,7 +2421,7 @@ paths:
         type: integer
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Delete a migration wave.
       tags:
       - migrationwaves
@@ -2093,7 +2461,7 @@ paths:
           $ref: '#/definitions/api.MigrationWave'
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Update a migration wave.
       tags:
       - migrationwaves
@@ -2144,7 +2512,7 @@ paths:
         type: string
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Delete an proxy.
       tags:
       - proxies
@@ -2184,7 +2552,7 @@ paths:
           $ref: '#/definitions/api.Proxy'
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Update an proxy.
       tags:
       - proxies
@@ -2235,7 +2603,7 @@ paths:
         type: string
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Delete a review.
       tags:
       - reviews
@@ -2253,9 +2621,7 @@ paths:
         "200":
           description: OK
           schema:
-            items:
-              $ref: '#/definitions/api.Review'
-            type: array
+            $ref: '#/definitions/api.Review'
       summary: Get a review by ID.
       tags:
       - reviews
@@ -2277,7 +2643,7 @@ paths:
           $ref: '#/definitions/api.Review'
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Update a review.
       tags:
       - reviews
@@ -2295,7 +2661,7 @@ paths:
           $ref: '#/definitions/api.CopyRequest'
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Copy a review from one application to others.
       tags:
       - reviews
@@ -2346,7 +2712,7 @@ paths:
         type: string
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Delete a bundle.
       tags:
       - rulebundles
@@ -2386,7 +2752,7 @@ paths:
           $ref: '#/definitions/api.RuleBundle'
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Update a bundle.
       tags:
       - rulebundles
@@ -2450,7 +2816,7 @@ paths:
         type: string
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Delete a setting.
       tags:
       - settings
@@ -2485,7 +2851,7 @@ paths:
           $ref: '#/definitions/api.Setting'
       responses:
         "201":
-          description: Created
+          description: ""
       summary: Create a setting.
       tags:
       - settings
@@ -2503,7 +2869,7 @@ paths:
       - application/json
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Update a setting.
       tags:
       - settings
@@ -2554,7 +2920,7 @@ paths:
         type: string
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Delete a stakeholder group.
       tags:
       - stakeholdergroups
@@ -2594,7 +2960,7 @@ paths:
           $ref: '#/definitions/api.StakeholderGroup'
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Update a stakeholder group.
       tags:
       - stakeholdergroups
@@ -2645,7 +3011,7 @@ paths:
         type: string
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Delete a stakeholder.
       tags:
       - stakeholders
@@ -2685,7 +3051,7 @@ paths:
           $ref: '#/definitions/api.Stakeholder'
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Update a stakeholder.
       tags:
       - stakeholders
@@ -2741,7 +3107,7 @@ paths:
         type: string
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Delete a tag category.
       tags:
       - tagcategories
@@ -2781,7 +3147,7 @@ paths:
           $ref: '#/definitions/api.TagCategory'
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Update a tag category.
       tags:
       - tagcategories
@@ -2857,7 +3223,7 @@ paths:
         type: string
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Delete a tag.
       tags:
       - tags
@@ -2897,7 +3263,7 @@ paths:
           $ref: '#/definitions/api.Tag'
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Update a tag.
       tags:
       - tags
@@ -2948,7 +3314,7 @@ paths:
         type: string
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Delete a task group.
       tags:
       - taskgroups
@@ -2988,7 +3354,7 @@ paths:
           $ref: '#/definitions/api.TaskGroup'
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Update a task group.
       tags:
       - taskgroups
@@ -3005,7 +3371,7 @@ paths:
       - application/json
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Delete bucket content by ID and path.
       tags:
       - taskgroups
@@ -3028,7 +3394,7 @@ paths:
       - application/octet-stream
       responses:
         "200":
-          description: OK
+          description: ""
       summary: Get bucket content by ID and path.
       tags:
       - taskgroups
@@ -3045,7 +3411,7 @@ paths:
       - application/json
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Upload bucket content by ID and path.
       tags:
       - taskgroups
@@ -3067,7 +3433,7 @@ paths:
           $ref: '#/definitions/api.TaskGroup'
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Submit a task group.
       tags:
       - taskgroups
@@ -3118,7 +3484,7 @@ paths:
         type: string
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Delete a task.
       tags:
       - tasks
@@ -3158,7 +3524,7 @@ paths:
           $ref: '#/definitions/api.Task'
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Update a task.
       tags:
       - tasks
@@ -3175,7 +3541,7 @@ paths:
       - application/json
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Delete bucket content by ID and path.
       tags:
       - tasks
@@ -3198,7 +3564,7 @@ paths:
       - application/octet-stream
       responses:
         "200":
-          description: OK
+          description: ""
       summary: Get bucket content by ID and path.
       tags:
       - tasks
@@ -3215,7 +3581,7 @@ paths:
       - application/json
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Upload bucket content by ID and path.
       tags:
       - tasks
@@ -3230,7 +3596,7 @@ paths:
         type: string
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Cancel a task.
       tags:
       - tasks
@@ -3249,7 +3615,7 @@ paths:
       - application/json
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Delete a task report.
       tags:
       - tasks
@@ -3323,7 +3689,7 @@ paths:
           $ref: '#/definitions/api.Task'
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Submit a task.
       tags:
       - tasks
@@ -3374,7 +3740,7 @@ paths:
         type: integer
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Delete a ticket.
       tags:
       - tickets
@@ -3443,7 +3809,7 @@ paths:
         type: integer
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Delete a tracker.
       tags:
       - trackers
@@ -3483,7 +3849,7 @@ paths:
           $ref: '#/definitions/api.Tracker'
       responses:
         "204":
-          description: No Content
+          description: ""
       summary: Update a tracker.
       tags:
       - trackers


### PR DESCRIPTION
QE reported failures on Get actions for jobfunction, group. Updating swagger annotation to expect single value instead of array (jobfunction and review) and make a small fix when Get returned model instead of api package struct (group).

Also adding Analysis endpoint methods to generated swagger spec.

Fixes: https://issues.redhat.com/browse/MTA-582