### PR TITLE
:bug: Fix possible nil ptr dereference in Jira refresh

### DIFF
--- a/tracker/jira/connector.go
+++ b/tracker/jira/connector.go
@@ -97,7 +97,7 @@ func (r *Connector) RefreshAll() (tickets map[*model.Ticket]bool, err error) {
 	err = handleJiraError(response, err)
 	if err != nil {
 		// JIRA returns a 400 if the search returned no results.
-		if response.StatusCode == http.StatusBadRequest {
+		if response != nil && response.StatusCode == http.StatusBadRequest {
 			err = nil
 		}
 		return


### PR DESCRIPTION
It's possible for the Jira client to return a nil response, so we need to check it before using it. Other locations are already safe because the `handleJiraError` function checks the response for nil.