### PR TITLE
[backport] :sparkles: Support JIRA Bearer Auth (#374)

### DIFF
--- a/tracker/pkg.go
+++ b/tracker/pkg.go
@@ -9,6 +9,7 @@ import (
 // Tracker types
 const (
 	JiraCloud      = "jira-cloud"
+	JiraOnPrem     = "jira-onprem"
 	JiraServer     = "jira-server"
 	JiraDataCenter = "jira-datacenter"
 )
@@ -30,7 +31,7 @@ type Connector interface {
 // NewConnector instantiates a connector for an external ticket tracker.
 func NewConnector(t *model.Tracker) (conn Connector, err error) {
 	switch t.Kind {
-	case JiraCloud, JiraServer, JiraDataCenter:
+	case JiraCloud, JiraServer, JiraDataCenter, JiraOnPrem:
 		conn = &jira.Connector{}
 		conn.With(t)
 	default:


### PR DESCRIPTION
Backport #374 

Fixes https://issues.redhat.com/browse/MTA-699 by making it possible to authenticate with On-Prem Jira deployments that use bearer token auth.