### PR TITLE
:sparkles: Expose Prometheus metrics

### DIFF
--- a/api/pathfinder.go
+++ b/api/pathfinder.go
@@ -6,6 +6,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
 	liberr "github.com/jortel/go-utils/error"
+	"github.com/konveyor/tackle2-hub/metrics"
 	"io"
 	"net/http"
 	"net/http/httputil"
@@ -49,6 +50,10 @@ func (h PathfinderHandler) ReverseProxy(ctx *gin.Context) {
 			req.URL.Scheme = target.Scheme
 			req.URL.Host = target.Host
 		},
+	}
+
+	if ctx.Request.Method == http.MethodPost {
+		metrics.AssessmentsInitiated.Inc()
 	}
 
 	proxy.ServeHTTP(ctx.Writer, ctx.Request)

--- a/metrics/manager.go
+++ b/metrics/manager.go
@@ -1,0 +1,47 @@
+package metrics
+
+import (
+	"context"
+	"github.com/jortel/go-utils/logr"
+	"github.com/konveyor/tackle2-hub/model"
+	"gorm.io/gorm"
+	"time"
+)
+
+var (
+	Log = logr.WithName("metrics")
+)
+
+// Manager provides metrics management.
+type Manager struct {
+	// DB
+	DB *gorm.DB
+}
+
+// Run the manager.
+func (m *Manager) Run(ctx context.Context) {
+	go func() {
+		Log.Info("Started.")
+		defer Log.Info("Died.")
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+				time.Sleep(time.Second * 30)
+				m.gaugeApplications()
+			}
+		}
+	}()
+}
+
+//
+// gaugeApplications reports the number of applications in inventory
+func (m *Manager) gaugeApplications() {
+	count := int64(0)
+	result := m.DB.Model(&model.Application{}).Count(&count)
+	if result.Error != nil {
+		Log.Error(result.Error, "unable to gauge applications")
+	}
+	Applications.Set(float64(count))
+}

--- a/metrics/pkg.go
+++ b/metrics/pkg.go
@@ -1,0 +1,25 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	AssessmentsInitiated = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "konveyor_assessments_initiated_total",
+		Help: "The total number of initiated assessments",
+	})
+	TasksInitiated = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "konveyor_tasks_initiated_total",
+		Help: "The total number of initiated tasks",
+	})
+	Applications = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "konveyor_applications_inventoried",
+		Help: "The current number of applications in inventory",
+	})
+	IssuesExported = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "konveyor_issues_exported_total",
+		Help: "The total number of issues exported to external trackers",
+	})
+)

--- a/settings/all.go
+++ b/settings/all.go
@@ -27,6 +27,10 @@ func (r *TackleSettings) Load() (err error) {
 	if err != nil {
 		return
 	}
+	err = r.Metrics.Load()
+	if err != nil {
+		return
+	}
 	return
 }
 

--- a/settings/metrics.go
+++ b/settings/metrics.go
@@ -9,36 +9,36 @@ import (
 //
 // Environment variables.
 const (
-	MetricsPort = "METRICS_PORT"
+	MetricsEnabled = "METRICS_ENABLED"
+	MetricsPort    = "METRICS_PORT"
 )
 
 //
 // Metrics settings
 type Metrics struct {
-	// Metrics port. 0 = disabled.
+	// Metrics port.
 	Port int
+	// Metrics enabled.
+	Enabled bool
 }
 
 //
 // Load settings.
 func (r *Metrics) Load() error {
+	// Enabled
+	r.Enabled = getEnvBool(MetricsEnabled, true)
 	// Port
 	if s, found := os.LookupEnv(MetricsPort); found {
 		r.Port, _ = strconv.Atoi(s)
 	} else {
-		r.Port = 8080
+		r.Port = 2112
 	}
 
 	return nil
 }
 
 //
-// Metrics address.
-// Port = 0 will disable metrics.
+// Address on which to serve metrics.
 func (r *Metrics) Address() string {
-	if r.Port > 0 {
-		return fmt.Sprintf(":%d", r.Port)
-	} else {
-		return "0"
-	}
+	return fmt.Sprintf(":%d", r.Port)
 }

--- a/task/manager.go
+++ b/task/manager.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jortel/go-utils/logr"
 	"github.com/konveyor/tackle2-hub/auth"
 	crd "github.com/konveyor/tackle2-hub/k8s/api/tackle/v1alpha1"
+	"github.com/konveyor/tackle2-hub/metrics"
 	"github.com/konveyor/tackle2-hub/model"
 	"github.com/konveyor/tackle2-hub/settings"
 	"gorm.io/gorm"
@@ -151,6 +152,7 @@ func (m *Manager) startReady() {
 				Log.Error(sErr, "")
 				continue
 			}
+			metrics.TasksInitiated.Inc()
 			rt := Task{ready}
 			err := rt.Run(m.Client)
 			if err != nil {

--- a/tracker/manager.go
+++ b/tracker/manager.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"github.com/jortel/go-utils/logr"
+	"github.com/konveyor/tackle2-hub/metrics"
 	"github.com/konveyor/tackle2-hub/model"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -195,6 +196,7 @@ func (m *Manager) create(tracker *model.Tracker, ticket *model.Ticket) (err erro
 	if err != nil {
 		return
 	}
+	metrics.IssuesExported.Inc()
 	result := m.DB.Save(ticket)
 	if result.Error != nil {
 		err = result.Error


### PR DESCRIPTION
By default, metrics are enabled and are available at `:2112/metrics`. To change the port, set the `METRICS_PORT` environment variable. To disable metrics, set `METRICS_ENABLED` to false.


* Current number of applications in inventory
* Count of tasks initiated
* Count of assessments initiated
* Count of issues exported to jira

Implements https://github.com/konveyor/tackle2-hub/issues/305