### PR TITLE
:bug: Update new TagCategory in CSV import

### DIFF
--- a/importer/manager.go
+++ b/importer/manager.go
@@ -237,6 +237,8 @@ func (m *Manager) createApplication(imp *model.Import) (ok bool) {
 					imp.ErrorMessage = fmt.Sprintf("TagCategory '%s' cannot be created.", impTag.Category)
 					return
 				}
+				// Add newly created Category to lookup list.
+				allCategories = append(allCategories, *category)
 			} else {
 				imp.ErrorMessage = fmt.Sprintf("TagCategory '%s' could not be found.", impTag.Category)
 				return


### PR DESCRIPTION
Application CSV import can create new Tag Categories. For performance reasons, list of Tag Categories is loaded from database before processing all Tag imports. This list wasn't updated with newly created Tag Categories, so it was not possible create a new Tag Category and assign multiple Tags to it on the Same application.

Adding new created Tag categories to the cached Tag Categories list.

Fixes: https://issues.redhat.com/browse/MTA-480