### PR TITLE
:ghost: Fix swagger updates notification

### DIFF
--- a/.github/workflows/swagger-change-notification.yml
+++ b/.github/workflows/swagger-change-notification.yml
@@ -16,4 +16,4 @@ jobs:
         uses: thollander/actions-comment-pull-request@v2
         with:
           message: |
-          :mega: There is a Swagger OpenAPI spec files change, please consider re-generating your API client. @konveyor/tackle-qe
+            :mega: There is a Swagger OpenAPI spec files change, please consider re-generating your API client. @konveyor/tackle-qe


### PR DESCRIPTION
Found out there are two issues preventing swagger spec files notification to work.
1. Incorrect message in YAML (updated in this PR) and
2. lack of privileges (and I cannot change it on this repository), can be adjusted at https://github.com/konveyor/tackle2-hub/settings/actions (bottom of the page Workflow / Read write permission).

![image](https://github.com/konveyor/tackle2-hub/assets/555381/53384b86-ec15-4838-bea5-1525b8aa18e3)

Related to: https://issues.redhat.com/browse/MTA-615 and https://github.com/konveyor/tackle2-hub/pull/341