### PR TITLE
[backport] :bug: Add uniq Name constrain to Identity

### DIFF
--- a/migration/v2/model/identity.go
+++ b/migration/v2/model/identity.go
@@ -5,12 +5,11 @@ import (
 	"github.com/konveyor/tackle2-hub/encryption"
 )
 
-//
 // Identity represents and identity with a set of credentials.
 type Identity struct {
 	Model
 	Kind        string `gorm:"not null"`
-	Name        string `gorm:"not null"`
+	Name        string `gorm:"index;unique;not null"`
 	Description string
 	User        string
 	Password    string

--- a/migration/v4/model/identity.go
+++ b/migration/v4/model/identity.go
@@ -5,12 +5,11 @@ import (
 	"github.com/konveyor/tackle2-hub/encryption"
 )
 
-//
 // Identity represents and identity with a set of credentials.
 type Identity struct {
 	Model
 	Kind        string `gorm:"not null"`
-	Name        string `gorm:"not null"`
+	Name        string `gorm:"index;unique;not null"`
 	Description string
 	User        string
 	Password    string
@@ -19,7 +18,6 @@ type Identity struct {
 	Proxies     []Proxy `gorm:"constraint:OnDelete:SET NULL"`
 }
 
-//
 // Encrypt sensitive fields.
 // The ref identity is used to determine when sensitive fields
 // have changed and need to be (re)encrypted.
@@ -56,7 +54,6 @@ func (r *Identity) Encrypt(ref *Identity) (err error) {
 	return
 }
 
-//
 // Decrypt sensitive fields.
 func (r *Identity) Decrypt() (err error) {
 	passphrase := Settings.Encryption.Passphrase

--- a/migration/v4/model/pkg.go
+++ b/migration/v4/model/pkg.go
@@ -20,7 +20,6 @@ type Bucket = v3.Bucket
 type BucketOwner = v3.BucketOwner
 type Dependency = v3.Dependency
 type File = v3.File
-type Identity = v3.Identity
 type Import = v3.Import
 type ImportSummary = v3.ImportSummary
 type ImportTag = v3.ImportTag

--- a/test/api/identity/api_test.go
+++ b/test/api/identity/api_test.go
@@ -3,6 +3,7 @@ package identity
 import (
 	"testing"
 
+	"github.com/konveyor/tackle2-hub/api"
 	"github.com/konveyor/tackle2-hub/test/assert"
 )
 
@@ -73,4 +74,34 @@ func TestIdentityList(t *testing.T) {
 	for _, r := range samples {
 		assert.Must(t, Identity.Delete(r.ID))
 	}
+}
+
+func TestIdentityNotCreateDuplicates(t *testing.T) {
+	r := GitPw
+
+	// Create sample.
+	assert.Should(t, Identity.Create(&r))
+
+	// Try duplicate with the same and different Kind
+	for _, kind := range []string{r.Kind, "mvn"} {
+		t.Run(kind, func(t *testing.T) {
+			// Prepare Identity with duplicate Name.
+			dup := &api.Identity{
+				Name: r.Name,
+				Kind: kind,
+			}
+
+			// Try create the duplicate.
+			err := Identity.Create(dup)
+			if err == nil {
+				t.Errorf("Created duplicate identity: %v", dup)
+
+				// Clean the duplicate.
+				assert.Must(t, Identity.Delete(dup.ID))
+			}
+		})
+	}
+
+	// Clean.
+	assert.Must(t, Identity.Delete(r.ID))
 }


### PR DESCRIPTION
release-0.2 backport of Add uniq Name constrain to Identity #377

Adding uniq Name constraint to Identity model. The constraint is enforced regardless Identity Kind in similar way as UI do for a while.

Fixes: https://issues.redhat.com/browse/MTA-27