### PR TITLE
:sparkles: Add sort field validation.

### DIFF
--- a/api/analysis.go
+++ b/api/analysis.go
@@ -410,8 +410,7 @@ func (h AnalysisHandler) AppDeps(ctx *gin.Context) {
 	}
 	// Find.
 	list := []model.TechDependency{}
-	db = h.paginated(ctx, db)
-	db = sort.Sorted(db)
+	db = h.paginated(ctx, sort, db)
 	result = db.Find(&list)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)
@@ -494,8 +493,7 @@ func (h AnalysisHandler) AppIssues(ctx *gin.Context) {
 	}
 	// Find.
 	list := []model.Issue{}
-	db = h.paginated(ctx, db)
-	db = sort.Sorted(db)
+	db = h.paginated(ctx, sort, db)
 	result = db.Find(&list)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)
@@ -579,8 +577,7 @@ func (h AnalysisHandler) Issues(ctx *gin.Context) {
 	}
 	//
 	// Find.
-	db = h.paginated(ctx, db)
-	db = sort.Sorted(db)
+	db = h.paginated(ctx, sort, db)
 	var list []model.Issue
 	result = db.Find(&list)
 	if result.Error != nil {
@@ -663,8 +660,7 @@ func (h AnalysisHandler) Incidents(ctx *gin.Context) {
 		return
 	}
 	// Find.
-	db = h.paginated(ctx, db)
-	db = sort.Sorted(db)
+	db = h.paginated(ctx, sort, db)
 	result = db.Find(&list)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)
