### PR TITLE
:sparkles: Add analysis total effort and include in the IssueReport.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,8 @@ controller-gen:
 addon: fmt vet
 	go build -o bin/addon github.com/konveyor/tackle2-hub/hack/cmd/addon
 
+docs: docs-swagger docs-binding
+
 # Build Swagger API spec into ./docs directory
 docs-swagger:
 	${GOBIN}/swag init -g api/base.go

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -4523,6 +4523,9 @@ const docTemplate = `{
                         "$ref": "#/definitions/api.TechDependency"
                     }
                 },
+                "effort": {
+                    "type": "integer"
+                },
                 "id": {
                     "type": "integer"
                 },
@@ -4540,23 +4543,11 @@ const docTemplate = `{
         "api.AnalysisManifest": {
             "type": "object",
             "properties": {
-                "createTime": {
-                    "type": "string"
-                },
-                "createUser": {
-                    "type": "string"
-                },
                 "dependencies": {
                     "$ref": "#/definitions/api.Ref"
                 },
-                "id": {
-                    "type": "integer"
-                },
                 "issues": {
                     "$ref": "#/definitions/api.Ref"
-                },
-                "updateUser": {
-                    "type": "string"
                 }
             }
         },
@@ -4978,15 +4969,23 @@ const docTemplate = `{
         },
         "api.IssueReport": {
             "type": "object",
-            "required": [
-                "category",
-                "name",
-                "rule",
-                "ruleset"
-            ],
             "properties": {
                 "application": {
-                    "$ref": "#/definitions/api.Ref"
+                    "type": "object",
+                    "required": [
+                        "id"
+                    ],
+                    "properties": {
+                        "effort": {
+                            "type": "integer"
+                        },
+                        "id": {
+                            "type": "integer"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    }
                 },
                 "category": {
                     "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -4511,6 +4511,9 @@
                         "$ref": "#/definitions/api.TechDependency"
                     }
                 },
+                "effort": {
+                    "type": "integer"
+                },
                 "id": {
                     "type": "integer"
                 },
@@ -4528,23 +4531,11 @@
         "api.AnalysisManifest": {
             "type": "object",
             "properties": {
-                "createTime": {
-                    "type": "string"
-                },
-                "createUser": {
-                    "type": "string"
-                },
                 "dependencies": {
                     "$ref": "#/definitions/api.Ref"
                 },
-                "id": {
-                    "type": "integer"
-                },
                 "issues": {
                     "$ref": "#/definitions/api.Ref"
-                },
-                "updateUser": {
-                    "type": "string"
                 }
             }
         },
@@ -4966,15 +4957,23 @@
         },
         "api.IssueReport": {
             "type": "object",
-            "required": [
-                "category",
-                "name",
-                "rule",
-                "ruleset"
-            ],
             "properties": {
                 "application": {
-                    "$ref": "#/definitions/api.Ref"
+                    "type": "object",
+                    "required": [
+                        "id"
+                    ],
+                    "properties": {
+                        "effort": {
+                            "type": "integer"
+                        },
+                        "id": {
+                            "type": "integer"
+                        },
+                        "name": {
+                            "type": "string"
+                        }
+                    }
                 },
                 "category": {
                     "type": "string"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -16,6 +16,8 @@ definitions:
         items:
           $ref: '#/definitions/api.TechDependency'
         type: array
+      effort:
+        type: integer
       id:
         type: integer
       issues:
@@ -27,18 +29,10 @@ definitions:
     type: object
   api.AnalysisManifest:
     properties:
-      createTime:
-        type: string
-      createUser:
-        type: string
       dependencies:
         $ref: '#/definitions/api.Ref'
-      id:
-        type: integer
       issues:
         $ref: '#/definitions/api.Ref'
-      updateUser:
-        type: string
     type: object
   api.Application:
     properties:
@@ -319,7 +313,16 @@ definitions:
   api.IssueReport:
     properties:
       application:
-        $ref: '#/definitions/api.Ref'
+        properties:
+          effort:
+            type: integer
+          id:
+            type: integer
+          name:
+            type: string
+        required:
+        - id
+        type: object
       category:
         type: string
       createTime:
@@ -354,11 +357,6 @@ definitions:
         type: string
       updateUser:
         type: string
-    required:
-    - category
-    - name
-    - rule
-    - ruleset
     type: object
   api.JobFunction:
     properties:

--- a/migration/v4/model/analysis.go
+++ b/migration/v4/model/analysis.go
@@ -4,6 +4,7 @@ package model
 // Analysis report.
 type Analysis struct {
 	Model
+	Effort        int
 	Issues        []Issue          `gorm:"constraint:OnDelete:CASCADE"`
 	Dependencies  []TechDependency `gorm:"constraint:OnDelete:CASCADE"`
 	ApplicationID uint             `gorm:"index;not null"`


### PR DESCRIPTION
Add analysis total effort and include in the IssueReport.

Also, noticed the IssueReport is not marshalled with `Issue` inline in YAML.  This is because the yaml:,inline tag is missing. However, the report redefines the incidents field.  This (field override) works with the json decoder but not the yaml decoder.