### PR TITLE
:sparkles: Sort validation.

### DIFF
--- a/api/application.go
+++ b/api/application.go
@@ -122,7 +122,7 @@ func (h ApplicationHandler) Get(ctx *gin.Context) {
 // @router /applications [get]
 func (h ApplicationHandler) List(ctx *gin.Context) {
 	var list []model.Application
-	db := h.preLoad(h.Paginated(ctx), clause.Associations)
+	db := h.preLoad(h.DB(ctx), clause.Associations)
 	db = db.Omit("Analyses")
 	result := db.Find(&list)
 	if result.Error != nil {

--- a/api/base.go
+++ b/api/base.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
 	"github.com/jortel/go-utils/logr"
+	"github.com/konveyor/tackle2-hub/api/sort"
 	"github.com/konveyor/tackle2-hub/auth"
 	"github.com/konveyor/tackle2-hub/model"
 	"gopkg.in/yaml.v3"
@@ -42,22 +43,6 @@ func (h *BaseHandler) Client(ctx *gin.Context) (client client.Client) {
 }
 
 //
-// Paginated returns a paginated AND sorted DB client.
-func (h *BaseHandler) Paginated(ctx *gin.Context) (db *gorm.DB) {
-	db = h.paginated(ctx, h.DB(ctx))
-	return
-}
-
-//
-// Sorted returns a sorted DB client.
-func (h *BaseHandler) Sorted(ctx *gin.Context) (db *gorm.DB) {
-	sort := Sort{}
-	sort.With(ctx)
-	db = sort.Sorted(h.DB(ctx))
-	return
-}
-
-//
 // WithCount report count.
 // Sets the X-Total header for pagination.
 // Returns an error when count exceeds the limited and
@@ -85,14 +70,11 @@ func (h *BaseHandler) WithCount(ctx *gin.Context, count int64) (err error) {
 }
 
 //
-// Paginated returns a paginated AND sorted DB client.
+// Paginated returns a paginated DB client.
 func (h *BaseHandler) paginated(ctx *gin.Context, in *gorm.DB) (db *gorm.DB) {
 	p := Page{}
 	p.With(ctx)
 	db = p.Paginated(in)
-	sort := Sort{}
-	sort.With(ctx)
-	db = sort.Sorted(db)
 	return
 }
 
@@ -440,45 +422,7 @@ func (p *Page) Paginated(in *gorm.DB) (out *gorm.DB) {
 
 //
 // Sort provides sorting.
-type Sort struct {
-	Descending bool
-	Field      string
-}
-
-//
-// With context.
-func (p *Sort) With(ctx *gin.Context) {
-	s := ctx.Query("sort")
-	if s == "" {
-		return
-	}
-	mark := strings.Index(s, ":")
-	if mark == -1 {
-		p.Field = s
-		return
-	}
-	d := strings.ToLower(s[:mark])
-	field := s[mark+1:]
-	if len(d) != 0 {
-		p.Descending = d[0] == 'd'
-	}
-	p.Field = field
-}
-
-//
-// Sorted returns sorted DB.
-func (p *Sort) Sorted(in *gorm.DB) (out *gorm.DB) {
-	out = in
-	if p.Field == "" {
-		return
-	}
-	sort := p.Field
-	if p.Descending {
-		sort += " DESC"
-	}
-	out = out.Order(sort)
-	return
-}
+type Sort = sort.Sort
 
 //
 // Decoder binding decoder.

--- a/api/bucket.go
+++ b/api/bucket.go
@@ -59,7 +59,7 @@ func (h BucketHandler) AddRoutes(e *gin.Engine) {
 // @router /buckets [get]
 func (h BucketHandler) List(ctx *gin.Context) {
 	var list []model.Bucket
-	result := h.Paginated(ctx).Find(&list)
+	result := h.DB(ctx).Find(&list)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)
 		return

--- a/api/businessservice.go
+++ b/api/businessservice.go
@@ -65,7 +65,7 @@ func (h BusinessServiceHandler) Get(ctx *gin.Context) {
 // @router /businessservices [get]
 func (h BusinessServiceHandler) List(ctx *gin.Context) {
 	var list []model.BusinessService
-	db := h.preLoad(h.Paginated(ctx), clause.Associations)
+	db := h.preLoad(h.DB(ctx), clause.Associations)
 	result := db.Find(&list)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)

--- a/api/dependency.go
+++ b/api/dependency.go
@@ -66,7 +66,7 @@ func (h DependencyHandler) Get(ctx *gin.Context) {
 func (h DependencyHandler) List(ctx *gin.Context) {
 	var list []model.Dependency
 
-	db := h.Paginated(ctx)
+	db := h.DB(ctx)
 	to := ctx.Query("to.id")
 	from := ctx.Query("from.id")
 	if to != "" {

--- a/api/file.go
+++ b/api/file.go
@@ -46,7 +46,7 @@ func (h FileHandler) AddRoutes(e *gin.Engine) {
 // @router /files [get]
 func (h FileHandler) List(ctx *gin.Context) {
 	var list []model.File
-	result := h.Paginated(ctx).Find(&list)
+	result := h.DB(ctx).Find(&list)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)
 		return

--- a/api/group.go
+++ b/api/group.go
@@ -65,7 +65,7 @@ func (h StakeholderGroupHandler) Get(ctx *gin.Context) {
 // @router /stakeholdergroups [get]
 func (h StakeholderGroupHandler) List(ctx *gin.Context) {
 	var list []model.StakeholderGroup
-	db := h.preLoad(h.Paginated(ctx), clause.Associations)
+	db := h.preLoad(h.DB(ctx), clause.Associations)
 	result := db.Find(&list)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)

--- a/api/identity.go
+++ b/api/identity.go
@@ -79,7 +79,7 @@ func (h IdentityHandler) List(ctx *gin.Context) {
 	var list []model.Identity
 	appId := ctx.Query(AppId)
 	kind := ctx.Query(Kind)
-	db := h.Paginated(ctx)
+	db := h.DB(ctx)
 	if appId != "" {
 		db = db.Where(
 			"id IN (SELECT identityID from ApplicationIdentity WHERE applicationID = ?)",

--- a/api/jobfunction.go
+++ b/api/jobfunction.go
@@ -65,7 +65,7 @@ func (h JobFunctionHandler) Get(ctx *gin.Context) {
 // @router /jobfunctions [get]
 func (h JobFunctionHandler) List(ctx *gin.Context) {
 	var list []model.JobFunction
-	db := h.preLoad(h.Paginated(ctx), clause.Associations)
+	db := h.preLoad(h.DB(ctx), clause.Associations)
 	result := db.Find(&list)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)

--- a/api/migrationwave.go
+++ b/api/migrationwave.go
@@ -66,7 +66,7 @@ func (h MigrationWaveHandler) Get(ctx *gin.Context) {
 // @router /migrationwaves [get]
 func (h MigrationWaveHandler) List(ctx *gin.Context) {
 	var list []model.MigrationWave
-	db := h.preLoad(h.Paginated(ctx), clause.Associations)
+	db := h.preLoad(h.DB(ctx), clause.Associations)
 	result := db.Find(&list)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)

--- a/api/proxy.go
+++ b/api/proxy.go
@@ -69,7 +69,7 @@ func (h ProxyHandler) Get(ctx *gin.Context) {
 func (h ProxyHandler) List(ctx *gin.Context) {
 	var list []model.Proxy
 	kind := ctx.Query(Kind)
-	db := h.preLoad(h.Paginated(ctx), clause.Associations)
+	db := h.preLoad(h.DB(ctx), clause.Associations)
 	if kind != "" {
 		db = db.Where(Kind, kind)
 	}

--- a/api/review.go
+++ b/api/review.go
@@ -67,7 +67,7 @@ func (h ReviewHandler) Get(ctx *gin.Context) {
 // @router /reviews [get]
 func (h ReviewHandler) List(ctx *gin.Context) {
 	var list []model.Review
-	db := h.preLoad(h.Paginated(ctx), clause.Associations)
+	db := h.preLoad(h.DB(ctx), clause.Associations)
 	result := db.Find(&list)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)

--- a/api/ruleset.go
+++ b/api/ruleset.go
@@ -68,7 +68,7 @@ func (h RuleSetHandler) Get(ctx *gin.Context) {
 func (h RuleSetHandler) List(ctx *gin.Context) {
 	var list []model.RuleSet
 	db := h.preLoad(
-		h.Paginated(ctx),
+		h.DB(ctx),
 		clause.Associations,
 		"Rules.File")
 	result := db.Find(&list)

--- a/api/setting.go
+++ b/api/setting.go
@@ -67,7 +67,7 @@ func (h SettingHandler) Get(ctx *gin.Context) {
 // @router /settings [get]
 func (h SettingHandler) List(ctx *gin.Context) {
 	var list []model.Setting
-	result := h.Paginated(ctx).Find(&list)
+	result := h.DB(ctx).Find(&list)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)
 		return

--- a/api/sort/error.go
+++ b/api/sort/error.go
@@ -1,0 +1,18 @@
+package sort
+
+import "fmt"
+
+//
+// SortError reports sorting error.
+type SortError struct {
+	field string
+}
+
+func (r *SortError) Error() string {
+	return fmt.Sprintf("\"%s\" not supported by sort.", r.field)
+}
+
+func (r *SortError) Is(err error) (matched bool) {
+	_, matched = err.(*SortError)
+	return
+}

--- a/api/sort/sort.go
+++ b/api/sort/sort.go
@@ -1,0 +1,149 @@
+package sort
+
+import (
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+	"reflect"
+	"strings"
+	"time"
+)
+
+//
+// Names column map.
+type Names map[string]string
+
+//
+// Clause sort clause.
+type Clause struct {
+	direction string
+	name      string
+}
+
+//
+// Sort provides sorting.
+type Sort struct {
+	names   Names
+	clauses []Clause
+}
+
+//
+// With context.
+// Fields formats:
+//   name
+//   name|column
+func (r *Sort) With(ctx *gin.Context, fields ...interface{}) (err error) {
+	param := ctx.Query("sort")
+	if param == "" {
+		return
+	}
+	r.names = make(Names)
+	for _, object := range fields {
+		switch object.(type) {
+		case string:
+			s := object.(string)
+			part := strings.SplitN(s, "|", 2)
+			name := strings.ToLower(part[0])
+			column := name
+			if len(part) == 2 {
+				column = part[1]
+			}
+			r.names[name] = column
+		default:
+			for _, s := range r.inspect(object) {
+				s = strings.ToLower(s)
+				r.names[s] = s
+			}
+		}
+	}
+	for _, s := range strings.Split(param, ",") {
+		clause := Clause{}
+		s = strings.TrimSpace(s)
+		s = strings.ToLower(s)
+		mark := strings.Index(s, ":")
+		if mark == -1 {
+			column, found := r.names[s]
+			if !found {
+				err = &SortError{s}
+				return
+			}
+			clause.name = column
+			r.clauses = append(
+				r.clauses,
+				clause)
+		} else {
+			d := strings.ToLower(s[:mark])
+			s := s[mark+1:]
+			if len(d) != 0 {
+				if d[0] == 'd' {
+					clause.direction = "DESC"
+				}
+			}
+			column, found := r.names[s]
+			if !found {
+				err = &SortError{s}
+				return
+			}
+			clause.name = column
+			r.clauses = append(
+				r.clauses,
+				clause)
+		}
+	}
+	return
+}
+
+//
+// Sorted returns sorted DB.
+func (r *Sort) Sorted(in *gorm.DB) (out *gorm.DB) {
+	out = in
+	if len(r.clauses) == 0 {
+		return
+	}
+	clauses := []string{}
+	for _, clause := range r.clauses {
+		clauses = append(clauses, clause.name+" "+clause.direction)
+	}
+	out = out.Order(strings.Join(clauses, ","))
+	return
+}
+
+//
+// inspect object and return fields.
+func (r *Sort) inspect(m interface{}) (fields []string) {
+	var inspect func(r interface{})
+	inspect = func(r interface{}) {
+		mt := reflect.TypeOf(r)
+		mv := reflect.ValueOf(r)
+		if mt.Kind() == reflect.Ptr {
+			mt = mt.Elem()
+			mv = mv.Elem()
+		}
+		for i := 0; i < mt.NumField(); i++ {
+			ft := mt.Field(i)
+			fv := mv.Field(i)
+			if !ft.IsExported() {
+				continue
+			}
+			switch fv.Kind() {
+			case reflect.Struct:
+				if ft.Anonymous {
+					inspect(fv.Interface())
+					continue
+				}
+				inst := fv.Interface()
+				switch inst.(type) {
+				case time.Time:
+					fields = append(fields, ft.Name)
+				}
+			case reflect.Array,
+				reflect.Slice,
+				reflect.Ptr:
+				continue
+			default:
+				fields = append(fields, ft.Name)
+			}
+		}
+	}
+	inspect(m)
+	return
+}

--- a/api/stakeholder.go
+++ b/api/stakeholder.go
@@ -65,7 +65,7 @@ func (h StakeholderHandler) Get(ctx *gin.Context) {
 // @router /stakeholders [get]
 func (h StakeholderHandler) List(ctx *gin.Context) {
 	var list []model.Stakeholder
-	db := h.preLoad(h.Paginated(ctx), clause.Associations)
+	db := h.preLoad(h.DB(ctx), clause.Associations)
 	result := db.Find(&list)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)

--- a/api/tag.go
+++ b/api/tag.go
@@ -65,7 +65,7 @@ func (h TagHandler) Get(ctx *gin.Context) {
 // @router /tags [get]
 func (h TagHandler) List(ctx *gin.Context) {
 	var list []model.Tag
-	db := h.preLoad(h.Paginated(ctx), clause.Associations)
+	db := h.preLoad(h.DB(ctx), clause.Associations)
 	result := db.Find(&list)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)

--- a/api/tagcategory.go
+++ b/api/tagcategory.go
@@ -69,7 +69,7 @@ func (h TagCategoryHandler) Get(ctx *gin.Context) {
 // @param name query string false "Optional category name filter"
 func (h TagCategoryHandler) List(ctx *gin.Context) {
 	var list []model.TagCategory
-	db := h.preLoad(h.Paginated(ctx), clause.Associations)
+	db := h.preLoad(h.DB(ctx), clause.Associations)
 	if name, found := ctx.GetQuery(Name); found {
 		db = db.Where("name = ?", name)
 	}

--- a/api/task.go
+++ b/api/task.go
@@ -96,7 +96,7 @@ func (h TaskHandler) Get(ctx *gin.Context) {
 // @router /tasks [get]
 func (h TaskHandler) List(ctx *gin.Context) {
 	var list []model.Task
-	db := h.Paginated(ctx)
+	db := h.DB(ctx)
 	locator := ctx.Query(LocatorParam)
 	if locator != "" {
 		db = db.Where("locator", locator)

--- a/api/taskgroup.go
+++ b/api/taskgroup.go
@@ -80,7 +80,7 @@ func (h TaskGroupHandler) Get(ctx *gin.Context) {
 // @router /taskgroups [get]
 func (h TaskGroupHandler) List(ctx *gin.Context) {
 	var list []model.TaskGroup
-	db := h.Paginated(ctx).Preload(clause.Associations)
+	db := h.DB(ctx).Preload(clause.Associations)
 	result := db.Find(&list)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)

--- a/api/ticket.go
+++ b/api/ticket.go
@@ -70,7 +70,7 @@ func (h TicketHandler) List(ctx *gin.Context) {
 	var list []model.Ticket
 	appId := ctx.Query(AppId)
 	trackerId := ctx.Query(TrackerId)
-	db := h.preLoad(h.Paginated(ctx), clause.Associations)
+	db := h.preLoad(h.DB(ctx), clause.Associations)
 	if appId != "" {
 		db = db.Where("ApplicationID = ?", appId)
 	}

--- a/api/tracker.go
+++ b/api/tracker.go
@@ -70,7 +70,7 @@ func (h TrackerHandler) Get(ctx *gin.Context) {
 // @router /trackers [get]
 func (h TrackerHandler) List(ctx *gin.Context) {
 	var list []model.Tracker
-	db := h.preLoad(h.Paginated(ctx), clause.Associations)
+	db := h.preLoad(h.DB(ctx), clause.Associations)
 	kind := ctx.Query(Kind)
 	if kind != "" {
 		db = db.Where(Kind, kind)


### PR DESCRIPTION
Revert the usage of h.Paginated().
Removed BaseHandler.Paginated() because - Paginated endpoints need to fetch the count using the un-paginated DB client.  Then, add the pagination and sorting when fetching the models. 

Moved the sorting object to the _new_ sort package.

The Sort.With() enhanced to provide both validation (of supported files) and mapping to actual selected columns.