@@ -773,8 +769,7 @@ func (h AnalysisHandler) RuleReports(ctx *gin.Context) {
 	db = db.Select("*")
 	db = db.Table("(?)", q)
 	db = filter.Where(db)
-	db = h.paginated(ctx, db)
-	db = sort.Sorted(db)
+	db = h.paginated(ctx, sort, db)
 	var list []M
 	result := db.Find(&list)
 	if result.Error != nil {
@@ -938,8 +933,7 @@ func (h AnalysisHandler) AppReports(ctx *gin.Context) {
 	db = db.Select("*")
 	db = db.Table("(?)", q)
 	db = filter.Where(db)
-	db = h.paginated(ctx, db)
-	db = sort.Sorted(db)
+	db = h.paginated(ctx, sort, db)
 	var list []M
 	result := db.Find(&list)
 	if result.Error != nil {
@@ -1046,8 +1040,7 @@ func (h AnalysisHandler) FileReports(ctx *gin.Context) {
 	db = db.Select("*")
 	db = db.Table("(?)", q)
 	db = filter.Where(db)
-	db = h.paginated(ctx, db)
-	db = sort.Sorted(db)
+	db = h.paginated(ctx, sort, db)
 	result = db.Find(&list)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)
@@ -1127,8 +1120,7 @@ func (h AnalysisHandler) Deps(ctx *gin.Context) {
 		return
 	}
 	// Find.
-	db = h.paginated(ctx, db)
-	db = sort.Sorted(db)
+	db = h.paginated(ctx, sort, db)
 	list := []model.TechDependency{}
 	result = db.Find(&list)
 	if result.Error != nil {
@@ -1225,8 +1217,7 @@ func (h AnalysisHandler) DepReports(ctx *gin.Context) {
 	db = db.Select("*")
 	db = db.Table("(?)", q)
 	db = filter.Where(db)
-	db = h.paginated(ctx, db)
-	db = sort.Sorted(db)
+	db = h.paginated(ctx, sort, db)
 	result := db.Scan(&list)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)

--- a/api/analysis.go
+++ b/api/analysis.go
@@ -128,7 +128,7 @@ func (h AnalysisHandler) AppList(ctx *gin.Context) {
 	resources := []Analysis{}
 	// Build query.
 	id := h.pk(ctx)
-	db := h.Paginated(ctx)
+	db := h.DB(ctx)
 	db = db.Where("ApplicationID = ?", id)
 	count := int64(0)
 	// Count.
@@ -383,6 +383,12 @@ func (h AnalysisHandler) AppDeps(ctx *gin.Context) {
 		_ = ctx.Error(err)
 		return
 	}
+	sort := Sort{}
+	err = sort.With(ctx, &model.TechDependency{})
+	if err != nil {
+		_ = ctx.Error(err)
+		return
+	}
 	db = h.DB(ctx)
 	db = db.Where("AnalysisID = ?", analysis.ID)
 	db = db.Where("ID IN (?)", h.depIDs(ctx, filter))
@@ -405,6 +411,7 @@ func (h AnalysisHandler) AppDeps(ctx *gin.Context) {
 	// Find.
 	list := []model.TechDependency{}
 	db = h.paginated(ctx, db)
+	db = sort.Sorted(db)
 	result = db.Find(&list)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)
@@ -459,6 +466,12 @@ func (h AnalysisHandler) AppIssues(ctx *gin.Context) {
 		_ = ctx.Error(err)
 		return
 	}
+	sort := Sort{}
+	err = sort.With(ctx, &model.Issue{})
+	if err != nil {
+		_ = ctx.Error(err)
+		return
+	}
 	db = h.DB(ctx)
 	db = db.Model(&model.Issue{})
 	db = db.Where("AnalysisID = ?", analysis.ID)
@@ -482,6 +495,7 @@ func (h AnalysisHandler) AppIssues(ctx *gin.Context) {
 	// Find.
 	list := []model.Issue{}
 	db = h.paginated(ctx, db)
+	db = sort.Sorted(db)
 	result = db.Find(&list)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)
@@ -533,6 +547,12 @@ func (h AnalysisHandler) Issues(ctx *gin.Context) {
 		_ = ctx.Error(err)
 		return
 	}
+	sort := Sort{}
+	err = sort.With(ctx, &model.Issue{})
+	if err != nil {
+		_ = ctx.Error(err)
+		return
+	}
 	db := h.DB(ctx)
 	db = db.Table("Issue i")
 	db = db.Joins(",Analysis a")
@@ -560,6 +580,7 @@ func (h AnalysisHandler) Issues(ctx *gin.Context) {
 	//
 	// Find.
 	db = h.paginated(ctx, db)
+	db = sort.Sorted(db)
 	var list []model.Issue
 	result = db.Find(&list)
 	if result.Error != nil {
@@ -619,6 +640,12 @@ func (h AnalysisHandler) Incidents(ctx *gin.Context) {
 		_ = ctx.Error(err)
 		return
 	}
+	sort := Sort{}
+	err = sort.With(ctx, &model.Incident{})
+	if err != nil {
+		_ = ctx.Error(err)
+		return
+	}
 	var list []model.Incident
 	db := h.DB(ctx)
 	db = db.Where("IssueID", issueId)
@@ -637,6 +664,7 @@ func (h AnalysisHandler) Incidents(ctx *gin.Context) {
 	}
 	// Find.
 	db = h.paginated(ctx, db)
+	db = sort.Sorted(db)
 	result = db.Find(&list)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)
@@ -679,6 +707,10 @@ func (h AnalysisHandler) Incidents(ctx *gin.Context) {
 // @router /analyses/report/rules [get]
 func (h AnalysisHandler) RuleReports(ctx *gin.Context) {
 	resources := []*RuleReport{}
+	type M struct {
+		model.Issue
+		Applications int
+	}
 	// Build query.
 	filter, err := qf.New(ctx,
 		[]qf.Assert{
@@ -693,6 +725,12 @@ func (h AnalysisHandler) RuleReports(ctx *gin.Context) {
 			{Field: "businessService.name", Kind: qf.STRING},
 			{Field: "tag.id", Kind: qf.LITERAL, Relation: true},
 		})
+	if err != nil {
+		_ = ctx.Error(err)
+		return
+	}
+	sort := Sort{}
+	err = sort.With(ctx, &M{})
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -731,15 +769,12 @@ func (h AnalysisHandler) RuleReports(ctx *gin.Context) {
 	}
 	affected := make(map[string]int)
 	// Find.
-	type M struct {
-		model.Issue
-		Applications int
-	}
 	db := h.DB(ctx)
 	db = db.Select("*")
 	db = db.Table("(?)", q)
 	db = filter.Where(db)
 	db = h.paginated(ctx, db)
+	db = sort.Sorted(db)
 	var list []M
 	result := db.Find(&list)
 	if result.Error != nil {
@@ -811,6 +846,19 @@ func (h AnalysisHandler) RuleReports(ctx *gin.Context) {
 // @router /analyses/report/applications [get]
 func (h AnalysisHandler) AppReports(ctx *gin.Context) {
 	resources := []AppReport{}
+	type M struct {
+		ID              uint
+		Name            string
+		Description     string
+		BusinessService string
+		Effort          int
+		Incidents       int
+		Files           int
+		IssueID         uint
+		IssueName       string
+		RuleSet         string
+		Rule            string
+	}
 	// Build query.
 	filter, err := qf.New(ctx,
 		[]qf.Assert{
@@ -833,6 +881,12 @@ func (h AnalysisHandler) AppReports(ctx *gin.Context) {
 			{Field: "businessService.name", Kind: qf.STRING},
 			{Field: "tag.id", Kind: qf.LITERAL, Relation: true},
 		})
+	if err != nil {
+		_ = ctx.Error(err)
+		return
+	}
+	sort := Sort{}
+	err = sort.With(ctx, &M{})
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -880,24 +934,12 @@ func (h AnalysisHandler) AppReports(ctx *gin.Context) {
 	}
 	//
 	// Find.
-	type M struct {
-		ID              uint
-		Name            string
-		Description     string
-		BusinessService string
-		Effort          int
-		Incidents       int
-		Files           int
-		IssueID         uint
-		IssueName       string
-		RuleSet         string
-		Rule            string
-	}
 	db := h.DB(ctx)
 	db = db.Select("*")
 	db = db.Table("(?)", q)
 	db = filter.Where(db)
 	db = h.paginated(ctx, db)
+	db = sort.Sorted(db)
 	var list []M
 	result := db.Find(&list)
 	if result.Error != nil {
@@ -941,6 +983,12 @@ func (h AnalysisHandler) AppReports(ctx *gin.Context) {
 // @router /analyses/report/issues/{id}/files [get]
 func (h AnalysisHandler) FileReports(ctx *gin.Context) {
 	resources := []FileReport{}
+	type M struct {
+		IssueId   uint
+		File      string
+		Effort    int
+		Incidents int
+	}
 	issueId := h.pk(ctx)
 	issue := &model.Issue{}
 	result := h.DB(ctx).First(issue, issueId)
@@ -956,6 +1004,12 @@ func (h AnalysisHandler) FileReports(ctx *gin.Context) {
 			{Field: "incidents", Kind: qf.LITERAL},
 			{Field: "effort", Kind: qf.LITERAL},
 		})
+	if err != nil {
+		_ = ctx.Error(err)
+		return
+	}
+	sort := Sort{}
+	err = sort.With(ctx, &M{})
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -987,18 +1041,13 @@ func (h AnalysisHandler) FileReports(ctx *gin.Context) {
 		return
 	}
 	// Find.
-	type M struct {
-		IssueId   uint
-		File      string
-		Effort    int
-		Incidents int
-	}
 	var list []M
 	db := h.DB(ctx)
 	db = db.Select("*")
 	db = db.Table("(?)", q)
 	db = filter.Where(db)
 	db = h.paginated(ctx, db)
+	db = sort.Sorted(db)
 	result = db.Find(&list)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)
@@ -1052,6 +1101,12 @@ func (h AnalysisHandler) Deps(ctx *gin.Context) {
 		_ = ctx.Error(err)
 		return
 	}
+	sort := Sort{}
+	err = sort.With(ctx, &model.TechDependency{})
+	if err != nil {
+		_ = ctx.Error(err)
+		return
+	}
 	db := h.DB(ctx)
 	db = db.Where("AnalysisID IN (?)", h.analysisIDs(ctx, filter))
 	db = db.Where("ID IN (?)", h.depIDs(ctx, filter))
@@ -1073,6 +1128,7 @@ func (h AnalysisHandler) Deps(ctx *gin.Context) {
 	}
 	// Find.
 	db = h.paginated(ctx, db)
+	db = sort.Sorted(db)
 	list := []model.TechDependency{}
 	result = db.Find(&list)
 	if result.Error != nil {
@@ -1110,6 +1166,10 @@ func (h AnalysisHandler) Deps(ctx *gin.Context) {
 // @router /analyses/dependencies [get]
 func (h AnalysisHandler) DepReports(ctx *gin.Context) {
 	resources := []DepReport{}
+	type M struct {
+		model.TechDependency
+		Applications int
+	}
 	// Build query.
 	filter, err := qf.New(ctx,
 		[]qf.Assert{
@@ -1123,6 +1183,12 @@ func (h AnalysisHandler) DepReports(ctx *gin.Context) {
 			{Field: "application.name", Kind: qf.STRING},
 			{Field: "tag.id", Kind: qf.LITERAL, Relation: true},
 		})
+	if err != nil {
+		_ = ctx.Error(err)
+		return
+	}
+	sort := Sort{}
+	err = sort.With(ctx, &M{})
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -1154,16 +1220,13 @@ func (h AnalysisHandler) DepReports(ctx *gin.Context) {
 		return
 	}
 	// Find.
-	type M struct {
-		model.TechDependency
-		Applications int
-	}
 	var list []M
 	db := h.DB(ctx)
 	db = db.Select("*")
 	db = db.Table("(?)", q)
 	db = filter.Where(db)
 	db = h.paginated(ctx, db)
+	db = sort.Sorted(db)
 	result := db.Scan(&list)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)

--- a/api/application.go
+++ b/api/application.go
@@ -122,7 +122,7 @@ func (h ApplicationHandler) Get(ctx *gin.Context) {
 // @router /applications [get]
 func (h ApplicationHandler) List(ctx *gin.Context) {
 	var list []model.Application
-	db := h.preLoad(h.Paginated(ctx), clause.Associations)
+	db := h.preLoad(h.DB(ctx), clause.Associations)
 	db = db.Omit("Analyses")
 	result := db.Find(&list)
 	if result.Error != nil {

--- a/api/base.go
+++ b/api/base.go
@@ -70,11 +70,12 @@ func (h *BaseHandler) WithCount(ctx *gin.Context, count int64) (err error) {
 }
 
 //
-// Paginated returns a paginated DB client.
-func (h *BaseHandler) paginated(ctx *gin.Context, in *gorm.DB) (db *gorm.DB) {
+// Paginated returns a paginated and sorted DB client.
+func (h *BaseHandler) paginated(ctx *gin.Context, sort Sort, in *gorm.DB) (db *gorm.DB) {
 	p := Page{}
 	p.With(ctx)
 	db = p.Paginated(in)
+	db = sort.Sorted(db)
 	return
 }
 

--- a/api/base.go
+++ b/api/base.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
 	"github.com/jortel/go-utils/logr"
+	"github.com/konveyor/tackle2-hub/api/sort"
 	"github.com/konveyor/tackle2-hub/auth"
 	"github.com/konveyor/tackle2-hub/model"
 	"gopkg.in/yaml.v3"
@@ -42,22 +43,6 @@ func (h *BaseHandler) Client(ctx *gin.Context) (client client.Client) {
 }
 
 //
-// Paginated returns a paginated AND sorted DB client.
-func (h *BaseHandler) Paginated(ctx *gin.Context) (db *gorm.DB) {
-	db = h.paginated(ctx, h.DB(ctx))
-	return
-}
-
-//
-// Sorted returns a sorted DB client.
-func (h *BaseHandler) Sorted(ctx *gin.Context) (db *gorm.DB) {
-	sort := Sort{}
-	sort.With(ctx)
-	db = sort.Sorted(h.DB(ctx))
-	return
-}
-
-//
 // WithCount report count.
 // Sets the X-Total header for pagination.
 // Returns an error when count exceeds the limited and
@@ -85,14 +70,11 @@ func (h *BaseHandler) WithCount(ctx *gin.Context, count int64) (err error) {
 }
 
 //
-// Paginated returns a paginated AND sorted DB client.
+// Paginated returns a paginated DB client.
 func (h *BaseHandler) paginated(ctx *gin.Context, in *gorm.DB) (db *gorm.DB) {
 	p := Page{}
 	p.With(ctx)
 	db = p.Paginated(in)
-	sort := Sort{}
-	sort.With(ctx)
-	db = sort.Sorted(db)
 	return
 }
 
@@ -441,45 +423,7 @@ func (p *Page) Paginated(in *gorm.DB) (out *gorm.DB) {
 
 //
 // Sort provides sorting.
-type Sort struct {
-	Descending bool
-	Field      string
-}
-
-//
-// With context.
-func (p *Sort) With(ctx *gin.Context) {
-	s := ctx.Query("sort")
-	if s == "" {
-		return
-	}
-	mark := strings.Index(s, ":")
-	if mark == -1 {
-		p.Field = s
-		return
-	}
-	d := strings.ToLower(s[:mark])
-	field := s[mark+1:]
-	if len(d) != 0 {
-		p.Descending = d[0] == 'd'
-	}
-	p.Field = field
-}
-
-//
-// Sorted returns sorted DB.
-func (p *Sort) Sorted(in *gorm.DB) (out *gorm.DB) {
-	out = in
-	if p.Field == "" {
-		return
-	}
-	sort := p.Field
-	if p.Descending {
-		sort += " DESC"
-	}
-	out = out.Order(sort)
-	return
-}
+type Sort = sort.Sort
 
 //
 // Decoder binding decoder.

--- a/api/bucket.go
+++ b/api/bucket.go
@@ -59,7 +59,7 @@ func (h BucketHandler) AddRoutes(e *gin.Engine) {
 // @router /buckets [get]
 func (h BucketHandler) List(ctx *gin.Context) {
 	var list []model.Bucket
-	result := h.Paginated(ctx).Find(&list)
+	result := h.DB(ctx).Find(&list)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)
 		return

--- a/api/businessservice.go
+++ b/api/businessservice.go
@@ -65,7 +65,7 @@ func (h BusinessServiceHandler) Get(ctx *gin.Context) {
 // @router /businessservices [get]
 func (h BusinessServiceHandler) List(ctx *gin.Context) {
 	var list []model.BusinessService
-	db := h.preLoad(h.Paginated(ctx), clause.Associations)
+	db := h.preLoad(h.DB(ctx), clause.Associations)
 	result := db.Find(&list)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)

--- a/api/dependency.go
+++ b/api/dependency.go
@@ -66,7 +66,7 @@ func (h DependencyHandler) Get(ctx *gin.Context) {
 func (h DependencyHandler) List(ctx *gin.Context) {
 	var list []model.Dependency
 
-	db := h.Paginated(ctx)
+	db := h.DB(ctx)
 	to := ctx.Query("to.id")
 	from := ctx.Query("from.id")
 	if to != "" {

--- a/api/error.go
+++ b/api/error.go
@@ -5,6 +5,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/go-playground/validator/v10"
 	"github.com/konveyor/tackle2-hub/api/filter"
+	"github.com/konveyor/tackle2-hub/api/sort"
 	"github.com/konveyor/tackle2-hub/model"
 	"github.com/mattn/go-sqlite3"
 	"gorm.io/gorm"
@@ -63,6 +64,7 @@ func ErrorHandler() gin.HandlerFunc {
 		rtx := WithContext(ctx)
 		if errors.Is(err, &BadRequestError{}) ||
 			errors.Is(err, &filter.Error{}) ||
+			errors.Is(err, &sort.SortError{}) ||
 			errors.Is(err, validator.ValidationErrors{}) {
 			rtx.Respond(
 				http.StatusBadRequest,

--- a/api/file.go
+++ b/api/file.go
@@ -46,7 +46,7 @@ func (h FileHandler) AddRoutes(e *gin.Engine) {
 // @router /files [get]
 func (h FileHandler) List(ctx *gin.Context) {
 	var list []model.File
-	result := h.Paginated(ctx).Find(&list)
+	result := h.DB(ctx).Find(&list)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)
 		return

--- a/api/group.go
+++ b/api/group.go
@@ -65,7 +65,7 @@ func (h StakeholderGroupHandler) Get(ctx *gin.Context) {
 // @router /stakeholdergroups [get]
 func (h StakeholderGroupHandler) List(ctx *gin.Context) {
 	var list []model.StakeholderGroup
-	db := h.preLoad(h.Paginated(ctx), clause.Associations)
+	db := h.preLoad(h.DB(ctx), clause.Associations)
 	result := db.Find(&list)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)

--- a/api/identity.go
+++ b/api/identity.go
@@ -79,7 +79,7 @@ func (h IdentityHandler) List(ctx *gin.Context) {
 	var list []model.Identity
 	appId := ctx.Query(AppId)
 	kind := ctx.Query(Kind)
-	db := h.Paginated(ctx)
+	db := h.DB(ctx)
 	if appId != "" {
 		db = db.Where(
 			"id IN (SELECT identityID from ApplicationIdentity WHERE applicationID = ?)",

--- a/api/jobfunction.go
+++ b/api/jobfunction.go
@@ -65,7 +65,7 @@ func (h JobFunctionHandler) Get(ctx *gin.Context) {
 // @router /jobfunctions [get]
 func (h JobFunctionHandler) List(ctx *gin.Context) {
 	var list []model.JobFunction
-	db := h.preLoad(h.Paginated(ctx), clause.Associations)
+	db := h.preLoad(h.DB(ctx), clause.Associations)
 	result := db.Find(&list)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)

--- a/api/migrationwave.go
+++ b/api/migrationwave.go
@@ -66,7 +66,7 @@ func (h MigrationWaveHandler) Get(ctx *gin.Context) {
 // @router /migrationwaves [get]
 func (h MigrationWaveHandler) List(ctx *gin.Context) {
 	var list []model.MigrationWave
-	db := h.preLoad(h.Paginated(ctx), clause.Associations)
+	db := h.preLoad(h.DB(ctx), clause.Associations)
 	result := db.Find(&list)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)

--- a/api/proxy.go
+++ b/api/proxy.go
@@ -69,7 +69,7 @@ func (h ProxyHandler) Get(ctx *gin.Context) {
 func (h ProxyHandler) List(ctx *gin.Context) {
 	var list []model.Proxy
 	kind := ctx.Query(Kind)
-	db := h.preLoad(h.Paginated(ctx), clause.Associations)
+	db := h.preLoad(h.DB(ctx), clause.Associations)
 	if kind != "" {
 		db = db.Where(Kind, kind)
 	}

--- a/api/reflect/fields.go
+++ b/api/reflect/fields.go
@@ -1,0 +1,86 @@
+package reflect
+
+import (
+	"reflect"
+	"time"
+)
+
+//
+// Fields returns a map of fields.
+func Fields(m interface{}) (mp map[string]interface{}) {
+	var inspect func(r interface{})
+	inspect = func(r interface{}) {
+		mt := reflect.TypeOf(r)
+		mv := reflect.ValueOf(r)
+		if mt.Kind() == reflect.Ptr {
+			mt = mt.Elem()
+			mv = mv.Elem()
+		}
+		for i := 0; i < mt.NumField(); i++ {
+			ft := mt.Field(i)
+			fv := mv.Field(i)
+			if !ft.IsExported() {
+				continue
+			}
+			switch fv.Kind() {
+			case reflect.Ptr:
+				pt := ft.Type.Elem()
+				switch pt.Kind() {
+				case reflect.Struct,
+					reflect.Slice,
+					reflect.Array:
+					continue
+				default:
+					mp[ft.Name] = fv.Interface()
+				}
+			case reflect.Struct:
+				if ft.Anonymous {
+					inspect(fv.Addr().Interface())
+					continue
+				}
+				inst := fv.Interface()
+				switch inst.(type) {
+				case time.Time:
+					mp[ft.Name] = inst
+				}
+			case reflect.Array:
+				continue
+			case reflect.Slice:
+				inst := fv.Interface()
+				switch inst.(type) {
+				case []byte:
+					mp[ft.Name] = fv.Interface()
+				}
+			default:
+				mp[ft.Name] = fv.Interface()
+			}
+		}
+	}
+	mp = map[string]interface{}{}
+	inspect(m)
+	return
+}
+
+//
+// NameOf returns the name of a model.
+func NameOf(m interface{}) (name string) {
+	mt := reflect.TypeOf(m)
+	mv := reflect.ValueOf(m)
+	if mv.IsNil() {
+		return
+	}
+	if mt.Kind() == reflect.Ptr {
+		mt = mt.Elem()
+		mv = mv.Elem()
+	}
+	for i := 0; i < mt.NumField(); i++ {
+		ft := mt.Field(i)
+		fv := mv.Field(i)
+		switch ft.Name {
+		case "Name":
+			name = fv.String()
+			return
+		}
+	}
+	return
+}

--- a/api/review.go
+++ b/api/review.go
@@ -67,7 +67,7 @@ func (h ReviewHandler) Get(ctx *gin.Context) {
 // @router /reviews [get]
 func (h ReviewHandler) List(ctx *gin.Context) {
 	var list []model.Review
-	db := h.preLoad(h.Paginated(ctx), clause.Associations)
+	db := h.preLoad(h.DB(ctx), clause.Associations)
 	result := db.Find(&list)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)

--- a/api/ruleset.go
+++ b/api/ruleset.go
@@ -68,7 +68,7 @@ func (h RuleSetHandler) Get(ctx *gin.Context) {
 func (h RuleSetHandler) List(ctx *gin.Context) {
 	var list []model.RuleSet
 	db := h.preLoad(
-		h.Paginated(ctx),
+		h.DB(ctx),
 		clause.Associations,
 		"Rules.File")
 	result := db.Find(&list)

--- a/api/setting.go
+++ b/api/setting.go
@@ -67,7 +67,7 @@ func (h SettingHandler) Get(ctx *gin.Context) {
 // @router /settings [get]
 func (h SettingHandler) List(ctx *gin.Context) {
 	var list []model.Setting
-	result := h.Paginated(ctx).Find(&list)
+	result := h.DB(ctx).Find(&list)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)
 		return

--- a/api/sort/error.go
+++ b/api/sort/error.go
@@ -1,0 +1,18 @@
+package sort
+
+import "fmt"
+
+//
+// SortError reports sorting error.
+type SortError struct {
+	field string
+}
+
+func (r *SortError) Error() string {
+	return fmt.Sprintf("\"%s\" not supported by sort.", r.field)
+}
+
+func (r *SortError) Is(err error) (matched bool) {
+	_, matched = err.(*SortError)
+	return
+}

--- a/api/sort/sort.go
+++ b/api/sort/sort.go
@@ -1,0 +1,124 @@
+package sort
+
+import (
+	"github.com/gin-gonic/gin"
+	"gorm.io/gorm"
+	"reflect"
+	"strings"
+	"time"
+)
+
+//
+// Clause sort clause.
+type Clause struct {
+	direction string
+	name      string
+}
+
+//
+// Sort provides sorting.
+type Sort struct {
+	fields  map[string]bool
+	clauses []Clause
+}
+
+//
+// With context.
+func (r *Sort) With(ctx *gin.Context, m interface{}) (err error) {
+	param := ctx.Query("sort")
+	if param == "" {
+		return
+	}
+	for _, s := range strings.Split(param, ",") {
+		clause := Clause{}
+		s = strings.TrimSpace(s)
+		s = strings.ToLower(s)
+		mark := strings.Index(s, ":")
+		if mark == -1 {
+			_, found := r.fields[s]
+			if !found {
+				err = &SortError{s}
+				return
+			}
+			clause.name = s
+			r.clauses = append(
+				r.clauses,
+				clause)
+		} else {
+			d := strings.ToLower(s[:mark])
+			s := s[mark+1:]
+			if len(d) != 0 {
+				if d[0] == 'd' {
+					clause.direction = "DESC"
+				}
+			}
+			_, found := r.fields[s]
+			if !found {
+				err = &SortError{s}
+				return
+			}
+			clause.name = s
+			r.clauses = append(
+				r.clauses,
+				clause)
+		}
+	}
+	return
+}
+
+//
+// Sorted returns sorted DB.
+func (r *Sort) Sorted(in *gorm.DB) (out *gorm.DB) {
+	out = in
+	if len(r.clauses) == 0 {
+		return
+	}
+	clauses := []string{}
+	for _, clause := range r.clauses {
+		clauses = append(clauses, clause.name+" "+clause.direction)
+	}
+	out = out.Order(strings.Join(clauses, ","))
+	return
+}
+
+//
+// inspect object and return fields.
+func (r *Sort) inspect(m interface{}) (fields map[string]bool) {
+	fields = make(map[string]bool)
+	var inspect func(r interface{})
+	inspect = func(r interface{}) {
+		mt := reflect.TypeOf(r)
+		mv := reflect.ValueOf(r)
+		if mt.Kind() == reflect.Ptr {
+			mt = mt.Elem()
+			mv = mv.Elem()
+		}
+		for i := 0; i < mt.NumField(); i++ {
+			ft := mt.Field(i)
+			fv := mv.Field(i)
+			if !ft.IsExported() {
+				continue
+			}
+			switch fv.Kind() {
+			case reflect.Struct:
+				if ft.Anonymous {
+					inspect(fv.Interface())
+					continue
+				}
+				inst := fv.Interface()
+				switch inst.(type) {
+				case time.Time:
+					fields[strings.ToLower(ft.Name)] = true
+				}
+			case reflect.Array,
+				reflect.Slice,
+				reflect.Ptr:
+				continue
+			default:
+				fields[strings.ToLower(ft.Name)] = true
+			}
+		}
+	}
+	inspect(m)
+	return
+}

--- a/api/sort/sort.go
+++ b/api/sort/sort.go
@@ -29,6 +29,7 @@ func (r *Sort) With(ctx *gin.Context, m interface{}) (err error) {
 	if param == "" {
 		return
 	}
+	r.fields = r.inspect(m)
 	for _, s := range strings.Split(param, ",") {
 		clause := Clause{}
 		s = strings.TrimSpace(s)

--- a/api/stakeholder.go
+++ b/api/stakeholder.go
@@ -65,7 +65,7 @@ func (h StakeholderHandler) Get(ctx *gin.Context) {
 // @router /stakeholders [get]
 func (h StakeholderHandler) List(ctx *gin.Context) {
 	var list []model.Stakeholder
-	db := h.preLoad(h.Paginated(ctx), clause.Associations)
+	db := h.preLoad(h.DB(ctx), clause.Associations)
 	result := db.Find(&list)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)

--- a/api/tag.go
+++ b/api/tag.go
@@ -65,7 +65,7 @@ func (h TagHandler) Get(ctx *gin.Context) {
 // @router /tags [get]
 func (h TagHandler) List(ctx *gin.Context) {
 	var list []model.Tag
-	db := h.preLoad(h.Paginated(ctx), clause.Associations)
+	db := h.preLoad(h.DB(ctx), clause.Associations)
 	result := db.Find(&list)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)

--- a/api/tagcategory.go
+++ b/api/tagcategory.go
@@ -69,7 +69,7 @@ func (h TagCategoryHandler) Get(ctx *gin.Context) {
 // @param name query string false "Optional category name filter"
 func (h TagCategoryHandler) List(ctx *gin.Context) {
 	var list []model.TagCategory
-	db := h.preLoad(h.Paginated(ctx), clause.Associations)
+	db := h.preLoad(h.DB(ctx), clause.Associations)
 	if name, found := ctx.GetQuery(Name); found {
 		db = db.Where("name = ?", name)
 	}

--- a/api/task.go
+++ b/api/task.go
@@ -96,7 +96,7 @@ func (h TaskHandler) Get(ctx *gin.Context) {
 // @router /tasks [get]
 func (h TaskHandler) List(ctx *gin.Context) {
 	var list []model.Task
-	db := h.Paginated(ctx)
+	db := h.DB(ctx)
 	locator := ctx.Query(LocatorParam)
 	if locator != "" {
 		db = db.Where("locator", locator)

--- a/api/taskgroup.go
+++ b/api/taskgroup.go
@@ -80,7 +80,7 @@ func (h TaskGroupHandler) Get(ctx *gin.Context) {
 // @router /taskgroups [get]
 func (h TaskGroupHandler) List(ctx *gin.Context) {
 	var list []model.TaskGroup
-	db := h.Paginated(ctx).Preload(clause.Associations)
+	db := h.DB(ctx).Preload(clause.Associations)
 	result := db.Find(&list)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)

--- a/api/ticket.go
+++ b/api/ticket.go
@@ -70,7 +70,7 @@ func (h TicketHandler) List(ctx *gin.Context) {
 	var list []model.Ticket
 	appId := ctx.Query(AppId)
 	trackerId := ctx.Query(TrackerId)
-	db := h.preLoad(h.Paginated(ctx), clause.Associations)
+	db := h.preLoad(h.DB(ctx), clause.Associations)
 	if appId != "" {
 		db = db.Where("ApplicationID = ?", appId)
 	}

--- a/api/tracker.go
+++ b/api/tracker.go
@@ -70,7 +70,7 @@ func (h TrackerHandler) Get(ctx *gin.Context) {
 // @router /trackers [get]
 func (h TrackerHandler) List(ctx *gin.Context) {
 	var list []model.Tracker
-	db := h.preLoad(h.Paginated(ctx), clause.Associations)
+	db := h.preLoad(h.DB(ctx), clause.Associations)
 	kind := ctx.Query(Kind)
 	if kind != "" {
 		db = db.Where(Kind, kind)


### PR DESCRIPTION
The approach is to build the Sort object using the fields in the model used for the query.

Revert the usage of h.Paginated() in all but analysis.go. We can add pagination and sorting more deliberately as needed. This is most of the diff.

Moved the sorting object to the _new_ sort package.

Moved the BaseHandler.fields() and BaseHandler.nameOf() to a _new_ reflect package.  The Fields() used for both update and inspection of models for sort fields. 

Add Sort.With() enhanced to provide validation.