### PR TITLE
:seedling: Add Identity and Proxy to API tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,15 +123,15 @@ endif
 
 # Run unit tests.
 test:
-	go test -v ./auth/
+	go test -count=1 -v ./auth/
 
 # Run Hub REST API tests.
 test-api:
-	HUB_BASE_URL=${HUB_BASE_URL} go test -v ./test/api/...
+	HUB_BASE_URL=${HUB_BASE_URL} go test -count=1 -v ./test/api/...
 
 # Run Hub API integration tests.
 test-integration:
-	HUB_BASE_URL=${HUB_BASE_URL} go test -v ./test/integration/...
+	HUB_BASE_URL=${HUB_BASE_URL} go test -count=1 -v ./test/integration/...
 
 # Run Hub test suite.
 test-all: test-unit test-api test-integration

--- a/test/api/identity/api_test.go
+++ b/test/api/identity/api_test.go
@@ -1,0 +1,76 @@
+package identity
+
+import (
+	"testing"
+
+	"github.com/konveyor/tackle2-hub/test/assert"
+)
+
+func TestIdentityCRUD(t *testing.T) {
+	for _, r := range Samples {
+		t.Run(r.Name, func(t *testing.T) {
+			// Create.
+			err := Identity.Create(&r)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+
+			// Get.
+			got, err := Identity.Get(r.ID)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+			if assert.FlatEqual(got, r) {
+				t.Errorf("Different response error. Got %v, expected %v", got, r)
+			}
+
+			// Update.
+			r.Name = "Updated " + r.Name
+			err = Identity.Update(&r)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+
+			got, err = Identity.Get(r.ID)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+			if got.Name != r.Name {
+				t.Errorf("Different response error. Got %s, expected %s", got.Name, r.Name)
+			}
+
+			// Delete.
+			err = Identity.Delete(r.ID)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+
+			_, err = Identity.Get(r.ID)
+			if err == nil {
+				t.Errorf("Resource exits, but should be deleted: %v", r)
+			}
+		})
+	}
+}
+
+func TestIdentityList(t *testing.T) {
+	samples := Samples
+
+	for name := range samples {
+		sample := samples[name]
+		assert.Must(t, Identity.Create(&sample))
+		samples[name] = sample
+	}
+
+	got, err := Identity.List()
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if assert.FlatEqual(got, &samples) {
+		t.Errorf("Different response error. Got %v, expected %v", got, samples)
+	}
+
+	for _, r := range samples {
+		assert.Must(t, Identity.Delete(r.ID))
+	}
+}

--- a/test/api/identity/pkg.go
+++ b/test/api/identity/pkg.go
@@ -1,0 +1,20 @@
+package identity
+
+import (
+	"github.com/konveyor/tackle2-hub/binding"
+	"github.com/konveyor/tackle2-hub/test/api/client"
+)
+
+var (
+	RichClient *binding.RichClient
+	Identity binding.Identity
+)
+
+
+func init() {
+	// Prepare RichClient and login to Hub API (configured from env variables).
+	RichClient = client.PrepareRichClient()
+
+	// Shortcut for Identity-related RichClient methods.
+	Identity = RichClient.Identity
+}

--- a/test/api/identity/samples.go
+++ b/test/api/identity/samples.go
@@ -1,0 +1,88 @@
+package identity
+
+import (
+	"github.com/konveyor/tackle2-hub/api"
+)
+
+// Set of valid resources for tests and reuse.
+var (
+	GitPw = api.Identity{
+		Kind: "git",
+		Name: "git-pw",
+		User: "test-user",
+		Password: "test-password-123",
+	}
+	GitKey = api.Identity{
+		Kind: "git",
+		Name: "git-key",
+		User: "test-user",
+		Key:  /* The key was generated only for test purposes, not used anywhere, gitleaks:allow */ `-----BEGIN OPENSSH PRIVATE KEY-----
+		b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAlwAAAAdzc2gtcn
+		NhAAAAAwEAAQAAAIEAoDrNL4XSvv5xgPX4ty4nZFn+5nTG9F9Kvx8u+eNN2CdTKjzFUr0N
+		HYFfiBo98RyZO67plzQVi7hK+ooUTAdt+eU6bgF23VF62Cd8GT/l2AMB73tTedEYVmsOi5
+		aJwJV3BaLWmgEbg3YqbtJWeYHloWV1myC7ChYFIqgNgq/NikcAAAIAQpLNF0KSzRcAAAAH
+		c3NoLXJzYQAAAIEAoDrNL4XSvv5xgPX4ty4nZFn+5nTG9F9Kvx8u+eNN2CdTKjzFUr0NHY
+		FfiBo98RyZO67plzQVi7hK+ooUTAdt+eU6bgF23VF62Cd8GT/l2AMB73tTedEYVmsOi5aJ
+		wJV3BaLWmgEbg3YqbtJWeYHloWV1myC7ChYFIqgNgq/NikcAAAADAQABAAAAgC9qd0Hy9j
+		SzE1+4aou6ysl1oGsOb7ntYS9BySMF0wl+SawcI8CiVXk/ycd7DI2HiwkQb+vg6+dW+ElA
+		B1WgdTigUZjmhJ8nAFgebav8PbTDc2izFGu31jLeP6dyLRcRG/ztcOvsglloh9Oj//jKzb
+		YBpKlhIaJbnmVokx0NgAMxAAAAQQCc8TsykYsJQz8R2MpddptTlIStFRIvt7bVcwZ8Hrr5
+		M8XT3aCxABvtcRgY++/VDZBkK+TNfcdWSS+1Cxrmp/X2AAAAQQDT109BFaf9bbmOdipdyd
+		nXFhQgxwZ2HbCBtMmOR2zEosCPDNf2c7McFTAOCM3Mh0qNlZPPbUL1v2TVWvDi9NQjAAAA
+		QQDBoU1fSYFq+Rf2Dyrq9RevXT4VO+uahlje46zV2sVA6Mg2lc+yqTbTIv9NvxnJMC51vO
+		B1q2YQPNuJWgd03jGNAAAACm1hdWZhcnRAbmI=
+		-----END OPENSSH PRIVATE KEY-----
+		`,
+	}
+	Mvn = api.Identity{
+		Kind: "mvn",
+		Name: "mvn-settings",
+		Settings: `<?xml version="1.0" encoding="UTF-8"?>
+		<settings xmlns="http://maven.apache.org/SETTINGS/1.2.0"
+				  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+				  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.2.0 http://maven.apache.org/xsd/settings-1.2.0.xsd">
+		  <pluginGroups>
+		  </pluginGroups>
+		  <proxies>
+		  </proxies>
+		  <servers>
+			<server>
+			   <id>tackle-testapp</id>
+			   <username>GITHUB_USER</username>
+			   <password>GITHUB_TOKEN</password>
+			 </server>
+		  </servers>
+		  <mirrors>
+			<mirror>
+			  <id>maven-default-http-blocker</id>
+			  <mirrorOf>external:http:*</mirrorOf>
+			  <name>Pseudo repository to mirror external repositories initially using HTTP.</name>
+			  <url>http://0.0.0.0/</url>
+			  <blocked>true</blocked>
+			</mirror>
+		  </mirrors>
+		  <profiles>
+			<profile>
+			  <id>github</id>
+			  <repositories>
+				<repository>
+				  <id>central</id>
+				  <url>https://repo1.maven.org/maven2</url>
+				</repository>
+				<repository>
+				  <id>tackle-testapp</id>
+				  <url>https://maven.pkg.github.com/konveyor/tackle-testapp</url>
+				  <snapshots>
+					<enabled>true</enabled>
+				  </snapshots>
+				</repository>
+			  </repositories>
+			</profile>
+		  </profiles>
+		  <activeProfiles>
+			<activeProfile>github</activeProfile>
+		  </activeProfiles>
+		</settings>`,	
+	}
+	Samples = []api.Identity{GitPw, GitKey, Mvn}
+)

