### PR TITLE
:bug: Support LIKE filter on lists.

### DIFF
--- a/api/analysis.go
+++ b/api/analysis.go
@@ -1287,7 +1287,7 @@ func (h *AnalysisHandler) appIDs(ctx *gin.Context, f qf.Filter) (q *gorm.DB) {
 			tq := h.DB(ctx)
 			tq = tq.Model(&model.ApplicationTag{})
 			tq = tq.Select("ApplicationID ID")
-			tq = tq.Where(field.SQL())
+			tq = field.Where(tq)
 			q = q.Where("ID IN (?)", tq)
 		}
 	}
@@ -1342,7 +1342,7 @@ func (h *AnalysisHandler) issueIDs(ctx *gin.Context, f qf.Filter) (q *gorm.DB) {
 			q = q.Table("Issue")
 			q = q.Joins("m ,json_each(Labels)")
 			q = q.Select("m.ID")
-			q = q.Where(f.SQL())
+			q = f.Where(q)
 		}
 	}
 	return
@@ -1376,7 +1376,7 @@ func (h *AnalysisHandler) depIDs(ctx *gin.Context, f qf.Filter) (q *gorm.DB) {
 			q = q.Table("Issue")
 			q = q.Joins("m ,json_each(Labels)")
 			q = q.Select("m.ID")
-			q = q.Where(f.SQL())
+			q = f.Where(q)
 		}
 	}
 	return

