### PR TITLE
:ghost: Add test badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tackle2-hub
 
-[![Hub Repository on Quay](https://quay.io/repository/konveyor/tackle2-hub/status "Hub Repository on Quay")](https://quay.io/repository/konveyor/tackle2-hub) [![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html) [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/konveyor/tackle2-hub/pulls)
+[![Hub Repository on Quay](https://quay.io/repository/konveyor/tackle2-hub/status "Hub Repository on Quay")](https://quay.io/repository/konveyor/tackle2-hub) [![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html) [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat)](https://github.com/konveyor/tackle2-hub/pulls) [![Hub main CI](https://github.com/konveyor/tackle2-hub/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/konveyor/tackle2-hub/actions/workflows/main.yml) [![Hub Test Suite nightly](https://github.com/konveyor/tackle2-hub/actions/workflows/test-nightly.yml/badge.svg?branch=main)](https://github.com/konveyor/tackle2-hub/actions/workflows/test-nightly.yml)
 
 Tackle (2nd generation) hub component.
 


### PR DESCRIPTION
Adding on-merge Hub build workflow and nightly tests badges to README (both are green as of now).