### PR TITLE
Fix Pathfinder assessment counting

### DIFF
--- a/api/pathfinder.go
+++ b/api/pathfinder.go
@@ -52,7 +52,7 @@ func (h PathfinderHandler) ReverseProxy(ctx *gin.Context) {
 		},
 	}
 
-	if ctx.Request.Method == http.MethodPost {
+	if ctx.Request.URL.Path == path.Join(PathfinderRoot, AssessmentsRoot) && ctx.Request.Method == http.MethodPost {
 		metrics.AssessmentsInitiated.Inc()
 	}
 


### PR DESCRIPTION
The UI makes POST requests to /pathfinder/assessments/assessment-risk in order to show the calculated risk on the side bar. This needs to be excluded in order to be sure we're only counting initiated assessments.

Check that POST requests are to /pathfinder/assessments.

Fixes https://issues.redhat.com/browse/MTA-682