### PR TITLE
:bug: Addon fact put

### DIFF
--- a/addon/application.go
+++ b/addon/application.go
@@ -247,7 +247,7 @@ func (h *AppFacts) Set(key string, value interface{}) (err error) {
 			api.Key:    key,
 			api.Source: h.source,
 		})
-	err = h.client.Put(path, value)
+	err = h.client.Put(path, api.Fact{Value: value})
 	return
 }
 

--- a/api/application.go
+++ b/api/application.go
@@ -719,7 +719,9 @@ func (h ApplicationHandler) FactPut(ctx *gin.Context) {
 			ApplicationID: id,
 			Value:         value,
 		}
-		result = h.DB(ctx).Create(m)
+		db := h.DB(ctx)
+		db = db.Clauses(clause.OnConflict{UpdateAll: true})
+		result = db.Create(m)
 		if result.Error != nil {
 			_ = ctx.Error(result.Error)
 			return

--- a/hack/update/fact.sh
+++ b/hack/update/fact.sh
@@ -2,7 +2,7 @@
 
 host="${HOST:-localhost:8080}"
 
-curl -X PUT ${host}/applications/1/facts/address \
+curl -L -X PUT ${host}/applications/1/facts/address \
   -H 'Content-Type:application/x-yaml' \
   -H 'Accept:application/x-yaml' \
   -d \

--- a/hack/update/fact.sh
+++ b/hack/update/fact.sh
@@ -2,4 +2,15 @@
 
 host="${HOST:-localhost:8080}"
 
-curl -X PUT ${host}/applications/1/facts/address -d \ '{"street": "Maple","City":"Huntsville","State":"AL"}' | jq -M .
+curl -X PUT ${host}/applications/1/facts/address \
+  -H 'Content-Type:application/x-yaml' \
+  -H 'Accept:application/x-yaml' \
+  -d \
+'
+---
+value:
+  street: 1234 Maple St.
+  city: Huntsville
+  state: AL
+  zip: 35763
+'


### PR DESCRIPTION
Fix the addon binding: Body is Fact (not the value).
Fix Both GORM create and save will add ON CONFLICT clause when the PK is set.  When source="", the entire composite PK is not considered set.

Backport: 0.2