--- a/api/analysis.go
+++ b/api/analysis.go
@@ -748,7 +748,7 @@ func (h AnalysisHandler) RuleReports(ctx *gin.Context) {
 	q = q.Joins("Analysis a")
 	q = q.Where("a.ID = i.AnalysisID")
 	q = q.Where("a.ID in (?)", h.analysisIDs(ctx, filter))
-	q = q.Where("i.ID IN (?)", h.issueIDs(ctx, filter.Resource("issue")))
+	q = q.Where("i.ID IN (?)", h.issueIDs(ctx, filter))
 	q = q.Group("i.RuleSet,i.Rule")
 	// Count.
 	filter = filter.With("-Labels")
@@ -1270,24 +1270,25 @@ func (h *AnalysisHandler) appIDs(ctx *gin.Context, f qf.Filter) (q *gorm.DB) {
 	appFilter := f.Resource("application")
 	q = appFilter.Where(q)
 	tagFilter := f.Resource("tag")
-	if field, found := tagFilter.Field("id"); found {
-		if field.Value.Operator(qf.AND) {
+	if f, found := tagFilter.Field("id"); found {
+		if f.Value.Operator(qf.AND) {
 			var qs []*gorm.DB
-			for _, v := range field.Value.ByKind(qf.LITERAL, qf.STRING) {
+			for _, f = range f.Expand() {
+				f = f.As("TagID")
 				q := h.DB(ctx)
 				q = q.Model(&model.ApplicationTag{})
 				q = q.Select("applicationID ID")
-				q = q.Where("TagID = ?", qf.AsValue(v))
+				q = f.Where(q)
 				qs = append(qs, q)
 			}
 			tq := model.Intersect(qs...)
 			q = q.Where("ID IN (?)", tq)
 		} else {
-			field = field.As("TagID")
+			f = f.As("TagID")
 			tq := h.DB(ctx)
 			tq = tq.Model(&model.ApplicationTag{})
 			tq = tq.Select("ApplicationID ID")
-			tq = field.Where(tq)
+			tq = f.Where(tq)
 			q = q.Where("ID IN (?)", tq)
 		}
 	}
@@ -1327,16 +1328,13 @@ func (h *AnalysisHandler) issueIDs(ctx *gin.Context, f qf.Filter) (q *gorm.DB) {
 	if f, found := filter.Field("labels"); found {
 		if f.Value.Operator(qf.AND) {
 			var qs []*gorm.DB
-			operator := f.Operator.Value
-			if operator == string(qf.LIKE) {
-				operator = "LIKE"
-			}
-			for _, v := range f.Value.ByKind(qf.LITERAL, qf.STRING) {
+			for _, f = range f.Expand() {
+				f = f.As("json_each.value")
 				q := h.DB(ctx)
 				q = q.Table("Issue")
 				q = q.Joins("m ,json_each(Labels)")
 				q = q.Select("m.ID")
-				q = q.Where("json_each.value "+operator+" ?", qf.AsValue(v))
+				q = f.Where(q)
 				qs = append(qs, q)
 			}
 			q = model.Intersect(qs...)
@@ -1365,12 +1363,13 @@ func (h *AnalysisHandler) depIDs(ctx *gin.Context, f qf.Filter) (q *gorm.DB) {
 	if f, found := filter.Field("labels"); found {
 		if f.Value.Operator(qf.AND) {
 			var qs []*gorm.DB
-			for _, v := range f.Value.ByKind(qf.LITERAL, qf.STRING) {
+			for _, f = range f.Expand() {
+				f = f.As("json_each.value")
 				q := h.DB(ctx)
 				q = q.Table("Issue")
 				q = q.Joins("m ,json_each(Labels)")
 				q = q.Select("m.ID")
-				q = q.Where("json_each.value = ?", qf.AsValue(v))
+				q = f.Where(q)
 				qs = append(qs, q)
 			}
 			q = model.Intersect(qs...)

--- a/api/analysis.go
+++ b/api/analysis.go
@@ -1327,12 +1327,16 @@ func (h *AnalysisHandler) issueIDs(ctx *gin.Context, f qf.Filter) (q *gorm.DB) {
 	if f, found := filter.Field("labels"); found {
 		if f.Value.Operator(qf.AND) {
 			var qs []*gorm.DB
+			operator := f.Operator.Value
+			if operator == string(qf.LIKE) {
+				operator = "LIKE"
+			}
 			for _, v := range f.Value.ByKind(qf.LITERAL, qf.STRING) {
 				q := h.DB(ctx)
 				q = q.Table("Issue")
 				q = q.Joins("m ,json_each(Labels)")
 				q = q.Select("m.ID")
-				q = q.Where("json_each.value = ?", qf.AsValue(v))
+				q = q.Where("json_each.value "+operator+" ?", qf.AsValue(v))
 				qs = append(qs, q)
 			}
 			q = model.Intersect(qs...)

--- a/api/filter/filter_test.go
+++ b/api/filter/filter_test.go
@@ -229,7 +229,7 @@ func TestFilter(t *testing.T) {
 	}))
 	sql, values := f.SQL()
 	g.Expect(sql).To(gomega.Equal("category IN ?"))
-	g.Expect(values).To(gomega.Equal([]interface{}{"a", "b", "c"}))
+	g.Expect(values[0]).To(gomega.Equal([]interface{}{"a", "b", "c"}))
 
 	f, found = filter.Field("name.first")
 	g.Expect(found).To(gomega.BeTrue())
@@ -258,6 +258,13 @@ func TestFilter(t *testing.T) {
 	f, found = filter.Field("id")
 	g.Expect(found).To(gomega.BeTrue())
 	g.Expect(AsValue(f.Value[0])).To(gomega.Equal(0))
+
+	filter, err = p.Filter("category~(a|b)")
+	f, found = filter.Field("category")
+	g.Expect(found).To(gomega.BeTrue())
+	sql, values = f.SQL()
+	g.Expect(sql).To(gomega.Equal("(category LIKE ? OR category LIKE ?)"))
+	g.Expect(values).To(gomega.Equal([]interface{}{"a", "b"}))
 }
 
 func TestValidation(t *testing.T) {


### PR DESCRIPTION
Support LIKE filter with _LIST_ (OR) values in the _filter_ package.

```
?filter=category~(This*|That*)

(category LIKE 'This%' OR category LIKE 'That%')
```

Add support for filter on Labels AND using LIKE.  This needs to be done with an INTERSECT so cannot be entirely provided by the _filter_.
```
 ?filter=labels~(This*,That*)
 
SELECT ID FROM Thing WHERE category LIKE 'This%' 
INTERSECT 
SELECT ID FROM Thing WHERE category LIKE 'That%'
```
Adds Field.Expand() greatly simplifies building the query for AND Lists by delegating the building of each _WHERE clause_ to the _filter_ package. Applied pattern everywhere.

Fixes RuleReport filter on labels.