### PR TITLE
:seedling: add dependency  package in test/api

### DIFF
--- a/api/dependency.go
+++ b/api/dependency.go
@@ -64,35 +64,6 @@ func (h DependencyHandler) Get(ctx *gin.Context) {
 // @produce json
 // @success 200 {object} []api.Dependency
 // @router /dependencies [get]
-// func (h DependencyHandler) List(ctx *gin.Context) {
-// 	var list []model.Dependency
-
-// 	db := h.Paginated(ctx)
-// 	to := ctx.Query("to.id")
-// 	from := ctx.Query("from.id")
-// 	if to != "" {
-// 		db = db.Where("toid = ?", to)
-// 	} else if from != "" {
-// 		db = db.Where("fromid = ?", from)
-// 	}
-
-// 	db = h.preLoad(db, clause.Associations)
-// 	result := db.Find(&list)
-// 	if result.Error != nil {
-// 		_ = ctx.Error(result.Error)
-// 		return
-// 	}
-
-// 	resources := []Dependency{}
-// 	for i := range list {
-// 		r := Dependency{}
-// 		r.With(&list[i])
-// 		resources = append(resources, r)
-// 	}
-
-// 	h.Respond(ctx, http.StatusOK, resources)
-// }
-
 func (h DependencyHandler) List(ctx *gin.Context) {
 	var list []model.Dependency
 

--- a/api/dependency.go
+++ b/api/dependency.go
@@ -1,11 +1,10 @@
 package api
 
 import (
-	"net/http"
-
 	"github.com/gin-gonic/gin"
 	"github.com/konveyor/tackle2-hub/model"
 	"gorm.io/gorm/clause"
+	"net/http"
 )
 
 //

--- a/api/dependency.go
+++ b/api/dependency.go
@@ -68,15 +68,12 @@ func (h DependencyHandler) List(ctx *gin.Context) {
 	var list []model.Dependency
 
 	db := h.Paginated(ctx)
-	from := ctx.Query("from")
-	to := ctx.Query("to")
-
-	if from != "" && to != "" {
-		db = db.Where("fromid = ? AND toid = ?", from, to)
+	to := ctx.Query("to.id")
+	from := ctx.Query("from.id")
+	if to != "" {
+		db = db.Where("toid = ?", to)
 	} else if from != "" {
 		db = db.Where("fromid = ?", from)
-	} else if to != "" {
-		db = db.Where("toid = ?", to)
 	}
 
 	db = h.preLoad(db, clause.Associations)

--- a/api/dependency.go
+++ b/api/dependency.go
@@ -1,10 +1,11 @@
 package api
 
 import (
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	"github.com/konveyor/tackle2-hub/model"
 	"gorm.io/gorm/clause"
-	"net/http"
 )
 
 //
@@ -63,16 +64,48 @@ func (h DependencyHandler) Get(ctx *gin.Context) {
 // @produce json
 // @success 200 {object} []api.Dependency
 // @router /dependencies [get]
+// func (h DependencyHandler) List(ctx *gin.Context) {
+// 	var list []model.Dependency
+
+// 	db := h.Paginated(ctx)
+// 	to := ctx.Query("to.id")
+// 	from := ctx.Query("from.id")
+// 	if to != "" {
+// 		db = db.Where("toid = ?", to)
+// 	} else if from != "" {
+// 		db = db.Where("fromid = ?", from)
+// 	}
+
+// 	db = h.preLoad(db, clause.Associations)
+// 	result := db.Find(&list)
+// 	if result.Error != nil {
+// 		_ = ctx.Error(result.Error)
+// 		return
+// 	}
+
+// 	resources := []Dependency{}
+// 	for i := range list {
+// 		r := Dependency{}
+// 		r.With(&list[i])
+// 		resources = append(resources, r)
+// 	}
+
+// 	h.Respond(ctx, http.StatusOK, resources)
+// }
+
 func (h DependencyHandler) List(ctx *gin.Context) {
 	var list []model.Dependency
 
 	db := h.Paginated(ctx)
-	to := ctx.Query("to.id")
-	from := ctx.Query("from.id")
-	if to != "" {
-		db = db.Where("toid = ?", to)
+	from := ctx.Query("from")
+	to := ctx.Query("to")
+
+	if from != "" && to != "" {
+		db = db.Where("fromid = ? AND toid = ?", from, to)
 	} else if from != "" {
 		db = db.Where("fromid = ?", from)
+	} else if to != "" {
+		db = db.Where("toid = ?", to)
 	}
 
 	db = h.preLoad(db, clause.Associations)

--- a/api/dependency.go
+++ b/api/dependency.go
@@ -1,10 +1,11 @@
 package api
 
 import (
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	"github.com/konveyor/tackle2-hub/model"
 	"gorm.io/gorm/clause"
-	"net/http"
 )
 
 //
@@ -115,7 +116,7 @@ func (h DependencyHandler) Create(ctx *gin.Context) {
 		_ = ctx.Error(err)
 		return
 	}
-
+	r.With(m)
 	h.Respond(ctx, http.StatusCreated, r)
 }
 

--- a/binding/dependency.go
+++ b/binding/dependency.go
@@ -36,14 +36,6 @@ func (h *Dependency) List() (list []api.Dependency, err error) {
 }
 
 //
-// Update a Dependency.
-func (h *Dependency) Update(r *api.Dependency) (err error) {
-	path := Path(api.DependencyRoot).Inject(Params{api.ID: r.From.ID})
-	err = h.client.Put(path, r)
-	return
-}
-
-//
 // Delete a Dependency.
 func (h *Dependency) Delete(id uint) (err error) {
 	err = h.client.Delete(Path(api.DependencyRoot).Inject(Params{api.ID: id}))

--- a/binding/dependency.go
+++ b/binding/dependency.go
@@ -1,0 +1,51 @@
+package binding
+
+import (
+	"github.com/konveyor/tackle2-hub/api"
+)
+
+//
+// Dependency API.
+type Dependency struct {
+	// hub API client.
+	client *Client
+}
+
+//
+// Create a Dependency.
+func (h *Dependency) Create(r *api.Dependency) (err error) {
+	err = h.client.Post(api.DependenciesRoot, &r)
+	return
+}
+
+//
+// Get a Dependency by ID.
+func (h *Dependency) Get(id uint) (r *api.Dependency, err error) {
+	r = &api.Dependency{}
+	path := Path(api.DependencyRoot).Inject(Params{api.ID: id})
+	err = h.client.Get(path, r)
+	return
+}
+
+//
+// List Dependencies.
+func (h *Dependency) List() (list []api.Dependency, err error) {
+	list = []api.Dependency{}
+	err = h.client.Get(api.DependenciesRoot, &list)
+	return
+}
+
+//
+// Update a Dependency.
+func (h *Dependency) Update(r *api.Dependency) (err error) {
+	path := Path(api.DependencyRoot).Inject(Params{api.ID: r.From.ID})
+	err = h.client.Put(path, r)
+	return
+}
+
+//
+// Delete a Dependency.
+func (h *Dependency) Delete(id uint) (err error) {
+	err = h.client.Delete(Path(api.DependencyRoot).Inject(Params{api.ID: id}))
+	return
+}

--- a/binding/richclient.go
+++ b/binding/richclient.go
@@ -22,7 +22,7 @@ func init() {
 type RichClient struct {
 	// Resources APIs.
 	Application      Application
-	Bucket			 Bucket
+	Bucket           Bucket
 	BusinessService  BusinessService
 	Identity         Identity
 	JobFunction      JobFunction
@@ -32,6 +32,7 @@ type RichClient struct {
 	Tag              Tag
 	TagCategory      TagCategory
 	Task             Task
+	Dependency       Dependency
 
 	// A REST client.
 	client *Client
@@ -58,6 +59,9 @@ func New(baseUrl string) (r *RichClient) {
 			client: client,
 		},
 		BusinessService: BusinessService{
+			client: client,
+		},
+		Dependency: Dependency{
 			client: client,
 		},
 		Identity: Identity{

--- a/test/api/dependency/api_test.go
+++ b/test/api/dependency/api_test.go
@@ -12,8 +12,8 @@ func TestDependencyCRUD(t *testing.T) {
 	for _, sample := range Samples {
 		t.Run(fmt.Sprintf("Dependency from %s -> %s", sample.ApplicationFrom.Name, sample.ApplicationTo.Name), func(t *testing.T) {
 
-			assert.Should(t, Application.Create(&sample.ApplicationFrom))
-			assert.Should(t, Application.Create(&sample.ApplicationTo))
+			assert.Must(t, Application.Create(&sample.ApplicationFrom))
+			assert.Must(t, Application.Create(&sample.ApplicationTo))
 
 			// Create.
 			dependency := api.Dependency{
@@ -38,9 +38,14 @@ func TestDependencyCRUD(t *testing.T) {
 			// Delete dependency.
 			assert.Should(t, Dependency.Delete(dependency.ID))
 
+			_, err = Dependency.Get(dependency.ID)
+			if err == nil {
+				t.Errorf("Resource exits, but should be deleted: %v", dependency)
+			}
+
 			//Delete Applications
-			assert.Should(t, Application.Delete(sample.ApplicationFrom.ID))
-			assert.Should(t, Application.Delete(sample.ApplicationTo.ID))
+			assert.Must(t, Application.Delete(sample.ApplicationFrom.ID))
+			assert.Must(t, Application.Delete(sample.ApplicationTo.ID))
 		})
 	}
 }
@@ -49,8 +54,19 @@ func TestDependencyList(t *testing.T) {
 	for _, sample := range Samples {
 
 		// Create applications.
-		assert.Should(t, Application.Create(&sample.ApplicationFrom))
-		assert.Should(t, Application.Create(&sample.ApplicationTo))
+		assert.Must(t, Application.Create(&sample.ApplicationFrom))
+		assert.Must(t, Application.Create(&sample.ApplicationTo))
+
+		// Create dependencies.
+		dependency := api.Dependency{
+			From: api.Ref{
+				ID: sample.ApplicationFrom.ID,
+			},
+			To: api.Ref{
+				ID: sample.ApplicationTo.ID,
+			},
+		}
+		assert.Should(t, Dependency.Create(&dependency))
 	}
 
 	// List dependencies.
@@ -62,9 +78,14 @@ func TestDependencyList(t *testing.T) {
 		t.Errorf("Different response error. Got %v, expected %v", got, Samples)
 	}
 
+	// Delete Dependencies.
+	for _, dependency := range got {
+		assert.Should(t, Dependency.Delete(dependency.ID))
+	}
+
 	// Delete applications.
 	for _, sample := range Samples {
-		assert.Should(t, Application.Delete(sample.ApplicationFrom.ID))
-		assert.Should(t, Application.Delete(sample.ApplicationTo.ID))
+		assert.Must(t, Application.Delete(sample.ApplicationFrom.ID))
+		assert.Must(t, Application.Delete(sample.ApplicationTo.ID))
 	}
 }

--- a/test/api/dependency/api_test.go
+++ b/test/api/dependency/api_test.go
@@ -3,51 +3,56 @@ package dependency
 import (
 	"testing"
 
+	"github.com/konveyor/tackle2-hub/api"
 	"github.com/konveyor/tackle2-hub/test/assert"
 )
 
 func TestDependencyCRUD(t *testing.T) {
 	for _, r := range Samples {
 		t.Run("Dependency_CRUD", func(t *testing.T) {
+
+			applicationFrom := api.Application{
+				Name:        r.From.Name,
+				Description: "From application",
+			}
+
+			applicationTo := api.Application{
+				Name:        r.To.Name,
+				Description: "To application",
+			}
+
 			// Create.
-			err := Dependency.Create(&r)
+			dependency := api.Dependency{
+				From: api.Ref{
+					ID: applicationFrom.ID,
+				},
+				To: api.Ref{
+					ID: applicationTo.ID,
+				},
+			}
+			err := Dependency.Create(&dependency)
 			if err != nil {
 				t.Errorf(err.Error())
 			}
 
 			// Get.
-			got, err := Dependency.Get(r.ID)
+			got, err := Dependency.Get(dependency.ID)
 			if err != nil {
 				t.Errorf(err.Error())
 			}
-			if assert.FlatEqual(got, r) {
-				t.Errorf("Different response error. Got %v, expected %v", got, r)
-			}
-
-			// Update.
-			r.Name = "Updated " + r.Name
-			err = Dependency.Update(&r)
-			if err != nil {
-				t.Errorf(err.Error())
-			}
-
-			got, err = Dependency.Get(r.ID)
-			if err != nil {
-				t.Errorf(err.Error())
-			}
-			if got.Name != r.Name {
-				t.Errorf("Different response error. Got %s, expected %s", got.Name, r.Name)
-			}
-
-			// Delete.
-			err = Dependency.Delete(r.ID)
-			if err != nil {
-				t.Errorf(err.Error())
+			if assert.FlatEqual(got, dependency.ID) {
+				t.Errorf("Different response error. Got %v, expected %v", got, dependency.ID)
 			}
 
 			_, err = Dependency.Get(r.ID)
-			if err == nil {
-				t.Errorf("Resource exits, but should be deleted: %v", r)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+
+			// Delete dependency.
+			err = Dependency.Delete(dependency.ID)
+			if err != nil {
+				t.Errorf(err.Error())
 			}
 		})
 	}
@@ -58,10 +63,24 @@ func TestDependencyList(t *testing.T) {
 
 	for name := range samples {
 		sample := samples[name]
-		assert.Must(t, Dependency.Create(&sample))
+
+		// Create applications.
+		applicationFrom := api.Application{
+			Name:        sample.From.Name,
+			Description: "From application",
+		}
+		sample.From.ID = applicationFrom.ID
+
+		applicationTo := api.Application{
+			Name:        sample.To.Name,
+			Description: "To application",
+		}
+		sample.To.ID = applicationTo.ID
+
 		samples[name] = sample
 	}
 
+	// List dependencies.
 	got, err := Dependency.List()
 	if err != nil {
 		t.Errorf(err.Error())
@@ -70,6 +89,7 @@ func TestDependencyList(t *testing.T) {
 		t.Errorf("Different response error. Got %v, expected %v", got, samples)
 	}
 
+	// Delete dependencies
 	for _, r := range samples {
 		assert.Must(t, Dependency.Delete(r.ID))
 	}

--- a/test/api/dependency/api_test.go
+++ b/test/api/dependency/api_test.go
@@ -1,0 +1,76 @@
+package dependency
+
+import (
+	"testing"
+
+	"github.com/konveyor/tackle2-hub/test/assert"
+)
+
+func TestDependencyCRUD(t *testing.T) {
+	for _, r := range Samples {
+		t.Run("Dependency CRUD", func(t *testing.T) {
+			// Create.
+			err := Dependency.Create(&r)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+
+			// Get.
+			got, err := Dependency.Get(r.From.ID)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+			if assert.FlatEqual(got, r) {
+				t.Errorf("Different response error. Got %v, expected %v", got, r)
+			}
+
+			// Update.
+			r.From.Name = "Updated " + r.From.Name
+			err = Dependency.Update(&r)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+
+			got, err = Dependency.Get(r.From.ID)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+			if got.From.Name != r.From.Name {
+				t.Errorf("Different response error. Got %s, expected %s", got.From.Name, r.From.Name)
+			}
+
+			// Delete.
+			err = Dependency.Delete(r.From.ID)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+
+			_, err = Dependency.Get(r.From.ID)
+			if err == nil {
+				t.Errorf("Resource exits, but should be deleted: %v", r)
+			}
+		})
+	}
+}
+
+func TestDependencyList(t *testing.T) {
+	samples := Samples
+
+	for name := range samples {
+		sample := samples[name]
+		assert.Must(t, Dependency.Create(&sample))
+		samples[name] = sample
+	}
+
+	got, err := Dependency.List()
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if assert.FlatEqual(got, &samples) {
+		t.Errorf("Different response error. Got %v, expected %v", got, samples)
+	}
+
+	for _, r := range samples {
+		assert.Must(t, Dependency.Delete(r.ID))
+	}
+}

--- a/test/api/dependency/api_test.go
+++ b/test/api/dependency/api_test.go
@@ -62,6 +62,17 @@ func TestDependencyCRUD(t *testing.T) {
 			if err != nil {
 				t.Errorf(err.Error())
 			}
+
+			//Delete Applications
+			err = app.Application.Delete(applicationFrom.ID)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+
+			err = app.Application.Delete(applicationTo.ID)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
 		})
 	}
 }
@@ -99,8 +110,10 @@ func TestDependencyList(t *testing.T) {
 		t.Errorf("Different response error. Got %v, expected %v", got, samples)
 	}
 
-	// Delete dependencies
+	// Delete dependencies as well as applications.
 	for _, r := range samples {
 		assert.Must(t, Dependency.Delete(r.ID))
+		assert.Must(t, app.Application.Delete(r.From.ID))
+		assert.Must(t, app.Application.Delete(r.To.ID))
 	}
 }

--- a/test/api/dependency/api_test.go
+++ b/test/api/dependency/api_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestDependencyCRUD(t *testing.T) {
 	for _, r := range Samples {
-		t.Run("Dependency CRUD", func(t *testing.T) {
+		t.Run("Dependency_CRUD", func(t *testing.T) {
 			// Create.
 			err := Dependency.Create(&r)
 			if err != nil {
@@ -16,7 +16,7 @@ func TestDependencyCRUD(t *testing.T) {
 			}
 
 			// Get.
-			got, err := Dependency.Get(r.From.ID)
+			got, err := Dependency.Get(r.ID)
 			if err != nil {
 				t.Errorf(err.Error())
 			}
@@ -25,27 +25,27 @@ func TestDependencyCRUD(t *testing.T) {
 			}
 
 			// Update.
-			r.From.Name = "Updated " + r.From.Name
+			r.Name = "Updated " + r.Name
 			err = Dependency.Update(&r)
 			if err != nil {
 				t.Errorf(err.Error())
 			}
 
-			got, err = Dependency.Get(r.From.ID)
+			got, err = Dependency.Get(r.ID)
 			if err != nil {
 				t.Errorf(err.Error())
 			}
-			if got.From.Name != r.From.Name {
-				t.Errorf("Different response error. Got %s, expected %s", got.From.Name, r.From.Name)
+			if got.Name != r.Name {
+				t.Errorf("Different response error. Got %s, expected %s", got.Name, r.Name)
 			}
 
 			// Delete.
-			err = Dependency.Delete(r.From.ID)
+			err = Dependency.Delete(r.ID)
 			if err != nil {
 				t.Errorf(err.Error())
 			}
 
-			_, err = Dependency.Get(r.From.ID)
+			_, err = Dependency.Get(r.ID)
 			if err == nil {
 				t.Errorf("Resource exits, but should be deleted: %v", r)
 			}

--- a/test/api/dependency/api_test.go
+++ b/test/api/dependency/api_test.go
@@ -12,22 +12,19 @@ func TestDependencyCRUD(t *testing.T) {
 	for _, sample := range Samples {
 		t.Run(fmt.Sprintf("Dependency from %s -> %s", sample.ApplicationFrom.Name, sample.ApplicationTo.Name), func(t *testing.T) {
 
-			applicationFrom := sample.ApplicationFrom
-			assert.Must(t, Application.Create(&applicationFrom))
-
-			applicationTo := sample.ApplicationTo
-			assert.Must(t, Application.Create(&applicationTo))
+			assert.Should(t, Application.Create(&sample.ApplicationFrom))
+			assert.Should(t, Application.Create(&sample.ApplicationTo))
 
 			// Create.
 			dependency := api.Dependency{
 				From: api.Ref{
-					ID: applicationFrom.ID,
+					ID: sample.ApplicationFrom.ID,
 				},
 				To: api.Ref{
-					ID: applicationTo.ID,
+					ID: sample.ApplicationTo.ID,
 				},
 			}
-			assert.Must(t, Dependency.Create(&dependency))
+			assert.Should(t, Dependency.Create(&dependency))
 
 			// Get.
 			got, err := Dependency.Get(dependency.ID)
@@ -39,25 +36,21 @@ func TestDependencyCRUD(t *testing.T) {
 			}
 
 			// Delete dependency.
-			assert.Must(t, Dependency.Delete(dependency.ID))
+			assert.Should(t, Dependency.Delete(dependency.ID))
 
 			//Delete Applications
-			assert.Must(t, Application.Delete(applicationFrom.ID))
-			assert.Must(t, Application.Delete(applicationTo.ID))
+			assert.Should(t, Application.Delete(sample.ApplicationFrom.ID))
+			assert.Should(t, Application.Delete(sample.ApplicationTo.ID))
 		})
 	}
 }
 
 func TestDependencyList(t *testing.T) {
 	for _, sample := range Samples {
-		// Create applications.
-		applicationFrom := sample.ApplicationFrom
-		assert.Must(t, Application.Create(&applicationFrom))
-		sample.ApplicationFrom.ID = applicationFrom.ID
 
-		applicationTo := sample.ApplicationTo
-		assert.Must(t, Application.Create(&applicationTo))
-		sample.ApplicationTo.ID = applicationTo.ID
+		// Create applications.
+		assert.Should(t, Application.Create(&sample.ApplicationFrom))
+		assert.Should(t, Application.Create(&sample.ApplicationTo))
 	}
 
 	// List dependencies.
@@ -71,7 +64,7 @@ func TestDependencyList(t *testing.T) {
 
 	// Delete applications.
 	for _, sample := range Samples {
-		assert.Must(t, Application.Delete(sample.ApplicationFrom.ID))
-		assert.Must(t, Application.Delete(sample.ApplicationTo.ID))
+		assert.Should(t, Application.Delete(sample.ApplicationFrom.ID))
+		assert.Should(t, Application.Delete(sample.ApplicationTo.ID))
 	}
 }

--- a/test/api/dependency/api_test.go
+++ b/test/api/dependency/api_test.go
@@ -1,24 +1,36 @@
 package dependency
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/konveyor/tackle2-hub/api"
+	app "github.com/konveyor/tackle2-hub/test/api/application"
 	"github.com/konveyor/tackle2-hub/test/assert"
 )
 
 func TestDependencyCRUD(t *testing.T) {
 	for _, r := range Samples {
-		t.Run("Dependency_CRUD", func(t *testing.T) {
+		t.Run(fmt.Sprintf("Dependency from %s -> %s", r.From.Name, r.To.Name), func(t *testing.T) {
 
 			applicationFrom := api.Application{
 				Name:        r.From.Name,
 				Description: "From application",
 			}
 
+			err := app.Application.Create(&applicationFrom)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+
 			applicationTo := api.Application{
 				Name:        r.To.Name,
 				Description: "To application",
+			}
+
+			err = app.Application.Create(&applicationTo)
+			if err != nil {
+				t.Errorf(err.Error())
 			}
 
 			// Create.
@@ -30,7 +42,8 @@ func TestDependencyCRUD(t *testing.T) {
 					ID: applicationTo.ID,
 				},
 			}
-			err := Dependency.Create(&dependency)
+
+			err = Dependency.Create(&dependency)
 			if err != nil {
 				t.Errorf(err.Error())
 			}
@@ -42,11 +55,6 @@ func TestDependencyCRUD(t *testing.T) {
 			}
 			if assert.FlatEqual(got, dependency.ID) {
 				t.Errorf("Different response error. Got %v, expected %v", got, dependency.ID)
-			}
-
-			_, err = Dependency.Get(r.ID)
-			if err != nil {
-				t.Errorf(err.Error())
 			}
 
 			// Delete dependency.
@@ -69,12 +77,14 @@ func TestDependencyList(t *testing.T) {
 			Name:        sample.From.Name,
 			Description: "From application",
 		}
+		assert.Must(t, app.Application.Create(&applicationFrom))
 		sample.From.ID = applicationFrom.ID
 
 		applicationTo := api.Application{
 			Name:        sample.To.Name,
 			Description: "To application",
 		}
+		assert.Must(t, app.Application.Create(&applicationTo))
 		sample.To.ID = applicationTo.ID
 
 		samples[name] = sample

--- a/test/api/dependency/pkg.go
+++ b/test/api/dependency/pkg.go
@@ -1,0 +1,19 @@
+package dependency
+
+import (
+	"github.com/konveyor/tackle2-hub/binding"
+	"github.com/konveyor/tackle2-hub/test/api/client"
+)
+
+var (
+	RichClient *binding.RichClient
+	Dependency binding.Dependency
+)
+
+func init() {
+	// Prepare RichClient and login to Hub API (configured from env variables).
+	RichClient = client.PrepareRichClient()
+
+	// Shortcut for Dependencyrelated RichClient methods.
+	Dependency = RichClient.Dependency
+}

--- a/test/api/dependency/pkg.go
+++ b/test/api/dependency/pkg.go
@@ -6,14 +6,18 @@ import (
 )
 
 var (
-	RichClient *binding.RichClient
-	Dependency binding.Dependency
+	RichClient  *binding.RichClient
+	Dependency  binding.Dependency
+	Application binding.Application
 )
 
 func init() {
 	// Prepare RichClient and login to Hub API (configured from env variables).
 	RichClient = client.PrepareRichClient()
 
-	// Shortcut for Dependencyrelated RichClient methods.
+	// Shortcut for Dependency related RichClient methods.
 	Dependency = RichClient.Dependency
+
+	//Shortcut for Application related RichClient methods.
+	Application = RichClient.Application
 }

--- a/test/api/dependency/samples.go
+++ b/test/api/dependency/samples.go
@@ -5,10 +5,17 @@ import (
 )
 
 // Set of valid resources for tests and reuse.
+type TestCase struct {
+	Name         string
+	Dependency   api.Dependency
+	Application1 api.Application
+	Application2 api.Application
+}
+
 var (
-	firstDependency = api.Dependency{
+	dependency = api.Dependency{
 		To: api.Ref{
-			ID:   uint(1473),
+			ID:   uint(1),
 			Name: "Alice",
 		},
 		From: api.Ref{
@@ -17,16 +24,21 @@ var (
 		},
 	}
 
-	secondDependency = api.Dependency{
-		To: api.Ref{
-			ID:   uint(2123),
-			Name: "Bob",
-		},
-		From: api.Ref{
-			ID:   uint(1),
-			Name: "Alice",
-		},
+	aliceApplication = api.Application{
+		Name:        "Alice",
+		Description: "alice's application",
+	}
+	bobApplication = api.Application{
+		Name:        "Bob",
+		Description: "bob's application",
 	}
 
-	Samples = []api.Dependency{firstDependency, secondDependency}
+	testCase = TestCase{
+		Name:         "Test",
+		Dependency:   dependency,
+		Application1: aliceApplication,
+		Application2: bobApplication,
+	}
+	tc      = []TestCase{testCase}
+	Samples = []api.Dependency{tc}
 )

--- a/test/api/dependency/samples.go
+++ b/test/api/dependency/samples.go
@@ -4,41 +4,21 @@ import (
 	"github.com/konveyor/tackle2-hub/api"
 )
 
-// Set of valid resources for tests and reuse.
-type TestCase struct {
-	Name            string
+// Struct to hold dependency sample data.
+type DependencySample struct {
 	ApplicationFrom api.Application
 	ApplicationTo   api.Application
 }
 
-var Samples = []api.Dependency{}
-
-var (
-	Gateway = api.Application{
-		Name:        "Gateway",
-		Description: "Gateway application",
-	}
-	Inventory = api.Application{
-		Name:        "Inventory",
-		Description: "Inventory application",
-	}
-
-	testCase = TestCase{
-		Name:            "Test",
-		ApplicationFrom: Gateway,
-		ApplicationTo:   Inventory,
-	}
-
-	dependency = api.Dependency{
-		To: api.Ref{
-			Name: testCase.ApplicationTo.Name,
+var Samples = []DependencySample{
+	{
+		ApplicationFrom: api.Application{
+			Name:        "Gateway",
+			Description: "Gateway application",
 		},
-		From: api.Ref{
-			Name: testCase.ApplicationFrom.Name,
+		ApplicationTo: api.Application{
+			Name:        "Inventory",
+			Description: "Inventory application",
 		},
-	}
-)
-
-func init() {
-	Samples = []api.Dependency{dependency}
+	},
 }

--- a/test/api/dependency/samples.go
+++ b/test/api/dependency/samples.go
@@ -11,16 +11,9 @@ type TestCase struct {
 	ApplicationTo   api.Application
 }
 
-var (
-	dependency = api.Dependency{
-		To: api.Ref{
-			Name: "Gateway",
-		},
-		From: api.Ref{
-			Name: "Inventory",
-		},
-	}
+var Samples = []api.Dependency{}
 
+var (
 	Gateway = api.Application{
 		Name:        "Gateway",
 		Description: "Gateway application",
@@ -35,20 +28,17 @@ var (
 		ApplicationFrom: Gateway,
 		ApplicationTo:   Inventory,
 	}
-	Samples = []api.Dependency{}
+
+	dependency = api.Dependency{
+		To: api.Ref{
+			Name: testCase.ApplicationTo.Name,
+		},
+		From: api.Ref{
+			Name: testCase.ApplicationFrom.Name,
+		},
+	}
 )
 
 func init() {
-	tc := []TestCase{testCase}
-	for _, t := range tc {
-		dependency := api.Dependency{
-			To: api.Ref{
-				Name: t.ApplicationTo.Name,
-			},
-			From: api.Ref{
-				Name: t.ApplicationFrom.Name,
-			},
-		}
-		Samples = []api.Dependency{dependency}
-	}
+	Samples = []api.Dependency{dependency}
 }

--- a/test/api/dependency/samples.go
+++ b/test/api/dependency/samples.go
@@ -1,0 +1,32 @@
+package dependency
+
+import (
+	"github.com/konveyor/tackle2-hub/api"
+)
+
+// Set of valid resources for tests and reuse.
+var (
+	firstDependency = api.Dependency{
+		To: api.Ref{
+			ID:   uint(1473),
+			Name: "Alice",
+		},
+		From: api.Ref{
+			ID:   uint(2),
+			Name: "Bob",
+		},
+	}
+
+	secondDependency = api.Dependency{
+		To: api.Ref{
+			ID:   uint(2123),
+			Name: "Bob",
+		},
+		From: api.Ref{
+			ID:   uint(1),
+			Name: "Alice",
+		},
+	}
+
+	Samples = []api.Dependency{firstDependency, secondDependency}
+)

--- a/test/api/dependency/samples.go
+++ b/test/api/dependency/samples.go
@@ -6,39 +6,49 @@ import (
 
 // Set of valid resources for tests and reuse.
 type TestCase struct {
-	Name         string
-	Dependency   api.Dependency
-	Application1 api.Application
-	Application2 api.Application
+	Name            string
+	ApplicationFrom api.Application
+	ApplicationTo   api.Application
 }
 
 var (
 	dependency = api.Dependency{
 		To: api.Ref{
-			ID:   uint(1),
-			Name: "Alice",
+			Name: "Gateway",
 		},
 		From: api.Ref{
-			ID:   uint(2),
-			Name: "Bob",
+			Name: "Inventory",
 		},
 	}
 
-	aliceApplication = api.Application{
-		Name:        "Alice",
-		Description: "alice's application",
+	Gateway = api.Application{
+		Name:        "Gateway",
+		Description: "Gateway application",
 	}
-	bobApplication = api.Application{
-		Name:        "Bob",
-		Description: "bob's application",
+	Inventory = api.Application{
+		Name:        "Inventory",
+		Description: "Inventory application",
 	}
 
 	testCase = TestCase{
-		Name:         "Test",
-		Dependency:   dependency,
-		Application1: aliceApplication,
-		Application2: bobApplication,
+		Name:            "Test",
+		ApplicationFrom: Gateway,
+		ApplicationTo:   Inventory,
 	}
-	tc      = []TestCase{testCase}
-	Samples = []api.Dependency{tc}
+	Samples = []api.Dependency{}
 )
+
+func init() {
+	tc := []TestCase{testCase}
+	for _, t := range tc {
+		dependency := api.Dependency{
+			To: api.Ref{
+				Name: t.ApplicationTo.Name,
+			},
+			From: api.Ref{
+				Name: t.ApplicationFrom.Name,
+			},
+		}
+		Samples = []api.Dependency{dependency}
+	}
+}


### PR DESCRIPTION
Upstream issue [https://github.com/konveyor/tackle2-operator/issues/220](https://github.com/konveyor/tackle2-operator/issues/220)

Issue in the repo #370 

added api_test.go,pkg.go,samples.go in `dependency` directory. Also added `dependency.go` in binding package and added dependency client in `binding/richclient.go`