### PR TITLE
:bug: metrics: count issue export only when successful

### DIFF
--- a/tracker/jira.go
+++ b/tracker/jira.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"github.com/andygrunwald/go-jira"
 	liberr "github.com/jortel/go-utils/error"
+	"github.com/konveyor/tackle2-hub/metrics"
 	"github.com/konveyor/tackle2-hub/model"
 	"io"
 	"net/http"
@@ -58,6 +59,7 @@ func (r *JiraConnector) Create(t *model.Ticket) (err error) {
 	t.Reference = issue.Key
 	t.Link = issue.Self
 	t.LastUpdated = time.Now()
+	metrics.IssuesExported.Inc()
 
 	return
 }

--- a/tracker/manager.go
+++ b/tracker/manager.go
@@ -3,7 +3,6 @@ package tracker
 import (
 	"context"
 	"github.com/jortel/go-utils/logr"
-	"github.com/konveyor/tackle2-hub/metrics"
 	"github.com/konveyor/tackle2-hub/model"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -186,7 +185,6 @@ func (m *Manager) create(tracker *model.Tracker, ticket *model.Ticket) (err erro
 	if err != nil {
 		return
 	}
-	metrics.IssuesExported.Inc()
 	result := m.DB.Save(ticket)
 	if result.Error != nil {
 		err = result.Error


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/MTA-809 by moving the counter increment into the specific connector's create implementation, after the ticket has been created successfully.