### PR TITLE
:ghost: IssueReport refactored into: AppReport.

### DIFF
--- a/api/analysis.go
+++ b/api/analysis.go
@@ -728,8 +728,8 @@ func (h AnalysisHandler) RuleReports(ctx *gin.Context) {
 	q = q.Where("a.ID in (?)", h.analysisIDs(ctx, filter))
 	q = q.Where("i.ID IN (?)", h.issueIDs(ctx, filter.Resource("issue")))
 	q = q.Group("i.RuleSet,i.Rule")
-	q = filter.Where(q, "-Labels")
 	// Count.
+	filter = filter.With("-Labels")
 	count, err := h.count(h.DB(ctx), q, filter)
 	if err != nil {
 		_ = ctx.Error(err)
@@ -753,6 +753,7 @@ func (h AnalysisHandler) RuleReports(ctx *gin.Context) {
 	db := h.DB(ctx)
 	db = db.Select("*")
 	db = db.Table("(?)", q)
+	db = filter.Where(db)
 	db = h.paginated(ctx, db)
 	var list []M
 	result := db.Find(&list)
@@ -873,7 +874,8 @@ func (h AnalysisHandler) AppReports(ctx *gin.Context) {
 	q = q.Where("i.ID IN (?)", h.issueIDs(ctx, filter.Resource("issue")))
 	q = q.Group("i.ID")
 	// Count.
-	count, err := h.count(h.DB(ctx), q, filter.With("-Labels"))
+	filter = filter.With("-Labels")
+	count, err := h.count(h.DB(ctx), q, filter)
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -909,6 +911,7 @@ func (h AnalysisHandler) AppReports(ctx *gin.Context) {
 	db := h.DB(ctx)
 	db = db.Select("*")
 	db = db.Table("(?)", q)
+	db = filter.Where(db)
 	db = h.paginated(ctx, db)
 	var list []M
 	result := db.Find(&list)
@@ -1009,6 +1012,7 @@ func (h AnalysisHandler) FileReports(ctx *gin.Context) {
 	db := h.DB(ctx)
 	db = db.Select("*")
 	db = db.Table("(?)", q)
+	db = filter.Where(db)
 	db = h.paginated(ctx, db)
 	result = db.Find(&list)
 	if result.Error != nil {
@@ -1178,6 +1182,7 @@ func (h AnalysisHandler) DepReports(ctx *gin.Context) {
 	db := h.DB(ctx)
 	db = db.Select("*")
 	db = db.Table("(?)", q)
+	db = filter.Where(db)
 	db = h.paginated(ctx, db)
 	result := db.Scan(&list)
 	if result.Error != nil {

--- a/api/analysis.go
+++ b/api/analysis.go
@@ -17,17 +17,17 @@ import (
 //
 // Routes
 const (
-	AnalysesRoot            = "/analyses"
-	AnalysisRoot            = AnalysesRoot + "/:" + ID
-	AnalysesDepsRoot        = AnalysesRoot + "/dependencies"
-	AnalysesIssuesRoot      = AnalysesRoot + "/issues"
-	AnalysesIssueRoot       = AnalysesIssuesRoot + "/:" + ID
-	AnalysisIncidentsRoot   = AnalysesIssueRoot + "/incidents"
-	AnalysesReportRoot      = AnalysesRoot + "/report"
-	AnalysisReportDepRoot   = AnalysesReportRoot + "/dependencies"
-	AnalysisReportRuleRoot  = AnalysesReportRoot + "/rules"
-	AnalysisReportIssueRoot = AnalysesReportRoot + "/issues"
-	AnalysisReportFileRoot  = AnalysisReportIssueRoot + "/:" + ID + "/files"
+	AnalysesRoot           = "/analyses"
+	AnalysisRoot           = AnalysesRoot + "/:" + ID
+	AnalysesDepsRoot       = AnalysesRoot + "/dependencies"
+	AnalysesIssuesRoot     = AnalysesRoot + "/issues"
+	AnalysesIssueRoot      = AnalysesIssuesRoot + "/:" + ID
+	AnalysisIncidentsRoot  = AnalysesIssueRoot + "/incidents"
+	AnalysesReportRoot     = AnalysesRoot + "/report"
+	AnalysisReportDepRoot  = AnalysesReportRoot + "/dependencies"
+	AnalysisReportRuleRoot = AnalysesReportRoot + "/rules"
+	AnalysisReportAppRoot  = AnalysesReportRoot + "/applications"
+	AnalysisReportFileRoot = AnalysesReportRoot + "/issues/:" + ID + "/files"
 
 	AppAnalysesRoot       = ApplicationRoot + "/analyses"
 	AppAnalysisRoot       = ApplicationRoot + "/analysis"
@@ -59,7 +59,7 @@ func (h AnalysisHandler) AddRoutes(e *gin.Engine) {
 	routeGroup.GET(AnalysesIssueRoot, h.Issue)
 	routeGroup.GET(AnalysisIncidentsRoot, h.Incidents)
 	routeGroup.GET(AnalysisReportRuleRoot, h.RuleReports)
-	routeGroup.GET(AnalysisReportIssueRoot, h.IssueReports)
+	routeGroup.GET(AnalysisReportAppRoot, h.AppReports)
 	routeGroup.GET(AnalysisReportFileRoot, h.FileReports)
 	routeGroup.GET(AnalysisReportDepRoot, h.DepReports)
 	//
@@ -553,16 +553,9 @@ func (h AnalysisHandler) Issues(ctx *gin.Context) {
 	db = db.Table("Issue i")
 	db = db.Joins(",Analysis a")
 	db = db.Where("a.ID = i.AnalysisID")
-	db = db.Where("a.ID IN (?)", h.analysisIDs(ctx, &filter))
+	db = db.Where("a.ID IN (?)", h.analysisIDs(ctx, filter))
+	db = db.Where("i.ID IN (?)", h.issueIDs(ctx, filter))
 	db = db.Group("i.ID")
-	db = filter.Where(db, "-Labels")
-	n, q := h.withLabels(
-		&model.Issue{},
-		ctx,
-		&filter)
-	if n > 0 {
-		db = db.Where("i.ID IN (?)", q)
-	}
 	// Count.
 	count := int64(0)
 	result := db.Model(&model.Issue{}).Count(&count)
@@ -685,8 +678,16 @@ func (h AnalysisHandler) Incidents(ctx *gin.Context) {
 // @description - category
 // @description - effort
 // @description - labels
-// @description - application.(id|name)
+// @description - applications
+// @description - application.id
+// @description - application.name
 // @description - tag.id
+// @description sort:
+// @description - ruleset
+// @description - rule
+// @description - category
+// @description - effort
+// @description - applications
 // @tags rulereports
 // @produce json
 // @success 200 {object} []api.RuleReport
@@ -700,18 +701,19 @@ func (h AnalysisHandler) RuleReports(ctx *gin.Context) {
 			{Field: "rule", Kind: qf.STRING},
 			{Field: "category", Kind: qf.STRING},
 			{Field: "effort", Kind: qf.LITERAL},
-			{Field: "affected", Kind: qf.LITERAL},
 			{Field: "labels", Kind: qf.STRING, Relation: true},
+			{Field: "applications", Kind: qf.LITERAL},
 			{Field: "application.id", Kind: qf.STRING},
 			{Field: "application.name", Kind: qf.STRING},
+			{Field: "businessService.name", Kind: qf.STRING},
 			{Field: "tag.id", Kind: qf.LITERAL, Relation: true},
 		})
 	if err != nil {
 		_ = ctx.Error(err)
 		return
 	}
-	db := h.DB(ctx)
-	db = db.Select(
+	q := h.DB(ctx)
+	q = q.Select(
 		"i.RuleSet",
 		"i.Rule",
 		"i.Name",
@@ -720,24 +722,17 @@ func (h AnalysisHandler) RuleReports(ctx *gin.Context) {
 		"i.Effort",
 		"i.Labels",
 		"COUNT(distinct a.ID) Applications")
-	db = db.Table("Issue i,")
-	db = db.Joins("Analysis a")
-	db = db.Where("a.ID = i.AnalysisID")
-	db = db.Where("a.ID in (?)", h.analysisIDs(ctx, &filter))
-	db = filter.Where(db, "-Labels")
-	n, q := h.withLabels(
-		&model.Issue{},
-		ctx,
-		&filter)
-	if n > 0 {
-		db = db.Where("i.ID IN (?)", q)
-	}
-	db = db.Group("i.RuleSet,i.Rule")
+	q = q.Table("Issue i,")
+	q = q.Joins("Analysis a")
+	q = q.Where("a.ID = i.AnalysisID")
+	q = q.Where("a.ID in (?)", h.analysisIDs(ctx, filter))
+	q = q.Where("i.ID IN (?)", h.issueIDs(ctx, filter.Resource("issue")))
+	q = q.Group("i.RuleSet,i.Rule")
+	q = filter.Where(q, "-Labels")
 	// Count.
-	count := int64(0)
-	result := db.Model(&model.Issue{}).Count(&count)
-	if result.Error != nil {
-		_ = ctx.Error(result.Error)
+	count, err := h.count(h.DB(ctx), q, filter)
+	if err != nil {
+		_ = ctx.Error(err)
 		return
 	}
 	if count == 0 {
@@ -755,9 +750,12 @@ func (h AnalysisHandler) RuleReports(ctx *gin.Context) {
 		model.Issue
 		Applications int
 	}
-	var list []M
+	db := h.DB(ctx)
+	db = db.Select("*")
+	db = db.Table("(?)", q)
 	db = h.paginated(ctx, db)
-	result = db.Scan(&list)
+	var list []M
+	result := db.Find(&list)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)
 		return
@@ -792,64 +790,92 @@ func (h AnalysisHandler) RuleReports(ctx *gin.Context) {
 	h.Respond(ctx, http.StatusOK, resources)
 }
 
-// IssueReports godoc
-// @summary List issue reports.
-// @description Each report collates issues by ruleset/rule and application.
+// AppReports godoc
+// @summary List application reports.
+// @description List application reports.
 // @description filters:
-// @description - ruleset
-// @description - rule
+// @description - id
 // @description - name
-// @description - category
+// @description - description
+// @description - businessService
 // @description - effort
-// @description - labels
-// @description - application.(id|name)
-// @description - tag.id
-// @tags issuereports
+// @description - incidents
+// @description - files
+// @description - issue.id
+// @description - issue.name
+// @description - issue.ruleset
+// @description - issue.rule
+// @description - issue.category
+// @description - issue.effort
+// @description - issue.labels
+// @description - application.id
+// @description - application.name
+// @description - businessService.name
+// @description sort:
+// @description - id
+// @description - name
+// @description - description
+// @description - businessService
+// @description - effort
+// @description - incidents
+// @description - files
+// @tags appreports
 // @produce json
-// @success 200 {object} []api.IssueReport
-// @router /analyses/report/issues [get]
-func (h AnalysisHandler) IssueReports(ctx *gin.Context) {
-	resources := []IssueReport{}
+// @success 200 {object} []api.AppReport
+// @router /analyses/report/applications [get]
+func (h AnalysisHandler) AppReports(ctx *gin.Context) {
+	resources := []AppReport{}
 	// Build query.
 	filter, err := qf.New(ctx,
 		[]qf.Assert{
-			{Field: "ruleset", Kind: qf.STRING},
-			{Field: "rule", Kind: qf.STRING},
+			{Field: "id", Kind: qf.STRING},
 			{Field: "name", Kind: qf.STRING},
-			{Field: "category", Kind: qf.STRING},
+			{Field: "description", Kind: qf.STRING},
+			{Field: "businessService", Kind: qf.STRING},
 			{Field: "effort", Kind: qf.LITERAL},
-			{Field: "labels", Kind: qf.STRING, Relation: true},
+			{Field: "incidents", Kind: qf.LITERAL},
+			{Field: "files", Kind: qf.LITERAL},
+			{Field: "issue.id", Kind: qf.LITERAL},
+			{Field: "issue.name", Kind: qf.LITERAL},
+			{Field: "issue.ruleset", Kind: qf.STRING},
+			{Field: "issue.rule", Kind: qf.STRING},
+			{Field: "issue.category", Kind: qf.STRING},
+			{Field: "issue.effort", Kind: qf.LITERAL},
+			{Field: "issue.labels", Kind: qf.STRING, Relation: true},
 			{Field: "application.id", Kind: qf.LITERAL},
 			{Field: "application.name", Kind: qf.STRING},
+			{Field: "businessService.name", Kind: qf.STRING},
 			{Field: "tag.id", Kind: qf.LITERAL, Relation: true},
 		})
 	if err != nil {
 		_ = ctx.Error(err)
 		return
 	}
-	db := h.DB(ctx)
-	db = db.Table("Issue i")
-	db = db.Joins(",Incident n")
-	db = db.Joins(",Analysis a")
-	db = db.Joins(",Application app")
-	db = db.Where("a.ApplicationID = app.ID")
-	db = db.Where("n.IssueID = i.ID")
-	db = db.Where("a.ID = i.AnalysisID")
-	db = db.Where("a.ID IN (?)", h.analysisIDs(ctx, &filter))
-	db = db.Group("i.ID")
-	db = filter.Where(db, "-Labels")
-	n, q := h.withLabels(
-		&model.Issue{},
-		ctx,
-		&filter)
-	if n > 0 {
-		db = db.Where("i.ID IN (?)", q)
-	}
+	q := h.DB(ctx)
+	q = q.Select(
+		"app.ID",
+		"app.Name",
+		"app.Description",
+		"b.Name BusinessService",
+		"a.Effort",
+		"COUNT(n.ID) Incidents",
+		"COUNT(distinct n.File) Files",
+		"i.ID IssueID",
+		"i.Name IssueName",
+		"i.RuleSet",
+		"i.Rule")
+	q = q.Table("Issue i")
+	q = q.Joins("LEFT JOIN Incident n ON n.IssueID = i.ID")
+	q = q.Joins("LEFT JOIN Analysis a ON a.ID = i.AnalysisID")
+	q = q.Joins("LEFT JOIN Application app ON app.ID = a.ApplicationID")
+	q = q.Joins("LEFT OUTER JOIN BusinessService b ON b.ID = app.BusinessServiceID")
+	q = q.Where("a.ID IN (?)", h.analysisIDs(ctx, filter))
+	q = q.Where("i.ID IN (?)", h.issueIDs(ctx, filter.Resource("issue")))
+	q = q.Group("i.ID")
 	// Count.
-	count := int64(0)
-	result := db.Model(&model.Issue{}).Count(&count)
-	if result.Error != nil {
-		_ = ctx.Error(result.Error)
+	count, err := h.count(h.DB(ctx), q, filter.With("-Labels"))
+	if err != nil {
+		_ = ctx.Error(err)
 		return
 	}
 	if count == 0 {
@@ -868,39 +894,42 @@ func (h AnalysisHandler) IssueReports(ctx *gin.Context) {
 	//
 	// Find.
 	type M struct {
-		model.Issue
-		Incidents int
-		Files     int
-		AppID     uint
-		AppName   string
-		AppEffort int
+		ID              uint
+		Name            string
+		Description     string
+		BusinessService string
+		Effort          int
+		Incidents       int
+		Files           int
+		IssueID         uint
+		IssueName       string
+		RuleSet         string
+		Rule            string
 	}
+	db := h.DB(ctx)
+	db = db.Select("*")
+	db = db.Table("(?)", q)
 	db = h.paginated(ctx, db)
-	db = db.Select(
-		"i.*",
-		"COUNT(n.ID) Incidents",
-		"COUNT(distinct n.File) Files",
-		"app.ID AppID",
-		"app.Name AppName",
-		"a.Effort AppEffort")
 	var list []M
-	result = db.Find(&list)
+	result := db.Find(&list)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)
 		return
 	}
 	for i := range list {
 		m := &list[i]
-		r := IssueReport{}
-		r.With(&m.Issue)
+		r := AppReport{}
+		r.ID = m.ID
+		r.Name = m.Name
+		r.Description = m.Description
+		r.BusinessService = m.BusinessService
 		r.Effort = m.Effort
 		r.Incidents = m.Incidents
 		r.Files = m.Files
-		r.Application.Ref = Ref{
-			ID:   m.AppID,
-			Name: m.AppName,
-		}
-		r.Application.Effort = m.AppEffort
+		r.Issue.ID = m.IssueID
+		r.Issue.Name = m.IssueName
+		r.Issue.RuleSet = m.RuleSet
+		r.Issue.Rule = m.Rule
 		resources = append(resources, r)
 	}
 
@@ -911,6 +940,10 @@ func (h AnalysisHandler) IssueReports(ctx *gin.Context) {
 // @summary List incident file reports.
 // @description Each report collates incidents by file.
 // @description filters:
+// @description - file
+// @description - effort
+// @description - incidents
+// @description sort:
 // @description - file
 // @description - effort
 // @description - incidents
@@ -951,11 +984,7 @@ func (h AnalysisHandler) FileReports(ctx *gin.Context) {
 	q = q.Where("Issue.ID", issueId)
 	q = q.Group("File")
 	// Count.
-	db := h.DB(ctx)
-	db = db.Select("*")
-	db = db.Table("(?)", q)
-	db = filter.Where(db)
-	count, err := h.count(db, q)
+	count, err := h.count(h.DB(ctx), q, filter)
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -977,6 +1006,9 @@ func (h AnalysisHandler) FileReports(ctx *gin.Context) {
 		Incidents int
 	}
 	var list []M
+	db := h.DB(ctx)
+	db = db.Select("*")
+	db = db.Table("(?)", q)
 	db = h.paginated(ctx, db)
 	result = db.Find(&list)
 	if result.Error != nil {
@@ -1031,15 +1063,8 @@ func (h AnalysisHandler) Deps(ctx *gin.Context) {
 		return
 	}
 	db := h.DB(ctx)
-	db = db.Where("AnalysisID IN (?)", h.analysisIDs(ctx, &filter))
-	db = filter.Where(db, "-Labels")
-	n, q := h.withLabels(
-		&model.TechDependency{},
-		ctx,
-		&filter)
-	if n > 0 {
-		db = db.Where("ID IN (?)", q)
-	}
+	db = db.Where("AnalysisID IN (?)", h.analysisIDs(ctx, filter))
+	db = db.Where("ID IN (?)", h.depIDs(ctx, filter))
 	// Count.
 	count := int64(0)
 	result := db.Model(&model.TechDependency{}).Count(&count)
@@ -1082,8 +1107,13 @@ func (h AnalysisHandler) Deps(ctx *gin.Context) {
 // @description - sha
 // @description - indirect
 // @description - labels
-// @description - application.(id|name)
+// @description - application.id
+// @description - application.name
 // @description - tag.id
+// @description sort:
+// @description - name
+// @description - version
+// @description - sha
 // @tags dependencies
 // @produce json
 // @success 200 {object} []api.TechDependency
@@ -1098,6 +1128,7 @@ func (h AnalysisHandler) DepReports(ctx *gin.Context) {
 			{Field: "sha", Kind: qf.STRING},
 			{Field: "indirect", Kind: qf.STRING},
 			{Field: "labels", Kind: qf.STRING, Relation: true},
+			{Field: "applications", Kind: qf.LITERAL},
 			{Field: "application.id", Kind: qf.LITERAL},
 			{Field: "application.name", Kind: qf.STRING},
 			{Field: "tag.id", Kind: qf.LITERAL, Relation: true},
@@ -1106,23 +1137,17 @@ func (h AnalysisHandler) DepReports(ctx *gin.Context) {
 		_ = ctx.Error(err)
 		return
 	}
-	db := h.DB(ctx)
-	db = db.Select(
+	q := h.DB(ctx)
+	q = q.Select(
 		"Name",
 		"Version",
 		"SHA",
 		"Labels",
 		"COUNT(distinct AnalysisID) Applications")
-	db = db.Where("AnalysisID IN (?)", h.analysisIDs(ctx, &filter))
-	db = filter.Where(db, "-Labels")
-	n, q := h.withLabels(
-		&model.TechDependency{},
-		ctx,
-		&filter)
-	if n > 0 {
-		db = db.Where("ID IN (?)", q)
-	}
-	db = db.Group(
+	q = q.Model(&model.TechDependency{})
+	q = q.Where("AnalysisID IN (?)", h.analysisIDs(ctx, filter))
+	q = q.Where("ID IN (?)", h.depIDs(ctx, filter))
+	q = q.Group(
 		strings.Join(
 			[]string{
 				"Name",
@@ -1130,10 +1155,9 @@ func (h AnalysisHandler) DepReports(ctx *gin.Context) {
 			},
 			","))
 	// Count.
-	count := int64(0)
-	result := db.Model(&model.TechDependency{}).Count(&count)
-	if result.Error != nil {
-		_ = ctx.Error(result.Error)
+	count, err := h.count(h.DB(ctx), q, filter)
+	if err != nil {
+		_ = ctx.Error(err)
 		return
 	}
 	if count == 0 {
@@ -1151,8 +1175,11 @@ func (h AnalysisHandler) DepReports(ctx *gin.Context) {
 		Applications int
 	}
 	var list []M
+	db := h.DB(ctx)
+	db = db.Select("*")
+	db = db.Table("(?)", q)
 	db = h.paginated(ctx, db)
-	result = db.Scan(&list)
+	result := db.Scan(&list)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)
 		return
@@ -1176,9 +1203,9 @@ func (h AnalysisHandler) DepReports(ctx *gin.Context) {
 
 //
 // Count rows returned by q.
-func (h *BaseHandler) count(db, q *gorm.DB) (count int64, err error) {
-	db = db.Select("*")
+func (h *BaseHandler) count(db, q *gorm.DB, f qf.Filter) (count int64, err error) {
 	db = db.Table("(?)", q)
+	db = f.Where(db)
 	err = db.Count(&count).Error
 	return
 }
@@ -1188,7 +1215,7 @@ func (h *BaseHandler) count(db, q *gorm.DB) (count int64, err error) {
 // filter:
 // - application.(id|name)
 // - tag.id
-func (h *AnalysisHandler) appIDs(ctx *gin.Context, f *qf.Filter) (q *gorm.DB) {
+func (h *AnalysisHandler) appIDs(ctx *gin.Context, f qf.Filter) (q *gorm.DB) {
 	q = h.DB(ctx)
 	q = q.Model(&model.Application{})
 	q = q.Select("ID")
@@ -1216,12 +1243,20 @@ func (h *AnalysisHandler) appIDs(ctx *gin.Context, f *qf.Filter) (q *gorm.DB) {
 			q = q.Where("ID IN (?)", tq)
 		}
 	}
+	bsFilter := f.Resource("businessService")
+	if !bsFilter.Empty() {
+		bq := h.DB(ctx)
+		bq.Model(&model.BusinessService{})
+		bq.Select("ID")
+		bq = bsFilter.Where(bq)
+		return
+	}
 	return
 }
 
 //
 // analysisIDs provides analysis IDs.
-func (h *AnalysisHandler) analysisIDs(ctx *gin.Context, f *qf.Filter) (q *gorm.DB) {
+func (h *AnalysisHandler) analysisIDs(ctx *gin.Context, f qf.Filter) (q *gorm.DB) {
 	q = h.DB(ctx)
 	q = q.Model(&model.Analysis{})
 	q = q.Select("MAX(ID)")
@@ -1231,18 +1266,21 @@ func (h *AnalysisHandler) analysisIDs(ctx *gin.Context, f *qf.Filter) (q *gorm.D
 }
 
 //
-// withLabels returns IDs filtered by label.
-// filter:
-//   - labels
-func (h *AnalysisHandler) withLabels(m interface{}, ctx *gin.Context, f *qf.Filter) (n int, q *gorm.DB) {
+// issueIDs returns issue filtered issue IDs.
+// Filter:
+//  issue.*
+func (h *AnalysisHandler) issueIDs(ctx *gin.Context, f qf.Filter) (q *gorm.DB) {
+	q = h.DB(ctx)
+	q = q.Model(&model.Issue{})
+	q = q.Select("ID")
+	q = f.Where(q, "-Labels")
 	filter := f
 	if f, found := filter.Field("labels"); found {
-		n = len(f.Value)
 		if f.Value.Operator(qf.AND) {
 			var qs []*gorm.DB
 			for _, v := range f.Value.ByKind(qf.LITERAL, qf.STRING) {
 				q := h.DB(ctx)
-				q = q.Model(m)
+				q = q.Table("Issue")
 				q = q.Joins("m ,json_each(Labels)")
 				q = q.Select("m.ID")
 				q = q.Where("json_each.value = ?", qf.AsValue(v))
@@ -1252,7 +1290,41 @@ func (h *AnalysisHandler) withLabels(m interface{}, ctx *gin.Context, f *qf.Filt
 		} else {
 			f = f.As("json_each.value")
 			q = h.DB(ctx)
-			q = q.Model(m)
+			q = q.Table("Issue")
+			q = q.Joins("m ,json_each(Labels)")
+			q = q.Select("m.ID")
+			q = q.Where(f.SQL())
+		}
+	}
+	return
+}
+
+//
+// depIDs returns issue filtered issue IDs.
+// Filter:
+//  techDeps.*
+func (h *AnalysisHandler) depIDs(ctx *gin.Context, f qf.Filter) (q *gorm.DB) {
+	q = h.DB(ctx)
+	q = q.Model(&model.TechDependency{})
+	q = q.Select("ID")
+	q = f.Where(q, "-Labels")
+	filter := f
+	if f, found := filter.Field("labels"); found {
+		if f.Value.Operator(qf.AND) {
+			var qs []*gorm.DB
+			for _, v := range f.Value.ByKind(qf.LITERAL, qf.STRING) {
+				q := h.DB(ctx)
+				q = q.Table("Issue")
+				q = q.Joins("m ,json_each(Labels)")
+				q = q.Select("m.ID")
+				q = q.Where("json_each.value = ?", qf.AsValue(v))
+				qs = append(qs, q)
+			}
+			q = model.Intersect(qs...)
+		} else {
+			f = f.As("json_each.value")
+			q = h.DB(ctx)
+			q = q.Table("Issue")
 			q = q.Joins("m ,json_each(Labels)")
 			q = q.Select("m.ID")
 			q = q.Where(f.SQL())
@@ -1482,45 +1554,21 @@ func (r *RuleReport) RuleId() (id string) {
 }
 
 //
-// IssueReport REST resource.
-type IssueReport struct {
-	Resource    `yaml:",inline"`
-	RuleSet     string   `json:"ruleset"`
-	Rule        string   `json:"rule"`
-	Name        string   `json:"name"`
-	Description string   `json:"description,omitempty" yaml:",omitempty"`
-	Category    string   `json:"category"`
-	Effort      int      `json:"effort,omitempty" yaml:",omitempty"`
-	Links       []Link   `json:"links,omitempty" yaml:",omitempty"`
-	Facts       FactMap  `json:"facts,omitempty" yaml:",omitempty"`
-	Labels      []string `json:"labels"`
-	Incidents   int      `json:"incidents"`
-	Files       int      `json:"files"`
-	Application struct {
-		Ref    `yaml:",inline"`
-		Effort int `json:"effort"`
-	} `json:"application"`
-}
-
-//
-// With updates the resource with the model.
-func (r *IssueReport) With(m *model.Issue) {
-	r.Resource.With(&m.Model)
-	r.RuleSet = m.RuleSet
-	r.Rule = m.Rule
-	r.Name = m.Name
-	r.Description = m.Description
-	r.Category = m.Category
-	if m.Links != nil {
-		_ = json.Unmarshal(m.Links, &r.Links)
-	}
-	if m.Facts != nil {
-		_ = json.Unmarshal(m.Facts, &r.Facts)
-	}
-	if m.Labels != nil {
-		_ = json.Unmarshal(m.Labels, &r.Labels)
-	}
-	r.Effort = m.Effort
+// AppReport REST resource.
+type AppReport struct {
+	ID              uint   `json:"id"`
+	Name            string `json:"name"`
+	Description     string `json:"description"`
+	BusinessService string `json:"businessService"`
+	Effort          int    `json:"effort"`
+	Incidents       int    `json:"incidents"`
+	Files           int    `json:"files"`
+	Issue           struct {
+		ID      uint   `json:"id"`
+		Name    string `json:"name"`
+		RuleSet string `json:"ruleset"`
+		Rule    string `json:"rule"`
+	} `json:"issue"`
 }
 
 //

--- a/api/filter/filter.go
+++ b/api/filter/filter.go
@@ -122,6 +122,19 @@ func (f *Filter) Where(in *gorm.DB, selector ...string) (out *gorm.DB) {
 }
 
 //
+// With return filter with selected predicates.
+func (f *Filter) With(selector ...string) (out Filter) {
+	fs := FieldSelector(selector)
+	for _, p := range f.predicates {
+		field := Field{p}
+		if fs.Match(&field) {
+			out.predicates = append(out.predicates, p)
+		}
+	}
+	return
+}
+
+//
 // Delete specified fields.
 func (f *Filter) Delete(name string) (found bool) {
 	var wanted []Predicate

--- a/api/filter/filter_test.go
+++ b/api/filter/filter_test.go
@@ -340,3 +340,27 @@ func TestFieldSelector(t *testing.T) {
 	g.Expect(selector.Match(field("two"))).To(gomega.BeTrue())
 	g.Expect(selector.Match(field("resource.one"))).ToNot(gomega.BeTrue())
 }
+
+func TestFilterWith(t *testing.T) {
+	var err error
+	g := gomega.NewGomegaWithT(t)
+	p := Parser{}
+
+	filter, err := p.Filter("name:elmer,age:20,category=(a|b|c)")
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(len(filter.predicates)).To(gomega.Equal(3))
+	g.Expect(filter.Empty()).To(gomega.BeFalse())
+
+	f := filter.With("-name")
+	_, hasName := f.Field("name")
+	g.Expect(len(f.predicates)).To(gomega.Equal(2))
+	g.Expect(hasName).To(gomega.BeFalse())
+
+	f = filter.With("+name", "+age")
+	_, hasName = f.Field("name")
+	_, hasAge := f.Field("age")
+	_, hasCat := f.Field("category")
+	g.Expect(len(f.predicates)).To(gomega.Equal(2))
+	g.Expect(hasAge).To(gomega.BeTrue())
+	g.Expect(hasCat).To(gomega.BeFalse())
+}

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -122,7 +122,7 @@ const docTemplate = `{
         },
         "/analyses/dependencies": {
             "get": {
-                "description": "Each report collates dependencies by name and SHA.\nfilters:\n- name\n- version\n- sha\n- indirect\n- labels\n- application.(id|name)\n- tag.id",
+                "description": "Each report collates dependencies by name and SHA.\nfilters:\n- name\n- version\n- sha\n- indirect\n- labels\n- application.id\n- application.name\n- tag.id\nsort:\n- name\n- version\n- sha",
                 "produces": [
                     "application/json"
                 ],
@@ -209,23 +209,23 @@ const docTemplate = `{
                 }
             }
         },
-        "/analyses/report/issues": {
+        "/analyses/report/applications": {
             "get": {
-                "description": "Each report collates issues by ruleset/rule and application.\nfilters:\n- ruleset\n- rule\n- name\n- category\n- effort\n- labels\n- application.(id|name)\n- tag.id",
+                "description": "List application reports.\nfilters:\n- id\n- name\n- description\n- businessService\n- effort\n- incidents\n- files\n- issue.id\n- issue.name\n- issue.ruleset\n- issue.rule\n- issue.category\n- issue.effort\n- issue.labels\n- application.id\n- application.name\n- businessService.name\nsort:\n- id\n- name\n- description\n- businessService\n- effort\n- incidents\n- files",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
-                    "issuereports"
+                    "appreports"
                 ],
-                "summary": "List issue reports.",
+                "summary": "List application reports.",
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/api.IssueReport"
+                                "$ref": "#/definitions/api.AppReport"
                             }
                         }
                     }
@@ -234,7 +234,7 @@ const docTemplate = `{
         },
         "/analyses/report/issues/{id}/files": {
             "get": {
-                "description": "Each report collates incidents by file.",
+                "description": "Each report collates incidents by file.\nfilters:\n- file\n- effort\n- incidents\nsort:\n- file\n- effort\n- incidents",
                 "produces": [
                     "application/json"
                 ],
@@ -257,7 +257,7 @@ const docTemplate = `{
         },
         "/analyses/report/rules": {
             "get": {
-                "description": "Each report collates issues by ruleset/rule.\nfilters:\n- ruleset\n- rule\n- category\n- effort\n- labels\n- application.(id|name)\n- tag.id",
+                "description": "Each report collates issues by ruleset/rule.\nfilters:\n- ruleset\n- rule\n- category\n- effort\n- labels\n- applications\n- application.id\n- application.name\n- tag.id\nsort:\n- ruleset\n- rule\n- category\n- effort\n- applications",
                 "produces": [
                     "application/json"
                 ],
@@ -330,10 +330,7 @@ const docTemplate = `{
         },
         "/application/{id}/analyses": {
             "post": {
-                "description": "Create an analysis.\nForm fields:\n- issues: file that multiple api.Issue resources.\n- dependencies: file that multiple api.TechDependency resources.",
-                "consumes": [
-                    "application/json"
-                ],
+                "description": "Create an analysis.\nForm fields:\n- file: file that contains the api.Analysis resource.\n- issues: file that multiple api.Issue resources.\n- dependencies: file that multiple api.TechDependency resources.",
                 "produces": [
                     "application/json"
                 ],
@@ -4532,6 +4529,49 @@ const docTemplate = `{
                 }
             }
         },
+        "api.AppReport": {
+            "type": "object",
+            "properties": {
+                "businessService": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "effort": {
+                    "type": "integer"
+                },
+                "files": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "incidents": {
+                    "type": "integer"
+                },
+                "issue": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "integer"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "rule": {
+                            "type": "string"
+                        },
+                        "ruleset": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
         "api.Application": {
             "type": "object",
             "required": [
@@ -4762,6 +4802,9 @@ const docTemplate = `{
         "api.FileReport": {
             "type": "object",
             "properties": {
+                "effort": {
+                    "type": "integer"
+                },
                 "file": {
                     "type": "string"
                 },
@@ -4921,79 +4964,6 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/api.Incident"
                     }
-                },
-                "labels": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "links": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/api.Link"
-                    }
-                },
-                "name": {
-                    "type": "string"
-                },
-                "rule": {
-                    "type": "string"
-                },
-                "ruleset": {
-                    "type": "string"
-                },
-                "updateUser": {
-                    "type": "string"
-                }
-            }
-        },
-        "api.IssueReport": {
-            "type": "object",
-            "properties": {
-                "application": {
-                    "type": "object",
-                    "required": [
-                        "id"
-                    ],
-                    "properties": {
-                        "effort": {
-                            "type": "integer"
-                        },
-                        "id": {
-                            "type": "integer"
-                        },
-                        "name": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "category": {
-                    "type": "string"
-                },
-                "createTime": {
-                    "type": "string"
-                },
-                "createUser": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "effort": {
-                    "type": "integer"
-                },
-                "facts": {
-                    "$ref": "#/definitions/api.FactMap"
-                },
-                "files": {
-                    "type": "integer"
-                },
-                "id": {
-                    "type": "integer"
-                },
-                "incidents": {
-                    "type": "integer"
                 },
                 "labels": {
                     "type": "array",

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -110,7 +110,7 @@
         },
         "/analyses/dependencies": {
             "get": {
-                "description": "Each report collates dependencies by name and SHA.\nfilters:\n- name\n- version\n- sha\n- indirect\n- labels\n- application.(id|name)\n- tag.id",
+                "description": "Each report collates dependencies by name and SHA.\nfilters:\n- name\n- version\n- sha\n- indirect\n- labels\n- application.id\n- application.name\n- tag.id\nsort:\n- name\n- version\n- sha",
                 "produces": [
                     "application/json"
                 ],
@@ -197,23 +197,23 @@
                 }
             }
         },
-        "/analyses/report/issues": {
+        "/analyses/report/applications": {
             "get": {
-                "description": "Each report collates issues by ruleset/rule and application.\nfilters:\n- ruleset\n- rule\n- name\n- category\n- effort\n- labels\n- application.(id|name)\n- tag.id",
+                "description": "List application reports.\nfilters:\n- id\n- name\n- description\n- businessService\n- effort\n- incidents\n- files\n- issue.id\n- issue.name\n- issue.ruleset\n- issue.rule\n- issue.category\n- issue.effort\n- issue.labels\n- application.id\n- application.name\n- businessService.name\nsort:\n- id\n- name\n- description\n- businessService\n- effort\n- incidents\n- files",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
-                    "issuereports"
+                    "appreports"
                 ],
-                "summary": "List issue reports.",
+                "summary": "List application reports.",
                 "responses": {
                     "200": {
                         "description": "OK",
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/api.IssueReport"
+                                "$ref": "#/definitions/api.AppReport"
                             }
                         }
                     }
@@ -222,7 +222,7 @@
         },
         "/analyses/report/issues/{id}/files": {
             "get": {
-                "description": "Each report collates incidents by file.",
+                "description": "Each report collates incidents by file.\nfilters:\n- file\n- effort\n- incidents\nsort:\n- file\n- effort\n- incidents",
                 "produces": [
                     "application/json"
                 ],
@@ -245,7 +245,7 @@
         },
         "/analyses/report/rules": {
             "get": {
-                "description": "Each report collates issues by ruleset/rule.\nfilters:\n- ruleset\n- rule\n- category\n- effort\n- labels\n- application.(id|name)\n- tag.id",
+                "description": "Each report collates issues by ruleset/rule.\nfilters:\n- ruleset\n- rule\n- category\n- effort\n- labels\n- applications\n- application.id\n- application.name\n- tag.id\nsort:\n- ruleset\n- rule\n- category\n- effort\n- applications",
                 "produces": [
                     "application/json"
                 ],
@@ -318,10 +318,7 @@
         },
         "/application/{id}/analyses": {
             "post": {
-                "description": "Create an analysis.\nForm fields:\n- issues: file that multiple api.Issue resources.\n- dependencies: file that multiple api.TechDependency resources.",
-                "consumes": [
-                    "application/json"
-                ],
+                "description": "Create an analysis.\nForm fields:\n- file: file that contains the api.Analysis resource.\n- issues: file that multiple api.Issue resources.\n- dependencies: file that multiple api.TechDependency resources.",
                 "produces": [
                     "application/json"
                 ],
@@ -4520,6 +4517,49 @@
                 }
             }
         },
+        "api.AppReport": {
+            "type": "object",
+            "properties": {
+                "businessService": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "effort": {
+                    "type": "integer"
+                },
+                "files": {
+                    "type": "integer"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "incidents": {
+                    "type": "integer"
+                },
+                "issue": {
+                    "type": "object",
+                    "properties": {
+                        "id": {
+                            "type": "integer"
+                        },
+                        "name": {
+                            "type": "string"
+                        },
+                        "rule": {
+                            "type": "string"
+                        },
+                        "ruleset": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
         "api.Application": {
             "type": "object",
             "required": [
@@ -4750,6 +4790,9 @@
         "api.FileReport": {
             "type": "object",
             "properties": {
+                "effort": {
+                    "type": "integer"
+                },
                 "file": {
                     "type": "string"
                 },
@@ -4909,79 +4952,6 @@
                     "items": {
                         "$ref": "#/definitions/api.Incident"
                     }
-                },
-                "labels": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "links": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/api.Link"
-                    }
-                },
-                "name": {
-                    "type": "string"
-                },
-                "rule": {
-                    "type": "string"
-                },
-                "ruleset": {
-                    "type": "string"
-                },
-                "updateUser": {
-                    "type": "string"
-                }
-            }
-        },
-        "api.IssueReport": {
-            "type": "object",
-            "properties": {
-                "application": {
-                    "type": "object",
-                    "required": [
-                        "id"
-                    ],
-                    "properties": {
-                        "effort": {
-                            "type": "integer"
-                        },
-                        "id": {
-                            "type": "integer"
-                        },
-                        "name": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "category": {
-                    "type": "string"
-                },
-                "createTime": {
-                    "type": "string"
-                },
-                "createUser": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "effort": {
-                    "type": "integer"
-                },
-                "facts": {
-                    "$ref": "#/definitions/api.FactMap"
-                },
-                "files": {
-                    "type": "integer"
-                },
-                "id": {
-                    "type": "integer"
-                },
-                "incidents": {
-                    "type": "integer"
                 },
                 "labels": {
                     "type": "array",

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -27,6 +27,34 @@ definitions:
       updateUser:
         type: string
     type: object
+  api.AppReport:
+    properties:
+      businessService:
+        type: string
+      description:
+        type: string
+      effort:
+        type: integer
+      files:
+        type: integer
+      id:
+        type: integer
+      incidents:
+        type: integer
+      issue:
+        properties:
+          id:
+            type: integer
+          name:
+            type: string
+          rule:
+            type: string
+          ruleset:
+            type: string
+        type: object
+      name:
+        type: string
+    type: object
   api.Application:
     properties:
       binary:
@@ -179,6 +207,8 @@ definitions:
     type: object
   api.FileReport:
     properties:
+      effort:
+        type: integer
       file:
         type: string
       incidents:
@@ -302,54 +332,6 @@ definitions:
     - name
     - rule
     - ruleset
-    type: object
-  api.IssueReport:
-    properties:
-      application:
-        properties:
-          effort:
-            type: integer
-          id:
-            type: integer
-          name:
-            type: string
-        required:
-        - id
-        type: object
-      category:
-        type: string
-      createTime:
-        type: string
-      createUser:
-        type: string
-      description:
-        type: string
-      effort:
-        type: integer
-      facts:
-        $ref: '#/definitions/api.FactMap'
-      files:
-        type: integer
-      id:
-        type: integer
-      incidents:
-        type: integer
-      labels:
-        items:
-          type: string
-        type: array
-      links:
-        items:
-          $ref: '#/definitions/api.Link'
-        type: array
-      name:
-        type: string
-      rule:
-        type: string
-      ruleset:
-        type: string
-      updateUser:
-        type: string
     type: object
   api.JobFunction:
     properties:
@@ -1049,8 +1031,13 @@ paths:
         - sha
         - indirect
         - labels
-        - application.(id|name)
+        - application.id
+        - application.name
         - tag.id
+        sort:
+        - name
+        - version
+        - sha
       produces:
       - application/json
       responses:
@@ -1119,19 +1106,36 @@ paths:
       summary: List incidents for an issue.
       tags:
       - incidents
-  /analyses/report/issues:
+  /analyses/report/applications:
     get:
       description: |-
-        Each report collates issues by ruleset/rule and application.
+        List application reports.
         filters:
-        - ruleset
-        - rule
+        - id
         - name
-        - category
+        - description
+        - businessService
         - effort
-        - labels
-        - application.(id|name)
-        - tag.id
+        - incidents
+        - files
+        - issue.id
+        - issue.name
+        - issue.ruleset
+        - issue.rule
+        - issue.category
+        - issue.effort
+        - issue.labels
+        - application.id
+        - application.name
+        - businessService.name
+        sort:
+        - id
+        - name
+        - description
+        - businessService
+        - effort
+        - incidents
+        - files
       produces:
       - application/json
       responses:
@@ -1139,14 +1143,23 @@ paths:
           description: OK
           schema:
             items:
-              $ref: '#/definitions/api.IssueReport'
+              $ref: '#/definitions/api.AppReport'
             type: array
-      summary: List issue reports.
+      summary: List application reports.
       tags:
-      - issuereports
+      - appreports
   /analyses/report/issues/{id}/files:
     get:
-      description: Each report collates incidents by file.
+      description: |-
+        Each report collates incidents by file.
+        filters:
+        - file
+        - effort
+        - incidents
+        sort:
+        - file
+        - effort
+        - incidents
       produces:
       - application/json
       responses:
@@ -1169,8 +1182,16 @@ paths:
         - category
         - effort
         - labels
-        - application.(id|name)
+        - applications
+        - application.id
+        - application.name
         - tag.id
+        sort:
+        - ruleset
+        - rule
+        - category
+        - effort
+        - applications
       produces:
       - application/json
       responses:
@@ -1185,11 +1206,10 @@ paths:
       - rulereports
   /application/{id}/analyses:
     post:
-      consumes:
-      - application/json
       description: |-
         Create an analysis.
         Form fields:
+        - file: file that contains the api.Analysis resource.
         - issues: file that multiple api.Issue resources.
         - dependencies: file that multiple api.TechDependency resources.
       produces:

--- a/migration/migrate.go
+++ b/migration/migrate.go
@@ -45,7 +45,6 @@ func Migrate(migrations []Migration) (err error) {
 			return
 		}
 	}
-
 	var start = v.Version
 	if start != 0 && start < MinimumVersion {
 		err = errors.New("unsupported database version")


### PR DESCRIPTION
closes #367 

Also refit RuleReport using the _view_ pattern `select * from (select ...)`.

The _view_ pattern supports filtering and sorting on all report fields including derived (virtual) columns such as count().