--- a/test/api/proxy/api_test.go
+++ b/test/api/proxy/api_test.go
@@ -1,0 +1,64 @@
+package proxy
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestProxyGetUpdate(t *testing.T) {
+	for _, id := range []uint{1,2} {	// Existing proxies in Hub have IDs 1, 2
+		t.Run(fmt.Sprint(id), func(t *testing.T) {
+			// Get.
+			orig, err := Proxy.Get(id)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+
+			// Update.
+			update := orig
+			update.Host = "127.0.0.1"
+			update.Port = 8081
+			update.Enabled = true
+			err = Proxy.Update(update)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+
+			updated, err := Proxy.Get(update.ID)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+			if updated.Host != update.Host || updated.Port != update.Port || updated.Enabled != update.Enabled {
+				t.Errorf("Different response error. Got %+v, expected %+v", updated, update)
+			}
+
+			// Update back to original.
+			err = Proxy.Update(orig)
+			if err != nil {
+				t.Fatalf(err.Error())
+			}
+		})
+	}
+}
+
+func TestSeedProxyList(t *testing.T) {
+	got, err := Proxy.List()
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	foundHttp, foundHttps := false, false
+	for _, r := range got {
+		if r.Kind == "http" {
+			foundHttp = true
+		}
+		if r.Kind == "https" {
+			foundHttps = true
+		}
+	}
+	if !foundHttp {
+		t.Errorf("Cannot find HTTP proxy.")
+	}
+	if !foundHttps {
+		t.Errorf("Cannot find HTTPS proxy.")
+	}
+}

--- a/test/api/proxy/pkg.go
+++ b/test/api/proxy/pkg.go
@@ -1,0 +1,20 @@
+package proxy
+
+import (
+	"github.com/konveyor/tackle2-hub/binding"
+	"github.com/konveyor/tackle2-hub/test/api/client"
+)
+
+var (
+	RichClient *binding.RichClient
+	Proxy binding.Proxy
+)
+
+
+func init() {
+	// Prepare RichClient and login to Hub API (configured from env variables).
+	RichClient = client.PrepareRichClient()
+
+	// Shortcut for Proxy-related RichClient methods.
+	Proxy = RichClient.Proxy
+}

--- a/test/api/proxy/samples.go
+++ b/test/api/proxy/samples.go
@@ -1,0 +1,27 @@
+package proxy
+
+import (
+	"github.com/konveyor/tackle2-hub/api"
+)
+
+// Set of valid resources for tests and reuse.
+var (
+	PublicHTTP = api.Proxy{
+		Kind: "http",
+		Host: "http-proxy.local",
+		Port: 80,
+	}
+	PublicHTTPS = api.Proxy{
+		Kind:     "https",
+		Host:     "https-proxy.local",
+		Port:     443,
+		Excluded: []string{"excldomain.tld"},
+	}
+	//PrivateSquid = api.Proxy{
+	//	Kind: "https",
+	//	Host: "squidprivateproxy.local",
+	//	Port: 3128,
+	//	Identity: ,
+	//}
+	Samples = []api.Proxy{PublicHTTP, PublicHTTPS}
+)


### PR DESCRIPTION
Adding Indetity and Proxy resources to API tests. Identity provides samples with login/password, key and settings file.

Related to https://github.com/konveyor/tackle2-hub/pull/268