### PR TITLE
:sparkles: Emptydir and setting the workingDir discontinued.

### DIFF
--- a/settings/addon.go
+++ b/settings/addon.go
@@ -7,10 +7,9 @@ import (
 )
 
 const (
-	EnvAddonWorkingDir = "ADDON_WORKING_DIR"
-	EnvHubBaseURL      = "HUB_BASE_URL"
-	EnvHubToken        = "TOKEN"
-	EnvTask            = "TASK"
+	EnvHubBaseURL = "HUB_BASE_URL"
+	EnvHubToken   = "TOKEN"
+	EnvTask       = "TASK"
 )
 
 //
@@ -22,11 +21,6 @@ type Addon struct {
 		URL string
 		// Token for the hub API.
 		Token string
-	}
-	// Path.
-	Path struct {
-		// Working directory path.
-		WorkingDir string
 	}
 	//
 	Task int
@@ -43,10 +37,6 @@ func (r *Addon) Load() (err error) {
 		panic(err)
 	}
 	r.Hub.Token, found = os.LookupEnv(EnvHubToken)
-	r.Path.WorkingDir, found = os.LookupEnv(EnvAddonWorkingDir)
-	if !found {
-		r.Path.WorkingDir = "/tmp"
-	}
 	if s, found := os.LookupEnv(EnvTask); found {
 		r.Task, _ = strconv.Atoi(s)
 	}

--- a/task/manager.go
+++ b/task/manager.go
@@ -480,12 +480,6 @@ func (r *Task) pod(addon *crd.Addon, owner *crd.Tackle, secret *core.Secret) (po
 //
 // specification builds a Pod specification.
 func (r *Task) specification(addon *crd.Addon, secret *core.Secret) (specification core.PodSpec) {
-	working := core.Volume{
-		Name: "working",
-		VolumeSource: core.VolumeSource{
-			EmptyDir: &core.EmptyDirVolumeSource{},
-		},
-	}
 	cache := core.Volume{
 		Name: "cache",
 	}
@@ -507,7 +501,6 @@ func (r *Task) specification(addon *crd.Addon, secret *core.Secret) (specificati
 			r.container(addon, secret),
 		},
 		Volumes: []core.Volume{
-			working,
 			cache,
 		},
 	}
@@ -527,16 +520,11 @@ func (r *Task) container(addon *crd.Addon, secret *core.Secret) (container core.
 		Name:            "main",
 		Image:           r.Image,
 		ImagePullPolicy: policy,
-		WorkingDir:      Settings.Addon.Path.WorkingDir,
 		Resources:       addon.Spec.Resources,
 		Env: []core.EnvVar{
 			{
 				Name:  settings.EnvHubBaseURL,
 				Value: Settings.Addon.Hub.URL,
-			},
-			{
-				Name:  settings.EnvAddonWorkingDir,
-				Value: Settings.Addon.Path.WorkingDir,
 			},
 			{
 				Name:  settings.EnvTask,
@@ -555,10 +543,6 @@ func (r *Task) container(addon *crd.Addon, secret *core.Secret) (container core.
 			},
 		},
 		VolumeMounts: []core.VolumeMount{
-			{
-				Name:      "working",
-				MountPath: Settings.Addon.Path.WorkingDir,
-			},
 			{
 				Name:      "cache",
 				MountPath: Settings.Cache.Path,


### PR DESCRIPTION
There are is no meaningful advantage to mounting the emptyDir over the addon using the containerfs.
Mounting the emptyDir and setting (forcing) the workingDir is opinionated in ways that overrides the container configuration.

Backwards compatible with _known_ addons.