### PR TITLE
:ghost: Using multi-part form instead of manifest.

### DIFF
--- a/addon/application.go
+++ b/addon/application.go
@@ -252,7 +252,11 @@ func (h *AppFacts) Set(key string, value interface{}) (err error) {
 			api.Key:    key,
 			api.Source: h.source,
 		})
-	err = h.client.Put(path, value)
+	err = h.client.Put(
+		path, api.Fact{
+			Key:   key,
+			Value: value,
+		})
 	return
 }
 

--- a/addon/application.go
+++ b/addon/application.go
@@ -307,32 +307,21 @@ func (h *Analysis) Create(r *api.Analysis, encoding string, issues, deps io.Read
 		http.MethodPost,
 		[]Field{
 			{
-				Name:   api.FileField,
-				Reader: bytes.NewReader(b),
-				Path:   h.Ext(binding.MIMEYAML),
+				Name:     api.FileField,
+				Reader:   bytes.NewReader(b),
+				Encoding: binding.MIMEYAML,
 			},
 			{
-				Name:   api.IssueField,
-				Path:   h.Ext(encoding),
-				Reader: issues,
+				Name:     api.IssueField,
+				Encoding: encoding,
+				Reader:   issues,
 			},
 			{
-				Name:   api.DepField,
-				Path:   h.Ext(encoding),
-				Reader: deps,
+				Name:     api.DepField,
+				Encoding: encoding,
+				Reader:   deps,
 			},
 		},
 		r)
 	return
-}
-
-func (h *Analysis) Ext(encoding string) string {
-	switch encoding {
-	case binding.MIMEYAML:
-		return ".yaml"
-	case binding.MIMEJSON:
-		return ".json"
-	default:
-		return ""
-	}
 }

--- a/addon/application.go
+++ b/addon/application.go
@@ -3,6 +3,7 @@ package addon
 import (
 	liberr "github.com/jortel/go-utils/error"
 	"github.com/konveyor/tackle2-hub/api"
+	"net/http"
 	"strconv"
 )
 
