### PR TITLE
[BACKPORT] :sparkles: Omit Ref empty Name in API

### DIFF
--- a/api/base.go
+++ b/api/base.go
@@ -350,10 +350,10 @@ func (r *Resource) nameOf(m interface{}) (name string) {
 //
 // Ref represents a FK.
 // Contains the PK and (name) natural key.
-// The name is read-only.
+// The name is optional and read-only.
 type Ref struct {
 	ID   uint   `json:"id" binding:"required"`
-	Name string `json:"name"`
+	Name string `json:"name,omitempty"`
 }
 
 //

--- a/api/tag.go
+++ b/api/tag.go
@@ -98,6 +98,8 @@ func (h TagHandler) Create(ctx *gin.Context) {
 		return
 	}
 	m := r.Model()
+	// Load associated TagCategory.
+	h.DB(ctx).First(&m.Category, m.CategoryID)
 	m.CreateUser = h.BaseHandler.CurrentUser(ctx)
 	result := h.DB(ctx).Create(m)
 	if result.Error != nil {

--- a/api/tag.go
+++ b/api/tag.go
@@ -98,8 +98,6 @@ func (h TagHandler) Create(ctx *gin.Context) {
 		return
 	}
 	m := r.Model()
-	// Load associated TagCategory.
-	h.DB(ctx).First(&m.Category, m.CategoryID)
 	m.CreateUser = h.BaseHandler.CurrentUser(ctx)
 	result := h.DB(ctx).Create(m)
 	if result.Error != nil {


### PR DESCRIPTION
release-0.2 backport of https://github.com/konveyor/tackle2-hub/pull/359

There is a Ref API struct used e.g. in Tag-TagCategory association. API e.g. on Tag create doesn't load the Category so the API reponse doesn't contain Category Name.

Trying to solve this either with pre-loading the Category on TagCreate or drop name field from the Ref API response. To be discussed, looking forward to comments in this PR.

Related to https://issues.redhat.com/browse/MTA-674