@@ -290,8 +291,21 @@ type Analysis struct {
 
 //
 // Create an analysis report.
-func (h *Analysis) Create(r *api.AnalysisManifest) (err error) {
+func (h *Analysis) Create(r *api.Analysis, issues, deps string) (err error) {
 	path := Path(api.AppAnalysesRoot).Inject(Params{api.ID: h.appId})
-	err = h.client.Post(path, r)
+	err = h.client.FileSend(
+		path,
+		http.MethodPost,
+		[]Field{
+			{
+				Name: api.IssueField,
+				Path: issues,
+			},
+			{
+				Name: api.DepField,
+				Path: deps,
+			},
+		},
+		r)
 	return
 }

--- a/api/analysis.go
+++ b/api/analysis.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin/binding"
 	qf "github.com/konveyor/tackle2-hub/api/filter"
 	"github.com/konveyor/tackle2-hub/model"
 	"gorm.io/gorm"
@@ -209,7 +210,7 @@ func (h AnalysisHandler) AppCreate(ctx *gin.Context) {
 	defer func() {
 		_ = reader.Close()
 	}()
-	encoding := mime.TypeByExtension(path.Ext(input.Filename))
+	encoding := h.mimeByExtension(input.Filename)
 	d, err := h.Decoder(ctx, encoding, reader)
 	if err != nil {
 		h.Status(ctx, http.StatusBadRequest)
@@ -236,7 +237,7 @@ func (h AnalysisHandler) AppCreate(ctx *gin.Context) {
 	defer func() {
 		_ = reader.Close()
 	}()
-	encoding = mime.TypeByExtension(path.Ext(input.Filename))
+	encoding = h.mimeByExtension(input.Filename)
 	d, err = h.Decoder(ctx, encoding, reader)
 	if err != nil {
 		h.Status(ctx, http.StatusBadRequest)
@@ -277,7 +278,7 @@ func (h AnalysisHandler) AppCreate(ctx *gin.Context) {
 	defer func() {
 		_ = reader.Close()
 	}()
-	encoding = mime.TypeByExtension(path.Ext(input.Filename))
+	encoding = h.mimeByExtension(input.Filename)
 	d, err = h.Decoder(ctx, encoding, reader)
 	if err != nil {
 		h.Status(ctx, http.StatusBadRequest)
@@ -1225,6 +1226,21 @@ func (h *AnalysisHandler) withLabels(m interface{}, ctx *gin.Context, f *qf.Filt
 			q = q.Select("m.ID")
 			q = q.Where(f.SQL())
 		}
+	}
+	return
+}
+
+//
+// mimeByExtension returns MIME by file extension.
+func (h *AnalysisHandler) mimeByExtension(name string) (s string) {
+	ext := path.Ext(name)
+	switch strings.ToLower(ext) {
+	case ".yaml", ".yml":
+		s = binding.MIMEYAML
+	case ".json":
+		s = binding.MIMEJSON
+	default:
+		s = mime.TypeByExtension(ext)
 	}
 	return
 }

--- a/api/analysis.go
+++ b/api/analysis.go
@@ -4,16 +4,13 @@ import (
 	"encoding/json"
 	"errors"
 	"github.com/gin-gonic/gin"
-	"github.com/gin-gonic/gin/binding"
 	qf "github.com/konveyor/tackle2-hub/api/filter"
 	"github.com/konveyor/tackle2-hub/model"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 	"gorm.io/gorm/logger"
 	"io"
-	"mime"
 	"net/http"
-	"path"
 	"strings"
 )
 
@@ -210,7 +207,7 @@ func (h AnalysisHandler) AppCreate(ctx *gin.Context) {
 	defer func() {
 		_ = reader.Close()
 	}()
-	encoding := h.mimeByExtension(input.Filename)
+	encoding := input.Header.Get(ContentType)
 	d, err := h.Decoder(ctx, encoding, reader)
 	if err != nil {
 		h.Status(ctx, http.StatusBadRequest)
@@ -237,7 +234,7 @@ func (h AnalysisHandler) AppCreate(ctx *gin.Context) {
 	defer func() {
 		_ = reader.Close()
 	}()
-	encoding = h.mimeByExtension(input.Filename)
+	encoding = input.Header.Get(ContentType)
 	d, err = h.Decoder(ctx, encoding, reader)
 	if err != nil {
 		h.Status(ctx, http.StatusBadRequest)
@@ -278,7 +275,7 @@ func (h AnalysisHandler) AppCreate(ctx *gin.Context) {
 	defer func() {
 		_ = reader.Close()
 	}()
-	encoding = h.mimeByExtension(input.Filename)
+	encoding = input.Header.Get(ContentType)
 	d, err = h.Decoder(ctx, encoding, reader)
 	if err != nil {
 		h.Status(ctx, http.StatusBadRequest)
@@ -1226,21 +1223,6 @@ func (h *AnalysisHandler) withLabels(m interface{}, ctx *gin.Context, f *qf.Filt
 			q = q.Select("m.ID")
 			q = q.Where(f.SQL())
 		}
-	}
-	return
-}
-
-//
-// mimeByExtension returns MIME by file extension.
-func (h *AnalysisHandler) mimeByExtension(name string) (s string) {
-	ext := path.Ext(name)
-	switch strings.ToLower(ext) {
-	case ".yaml", ".yml":
-		s = binding.MIMEYAML
-	case ".json":
-		s = binding.MIMEJSON
-	default:
-		s = mime.TypeByExtension(ext)
 	}
 	return
 }

--- a/api/base.go
+++ b/api/base.go
@@ -246,7 +246,7 @@ func (h *BaseHandler) Bind(ctx *gin.Context, r interface{}) (err error) {
 }
 
 //
-// Decoder returns a decoder based on Content-Type header.
+// Decoder returns a decoder based on encoding.
 // Opinionated towards json.
 func (h *BaseHandler) Decoder(ctx *gin.Context, encoding string, r io.Reader) (d Decoder, err error) {
 	if r == nil {

--- a/api/base.go
+++ b/api/base.go
@@ -248,13 +248,14 @@ func (h *BaseHandler) Bind(ctx *gin.Context, r interface{}) (err error) {
 //
 // Decoder returns a decoder based on Content-Type header.
 // Opinionated towards json.
-func (h *BaseHandler) Decoder(ctx *gin.Context, r io.Reader) (d Decoder, err error) {
+func (h *BaseHandler) Decoder(ctx *gin.Context, encoding string, r io.Reader) (d Decoder, err error) {
 	if r == nil {
 		r = ctx.Request.Body
 	}
-	switch ctx.ContentType() {
+	switch encoding {
 	case "",
 		binding.MIMEPOSTForm,
+		binding.MIMEMultipartPOSTForm,
 		binding.MIMEJSON:
 		d = json.NewDecoder(r)
 	case binding.MIMEYAML:

--- a/docs/binding.txt
+++ b/docs/binding.txt
@@ -59,7 +59,7 @@ type Analysis struct {
 }
     Analysis API.
 
-func (h *Analysis) Create(r *api.AnalysisManifest) (err error)
+func (h *Analysis) Create(issues, deps string) (analysis *api.Analysis, err error)
     Create an analysis report.
 
 type AppFacts struct {
@@ -176,6 +176,9 @@ func (r *Client) BucketPut(source, destination string) (err error)
 func (r *Client) Delete(path string, params ...Param) (err error)
     Delete a resource.
 
+func (r *Client) FileForm(path, method string, files []FileField, object interface{}) (err error)
+    FileForm upload files.
+
 func (r *Client) FileGet(path, destination string) (err error)
     FileGet downloads a file.
 
@@ -220,6 +223,12 @@ func (h *File) Get(id uint, destination string) (err error)
 
 func (h *File) Put(source string) (r *api.File, err error)
     Put uploads a file.
+
+type FileField struct {
+	Name string
+	Path string
+}
+    FileField form file fields.
 
 type Identity struct {
 	// Has unexported fields.

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -330,7 +330,7 @@ const docTemplate = `{
         },
         "/application/{id}/analyses": {
             "post": {
-                "description": "Create an analysis.\nCaller must upload (2) files.\nAn issues file that multiple issue resources.\nA dependencies file that contains an array of dependencies.",
+                "description": "Create an analysis.\nForm fields:\n- issues: file that multiple api.Issue resources.\n- dependencies: file that multiple api.TechDependency resources.",
                 "consumes": [
                     "application/json"
                 ],
@@ -341,20 +341,12 @@ const docTemplate = `{
                     "analyses"
                 ],
                 "summary": "Create an analysis.",
-                "parameters": [
-                    {
-                        "description": "AnalysisManifest data",
-                        "name": "manifest",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/api.AnalysisManifest"
-                        }
-                    }
-                ],
                 "responses": {
-                    "204": {
-                        "description": "No Content"
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/api.Analysis"
+                        }
                     }
                 }
             }
@@ -4537,17 +4529,6 @@ const docTemplate = `{
                 },
                 "updateUser": {
                     "type": "string"
-                }
-            }
-        },
-        "api.AnalysisManifest": {
-            "type": "object",
-            "properties": {
-                "dependencies": {
-                    "$ref": "#/definitions/api.Ref"
-                },
-                "issues": {
-                    "$ref": "#/definitions/api.Ref"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -318,7 +318,7 @@
         },
         "/application/{id}/analyses": {
             "post": {
-                "description": "Create an analysis.\nCaller must upload (2) files.\nAn issues file that multiple issue resources.\nA dependencies file that contains an array of dependencies.",
+                "description": "Create an analysis.\nForm fields:\n- issues: file that multiple api.Issue resources.\n- dependencies: file that multiple api.TechDependency resources.",
                 "consumes": [
                     "application/json"
                 ],
@@ -329,20 +329,12 @@
                     "analyses"
                 ],
                 "summary": "Create an analysis.",
-                "parameters": [
-                    {
-                        "description": "AnalysisManifest data",
-                        "name": "manifest",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/api.AnalysisManifest"
-                        }
-                    }
-                ],
                 "responses": {
-                    "204": {
-                        "description": "No Content"
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/api.Analysis"
+                        }
                     }
                 }
             }
@@ -4525,17 +4517,6 @@
                 },
                 "updateUser": {
                     "type": "string"
-                }
-            }
-        },
-        "api.AnalysisManifest": {
-            "type": "object",
-            "properties": {
-                "dependencies": {
-                    "$ref": "#/definitions/api.Ref"
-                },
-                "issues": {
-                    "$ref": "#/definitions/api.Ref"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -27,13 +27,6 @@ definitions:
       updateUser:
         type: string
     type: object
-  api.AnalysisManifest:
-    properties:
-      dependencies:
-        $ref: '#/definitions/api.Ref'
-      issues:
-        $ref: '#/definitions/api.Ref'
-    type: object
   api.Application:
     properties:
       binary:
@@ -1196,21 +1189,16 @@ paths:
       - application/json
       description: |-
         Create an analysis.
-        Caller must upload (2) files.
-        An issues file that multiple issue resources.
-        A dependencies file that contains an array of dependencies.
-      parameters:
-      - description: AnalysisManifest data
-        in: body
-        name: manifest
-        required: true
-        schema:
-          $ref: '#/definitions/api.AnalysisManifest'
+        Form fields:
+        - issues: file that multiple api.Issue resources.
+        - dependencies: file that multiple api.TechDependency resources.
       produces:
       - application/json
       responses:
-        "204":
-          description: No Content
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/api.Analysis'
       summary: Create an analysis.
       tags:
       - analyses

--- a/hack/add/analysis.sh
+++ b/hack/add/analysis.sh
@@ -81,36 +81,29 @@ done
 #
 file=${dPath}
 echo -n "---
-- name: github.com/jboss
-  version: 5.0
-- name: github.com/hybernate
-  indirect: "true"
-  version: 4.6 
-- name: github.com/ejb
-  indirect: "true"
-  version: 4.3 
-- name: github.com/java
-  indirect: "true"
-  version: 8
+name: github.com/jboss
+version: 5.0
 " > ${file}
+echo -n "---
+name: github.com/hybernate
+indirect: "true"
+version: 4.6
+" >> ${file}
+echo -n "---
+name: github.com/ejb
+indirect: "true"
+version: 4.3
+" >> ${file}
+echo -n "---
+name: github.com/java
+indirect: "true"
+version: 8
+" >> ${file}
 
 echo "Report CREATED"
 
-issueId=$( curl -s -F "file=@${iPath}" ${host}/files/issues | jq .id )
-echo "File(issues) created id=${issueId}"
-
-depId=$( curl -s -F "file=@${dPath}" ${host}/files/deps | jq .id )
-echo "File(deps) created id=${issueId}"
-
-curl -i -X POST ${host}/applications/${app}/analyses \
-  -H 'Content-Type:application/x-yaml' \
-  -H 'Accept:application/x-yaml' \
-  -d \
-"
-issues:
-  id: ${issueId}
-dependencies:
-  id: ${depId}
-"
-
-
+curl \
+  -F "issues=@${iPath}" \
+  -F "dependencies=@${dPath}" \
+  ${host}/applications/${app}/analyses \
+  -H 'Accept:application/x-yaml'

--- a/hack/add/analysis.sh
+++ b/hack/add/analysis.sh
@@ -7,6 +7,7 @@ app="${1:-1}"
 nRuleSet="${2:-10}"
 nIssue="${3:-10}"
 nIncident="${4:-25}"
+aPath="/tmp/analysis.yaml"
 iPath="/tmp/issues.yaml"
 dPath="/tmp/deps.yaml"
 
@@ -99,10 +100,19 @@ name: github.com/java
 indirect: "true"
 version: 8
 " >> ${file}
+#
+# Analysis
+#
+file=${aPath}
+echo -n "---
+issues:
+dependencies:
+" > ${file}
 
 echo "Report CREATED"
 
 curl \
+  -F "file=@${aPath}" \
   -F "issues=@${iPath}" \
   -F "dependencies=@${dPath}" \
   ${host}/applications/${app}/analyses \

--- a/hack/add/analysis.sh
+++ b/hack/add/analysis.sh
@@ -111,9 +111,11 @@ dependencies:
 
 echo "Report CREATED"
 
+mime="application/x-yaml"
+
 curl \
-  -F "file=@${aPath}" \
-  -F "issues=@${iPath}" \
-  -F "dependencies=@${dPath}" \
+  -F "file=@${aPath};type=${mime}" \
+  -F "issues=@${iPath};type=${mime}" \
+  -F "dependencies=@${dPath};type=${mime}" \
   ${host}/applications/${app}/analyses \
-  -H 'Accept:application/x-yaml'
+  -H "Accept:${mime}"

--- a/hack/cmd/addon/main.go
+++ b/hack/cmd/addon/main.go
@@ -26,7 +26,7 @@ var (
 
 const (
 	BucketDir = "list"
-	TmpDir = "/tmp/list"
+	TmpDir    = "/tmp/list"
 )
 
 type SoftError = hub.SoftError
@@ -178,7 +178,7 @@ func playWithBucket(bucket *hub.Bucket) (err error) {
 	}
 	//
 	// Upload the index.
-	err = bucket.Put(TmpDir + "/index.html", BucketDir + "/index.html")
+	err = bucket.Put(TmpDir+"/index.html", BucketDir+"/index.html")
 	if err != nil {
 		return
 	}
@@ -186,7 +186,7 @@ func playWithBucket(bucket *hub.Bucket) (err error) {
 	// Add file.
 	elmer := tmpDir2 + "/elmer"
 	_, _ = os.Create(elmer)
-	err = bucket.Put(elmer, BucketDir + "/networks")
+	err = bucket.Put(elmer, BucketDir+"/networks")
 	if err != nil {
 		return
 	}
@@ -289,9 +289,9 @@ func addTags(application *api.Application, source string, names ...string) (err 
 	//
 	// Ensure type exists.
 	tp := &api.TagCategory{
-		Name: "DIRECTORY",
+		Name:  "DIRECTORY",
 		Color: "#2b9af3",
-		Rank: 3,
+		Rank:  3,
 	}
 	err = addon.TagCategory.Ensure(tp)
 	if err != nil {
@@ -325,9 +325,9 @@ func replaceTags(application *api.Application, source string, names ...string) (
 	//
 	// Ensure type exists.
 	tp := &api.TagCategory{
-		Name: "DIRECTORY",
+		Name:  "DIRECTORY",
 		Color: "#2b9af3",
-		Rank: 3,
+		Rank:  3,
 	}
 	err = addon.TagCategory.Ensure(tp)
 	if err != nil {


### PR DESCRIPTION
The approach of: using `File` and `AnalysisManifest` is intended to be more RESTful but after test driving it seems overly complicated.  Seems more straight forward to use a multi-part for as the _Manifest_.

Adds addon binding Client.FileSend() used by the `File` and `Application.Analysis` APIs.