### PR TITLE
:sparkles: Better perf using the cursor.

### DIFF
--- a/api/analysis.go
+++ b/api/analysis.go
@@ -653,6 +653,9 @@ func (h AnalysisHandler) Incidents(ctx *gin.Context) {
 	db = db.Offset(page.Limit)
 	var m model.Incident
 	cursor := Cursor{}
+	defer func() {
+		cursor.Close()
+	}()
 	cursor.With(db, page)
 	for cursor.Next(&m) {
 		if cursor.Error != nil {
@@ -762,6 +765,9 @@ func (h AnalysisHandler) RuleReports(ctx *gin.Context) {
 	var m M
 	cursor := Cursor{}
 	cursor.With(db, page)
+	defer func() {
+		cursor.Close()
+	}()
 	for cursor.Next(&m) {
 		if cursor.Error != nil {
 			_ = ctx.Error(cursor.Error)

--- a/api/analysis.go
+++ b/api/analysis.go
@@ -569,7 +569,6 @@ func (h AnalysisHandler) Issues(ctx *gin.Context) {
 	db = db.Where("a.ID IN (?)", h.analysisIDs(ctx, filter))
 	db = db.Where("i.ID IN (?)", h.issueIDs(ctx, filter))
 	db = db.Group("i.ID")
-	db = filter.Where(db, "-Labels")
 	db = sort.Sorted(db)
 	var list []model.Issue
 	var m model.Issue
@@ -771,7 +770,6 @@ func (h AnalysisHandler) RuleReports(ctx *gin.Context) {
 	db := h.DB(ctx)
 	db = db.Select("*")
 	db = db.Table("(?)", q)
-	db = filter.Where(db, "-Labels")
 	db = sort.Sorted(db)
 	var list []M
 	var m M

--- a/api/analysis.go
+++ b/api/analysis.go
@@ -156,7 +156,7 @@ func (h AnalysisHandler) AppList(ctx *gin.Context) {
 		}
 		list = append(list, m)
 	}
-	err = h.WithCount(ctx, cursor.Count)
+	err = h.WithCount(ctx, cursor.Count())
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -418,7 +418,7 @@ func (h AnalysisHandler) AppDeps(ctx *gin.Context) {
 		}
 		list = append(list, m)
 	}
-	err = h.WithCount(ctx, cursor.Count)
+	err = h.WithCount(ctx, cursor.Count())
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -502,7 +502,7 @@ func (h AnalysisHandler) AppIssues(ctx *gin.Context) {
 		}
 		list = append(list, m)
 	}
-	err = h.WithCount(ctx, cursor.Count)
+	err = h.WithCount(ctx, cursor.Count())
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -586,7 +586,7 @@ func (h AnalysisHandler) Issues(ctx *gin.Context) {
 		}
 		list = append(list, m)
 	}
-	err = h.WithCount(ctx, cursor.Count)
+	err = h.WithCount(ctx, cursor.Count())
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -674,7 +674,7 @@ func (h AnalysisHandler) Incidents(ctx *gin.Context) {
 		}
 		list = append(list, m)
 	}
-	err = h.WithCount(ctx, cursor.Count)
+	err = h.WithCount(ctx, cursor.Count())
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -787,7 +787,7 @@ func (h AnalysisHandler) RuleReports(ctx *gin.Context) {
 		}
 		list = append(list, m)
 	}
-	err = h.WithCount(ctx, cursor.Count)
+	err = h.WithCount(ctx, cursor.Count())
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -950,7 +950,7 @@ func (h AnalysisHandler) AppReports(ctx *gin.Context) {
 		}
 		list = append(list, m)
 	}
-	err = h.WithCount(ctx, cursor.Count)
+	err = h.WithCount(ctx, cursor.Count())
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -1059,7 +1059,7 @@ func (h AnalysisHandler) FileReports(ctx *gin.Context) {
 		}
 		list = append(list, m)
 	}
-	err = h.WithCount(ctx, cursor.Count)
+	err = h.WithCount(ctx, cursor.Count())
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -1141,7 +1141,7 @@ func (h AnalysisHandler) Deps(ctx *gin.Context) {
 		}
 		list = append(list, m)
 	}
-	err = h.WithCount(ctx, cursor.Count)
+	err = h.WithCount(ctx, cursor.Count())
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -1243,7 +1243,7 @@ func (h AnalysisHandler) DepReports(ctx *gin.Context) {
 		}
 		list = append(list, m)
 	}
-	err = h.WithCount(ctx, cursor.Count)
+	err = h.WithCount(ctx, cursor.Count())
 	if err != nil {
 		_ = ctx.Error(err)
 		return

--- a/api/analysis.go
+++ b/api/analysis.go
@@ -156,7 +156,7 @@ func (h AnalysisHandler) AppList(ctx *gin.Context) {
 		}
 		list = append(list, m)
 	}
-	err = h.WithCount(ctx, cursor.Count)
+	err = h.WithCount(ctx, cursor.Count())
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -418,7 +418,7 @@ func (h AnalysisHandler) AppDeps(ctx *gin.Context) {
 		}
 		list = append(list, m)
 	}
-	err = h.WithCount(ctx, cursor.Count)
+	err = h.WithCount(ctx, cursor.Count())
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -502,7 +502,7 @@ func (h AnalysisHandler) AppIssues(ctx *gin.Context) {
 		}
 		list = append(list, m)
 	}
-	err = h.WithCount(ctx, cursor.Count)
+	err = h.WithCount(ctx, cursor.Count())
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -587,7 +587,7 @@ func (h AnalysisHandler) Issues(ctx *gin.Context) {
 		}
 		list = append(list, m)
 	}
-	err = h.WithCount(ctx, cursor.Count)
+	err = h.WithCount(ctx, cursor.Count())
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -675,7 +675,7 @@ func (h AnalysisHandler) Incidents(ctx *gin.Context) {
 		}
 		list = append(list, m)
 	}
-	err = h.WithCount(ctx, cursor.Count)
+	err = h.WithCount(ctx, cursor.Count())
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -771,7 +771,7 @@ func (h AnalysisHandler) RuleReports(ctx *gin.Context) {
 	db := h.DB(ctx)
 	db = db.Select("*")
 	db = db.Table("(?)", q)
-	db = filter.Where(db)
+	db = filter.Where(db, "-Labels")
 	db = sort.Sorted(db)
 	var list []M
 	var m M
@@ -789,7 +789,7 @@ func (h AnalysisHandler) RuleReports(ctx *gin.Context) {
 		}
 		list = append(list, m)
 	}
-	err = h.WithCount(ctx, cursor.Count)
+	err = h.WithCount(ctx, cursor.Count())
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -952,7 +952,7 @@ func (h AnalysisHandler) AppReports(ctx *gin.Context) {
 		}
 		list = append(list, m)
 	}
-	err = h.WithCount(ctx, cursor.Count)
+	err = h.WithCount(ctx, cursor.Count())
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -1061,7 +1061,7 @@ func (h AnalysisHandler) FileReports(ctx *gin.Context) {
 		}
 		list = append(list, m)
 	}
-	err = h.WithCount(ctx, cursor.Count)
+	err = h.WithCount(ctx, cursor.Count())
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -1143,7 +1143,7 @@ func (h AnalysisHandler) Deps(ctx *gin.Context) {
 		}
 		list = append(list, m)
 	}
-	err = h.WithCount(ctx, cursor.Count)
+	err = h.WithCount(ctx, cursor.Count())
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -1245,7 +1245,7 @@ func (h AnalysisHandler) DepReports(ctx *gin.Context) {
 		}
 		list = append(list, m)
 	}
-	err = h.WithCount(ctx, cursor.Count)
+	err = h.WithCount(ctx, cursor.Count())
 	if err != nil {
 		_ = ctx.Error(err)
 		return

--- a/api/analysis.go
+++ b/api/analysis.go
@@ -398,6 +398,7 @@ func (h AnalysisHandler) AppDeps(ctx *gin.Context) {
 	}
 	// Find
 	db = h.DB(ctx)
+	db = db.Model(&model.TechDependency{})
 	db = db.Where("AnalysisID = ?", analysis.ID)
 	db = db.Where("ID IN (?)", h.depIDs(ctx, filter))
 	db = sort.Sorted(db)

--- a/api/analysis.go
+++ b/api/analysis.go
@@ -650,7 +650,6 @@ func (h AnalysisHandler) Incidents(ctx *gin.Context) {
 	db = db.Model(&model.Incident{})
 	db = db.Where("IssueID", issueId)
 	db = filter.Where(db)
-	db = db.Offset(page.Limit)
 	var m model.Incident
 	cursor := Cursor{}
 	defer func() {

--- a/api/analysis.go
+++ b/api/analysis.go
@@ -651,14 +651,10 @@ func (h AnalysisHandler) Incidents(ctx *gin.Context) {
 	db = db.Where("IssueID", issueId)
 	db = filter.Where(db)
 	db = db.Offset(page.Limit)
-	rows, err := db.Rows()
-	if err != nil {
-		_ = ctx.Error(err)
-		return
-	}
 	var m model.Incident
-	cursor := Cursor{Rows: rows}
-	for cursor.Next(db, page, &m) {
+	cursor := Cursor{}
+	cursor.With(db, page)
+	for cursor.Next(&m) {
 		if cursor.Error != nil {
 			_ = ctx.Error(cursor.Error)
 			return

--- a/api/analysis.go
+++ b/api/analysis.go
@@ -628,7 +628,6 @@ func (h AnalysisHandler) Issue(ctx *gin.Context) {
 // @router /analyses/issues/{id}/incidents [get]
 func (h AnalysisHandler) Incidents(ctx *gin.Context) {
 	issueId := ctx.Param(ID)
-	// Build query.
 	filter, err := qf.New(ctx,
 		[]qf.Assert{
 			{Field: "file", Kind: qf.STRING},

--- a/api/analysis.go
+++ b/api/analysis.go
@@ -661,9 +661,7 @@ func (h AnalysisHandler) Incidents(ctx *gin.Context) {
 			_ = ctx.Error(cursor.Error)
 			return
 		}
-		if cursor.Scanned {
-			list = append(list, m)
-		}
+		list = append(list, m)
 	}
 	err = h.WithCount(ctx, cursor.Count)
 	if err != nil {
@@ -772,9 +770,7 @@ func (h AnalysisHandler) RuleReports(ctx *gin.Context) {
 			_ = ctx.Error(cursor.Error)
 			return
 		}
-		if cursor.Scanned {
-			list = append(list, m)
-		}
+		list = append(list, m)
 	}
 	err = h.WithCount(ctx, cursor.Count)
 	if err != nil {

--- a/api/analysis.go
+++ b/api/analysis.go
@@ -126,11 +126,20 @@ func (h AnalysisHandler) AppLatest(ctx *gin.Context) {
 // @router /analyses [get]
 func (h AnalysisHandler) AppList(ctx *gin.Context) {
 	resources := []Analysis{}
+	// Sort
+	sort := Sort{}
+	err := sort.With(ctx, &model.Issue{})
+	if err != nil {
+		_ = ctx.Error(err)
+		return
+	}
 	// Find.
 	id := h.pk(ctx)
 	db := h.DB(ctx)
+	db = db.Model(&model.Analysis{})
 	db = db.Where("ApplicationID = ?", id)
 	db = db.Preload(clause.Associations)
+	db = sort.Sorted(db)
 	var list []model.Analysis
 	var m model.Analysis
 	page := Page{}
@@ -147,7 +156,7 @@ func (h AnalysisHandler) AppList(ctx *gin.Context) {
 		}
 		list = append(list, m)
 	}
-	err := h.WithCount(ctx, cursor.Count)
+	err = h.WithCount(ctx, cursor.Count)
 	if err != nil {
 		_ = ctx.Error(err)
 		return

--- a/api/analysis.go
+++ b/api/analysis.go
@@ -156,7 +156,7 @@ func (h AnalysisHandler) AppList(ctx *gin.Context) {
 		}
 		list = append(list, m)
 	}
-	err = h.WithCount(ctx, cursor.Count())
+	err = h.WithCount(ctx, cursor.Count)
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -418,7 +418,7 @@ func (h AnalysisHandler) AppDeps(ctx *gin.Context) {
 		}
 		list = append(list, m)
 	}
-	err = h.WithCount(ctx, cursor.Count())
+	err = h.WithCount(ctx, cursor.Count)
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -502,7 +502,7 @@ func (h AnalysisHandler) AppIssues(ctx *gin.Context) {
 		}
 		list = append(list, m)
 	}
-	err = h.WithCount(ctx, cursor.Count())
+	err = h.WithCount(ctx, cursor.Count)
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -586,7 +586,7 @@ func (h AnalysisHandler) Issues(ctx *gin.Context) {
 		}
 		list = append(list, m)
 	}
-	err = h.WithCount(ctx, cursor.Count())
+	err = h.WithCount(ctx, cursor.Count)
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -674,7 +674,7 @@ func (h AnalysisHandler) Incidents(ctx *gin.Context) {
 		}
 		list = append(list, m)
 	}
-	err = h.WithCount(ctx, cursor.Count())
+	err = h.WithCount(ctx, cursor.Count)
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -787,7 +787,7 @@ func (h AnalysisHandler) RuleReports(ctx *gin.Context) {
 		}
 		list = append(list, m)
 	}
-	err = h.WithCount(ctx, cursor.Count())
+	err = h.WithCount(ctx, cursor.Count)
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -950,7 +950,7 @@ func (h AnalysisHandler) AppReports(ctx *gin.Context) {
 		}
 		list = append(list, m)
 	}
-	err = h.WithCount(ctx, cursor.Count())
+	err = h.WithCount(ctx, cursor.Count)
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -1059,7 +1059,7 @@ func (h AnalysisHandler) FileReports(ctx *gin.Context) {
 		}
 		list = append(list, m)
 	}
-	err = h.WithCount(ctx, cursor.Count())
+	err = h.WithCount(ctx, cursor.Count)
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -1141,7 +1141,7 @@ func (h AnalysisHandler) Deps(ctx *gin.Context) {
 		}
 		list = append(list, m)
 	}
-	err = h.WithCount(ctx, cursor.Count())
+	err = h.WithCount(ctx, cursor.Count)
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -1243,7 +1243,7 @@ func (h AnalysisHandler) DepReports(ctx *gin.Context) {
 		}
 		list = append(list, m)
 	}
-	err = h.WithCount(ctx, cursor.Count())
+	err = h.WithCount(ctx, cursor.Count)
 	if err != nil {
 		_ = ctx.Error(err)
 		return

--- a/api/base.go
+++ b/api/base.go
@@ -67,10 +67,12 @@ func (h *BaseHandler) WithCount(ctx *gin.Context, count int64) (err error) {
 			return
 		}
 	}
-	mp := ctx.Writer.Header()
-	mp[Total] = []string{
-		strconv.Itoa(int(count)),
+	s := strconv.Itoa(n)
+	if n > MaxCount {
+		s = ">" + strconv.Itoa(MaxCount)
 	}
+	mp := ctx.Writer.Header()
+	mp[Total] = []string{s}
 	return
 }
 

--- a/api/base.go
+++ b/api/base.go
@@ -379,6 +379,7 @@ type Cursor struct {
 // Next returns true when has next row.
 func (r *Cursor) Next(m interface{}) (next bool) {
 	if r.Error != nil {
+		next = true
 		return
 	}
 	next = r.Rows.Next()
@@ -387,7 +388,7 @@ func (r *Cursor) Next(m interface{}) (next bool) {
 	} else {
 		return
 	}
-	if r.Count > int64(r.Limit) || r.Count > MaxPage {
+	if r.pageExceeded() || r.Count > MaxPage {
 		for r.Rows.Next() {
 			r.Count++
 			if r.Count > MaxCount {
@@ -417,4 +418,14 @@ func (r *Cursor) Close() {
 	if r.Rows != nil {
 		_ = r.Rows.Close()
 	}
+}
+
+//
+// pageExceeded returns true when page Limit defined and exceeded.
+func (r *Cursor) pageExceeded() (b bool) {
+	if r.Limit < 1 {
+		return
+	}
+	b = r.Count > int64(r.Limit)
+	return
 }

--- a/api/base.go
+++ b/api/base.go
@@ -390,14 +390,17 @@ func (r *Cursor) Next(m interface{}) (next bool) {
 		return
 	}
 	next = r.Rows.Next()
-	if !next {
+	if next {
+		r.Count++
+	} else {
 		return
 	}
-	r.Count++
 	if r.Count > int64(r.Limit) || r.Count > MaxPage {
 		for r.Rows.Next() {
 			r.Count++
 			if r.Count > MaxCount {
+				next = false
+				r.Close()
 				break
 			}
 		}

--- a/api/base.go
+++ b/api/base.go
@@ -77,16 +77,6 @@ func (h *BaseHandler) WithCount(ctx *gin.Context, count int64) (err error) {
 }
 
 //
-// Paginated returns a paginated and sorted DB client.
-func (h *BaseHandler) paginated(ctx *gin.Context, sort Sort, in *gorm.DB) (db *gorm.DB) {
-	p := Page{}
-	p.With(ctx)
-	db = p.Paginated(in)
-	db = sort.Sorted(db)
-	return
-}
-
-//
 // preLoad update DB to pre-load fields.
 func (h *BaseHandler) preLoad(db *gorm.DB, fields ...string) (tx *gorm.DB) {
 	tx = db

--- a/api/base.go
+++ b/api/base.go
@@ -25,7 +25,7 @@ var Log = logr.WithName("api")
 
 const (
 	MaxPage  = 500
-	MaxCount = 10000
+	MaxCount = 50000
 )
 
 //
@@ -399,11 +399,11 @@ func (r *Cursor) Next(m interface{}) (next bool) {
 		for r.Rows.Next() {
 			r.Count++
 			if r.Count > MaxCount {
-				next = false
-				r.Close()
 				break
 			}
 		}
+		next = false
+		r.Close()
 		return
 	}
 	r.Error = r.DB.ScanRows(r.Rows, m)

--- a/api/base.go
+++ b/api/base.go
@@ -416,3 +416,11 @@ func (r *Cursor) With(db *gorm.DB, p Page) {
 	r.Scanned = false
 	r.Count = int64(0)
 }
+
+//
+// Close the cursor.
+func (r *Cursor) Close() {
+	if r.Rows != nil {
+		_ = r.Rows.Close()
+	}
+}

--- a/api/base.go
+++ b/api/base.go
@@ -410,8 +410,8 @@ func (r *Cursor) Next(m interface{}) (next bool) {
 //
 // With configures the cursor.
 func (r *Cursor) With(db *gorm.DB, p Page) {
-	r.Rows, r.Error = db.Rows()
-	r.DB = db
+	r.DB = db.Offset(p.Offset)
+	r.Rows, r.Error = r.DB.Rows()
 	r.Page = p
 	r.Scanned = false
 	r.Count = int64(0)

--- a/api/base.go
+++ b/api/base.go
@@ -371,7 +371,7 @@ type Cursor struct {
 	Page
 	DB    *gorm.DB
 	Rows  *sql.Rows
-	Index int64
+	Count int64
 	Error error
 }
 
@@ -384,14 +384,14 @@ func (r *Cursor) Next(m interface{}) (next bool) {
 	}
 	next = r.Rows.Next()
 	if next {
-		r.Index++
+		r.Count++
 	} else {
 		return
 	}
-	if r.pageLimited() || r.Index > MaxPage {
+	if r.pageLimited() || r.Count > MaxPage {
 		for r.Rows.Next() {
-			r.Index++
-			if r.Index > MaxCount {
+			r.Count++
+			if r.Count > MaxCount {
 				break
 			}
 		}
@@ -408,15 +408,8 @@ func (r *Cursor) Next(m interface{}) (next bool) {
 func (r *Cursor) With(db *gorm.DB, p Page) {
 	r.DB = db.Offset(p.Offset)
 	r.Rows, r.Error = r.DB.Rows()
-	r.Index = int64(0)
+	r.Count = int64(p.Offset)
 	r.Page = p
-}
-
-//
-// Count returns the count.
-func (r *Cursor) Count() (n int64) {
-	n = int64(r.Offset) + r.Index
-	return
 }
 
 //
@@ -433,6 +426,6 @@ func (r *Cursor) pageLimited() (b bool) {
 	if r.Limit < 1 {
 		return
 	}
-	b = r.Index > int64(r.Limit)
+	b = r.Count > int64(r.Limit)
 	return
 }

--- a/api/base.go
+++ b/api/base.go
@@ -374,7 +374,7 @@ type Decoder interface {
 }
 
 //
-// Cursor Paginated cursor.
+// Cursor Paginated rows iterator.
 type Cursor struct {
 	Page
 	DB    *gorm.DB

--- a/database/pkg.go
+++ b/database/pkg.go
@@ -34,6 +34,7 @@ func Open(enforceFKs bool) (db *gorm.DB, err error) {
 	db, err = gorm.Open(
 		sqlite.Open(connStr),
 		&gorm.Config{
+			PrepareStmt:     true,
 			CreateBatchSize: 500,
 			NamingStrategy: &schema.NamingStrategy{
 				SingularTable: true,


### PR DESCRIPTION
To support pagination, the hub sets the X-Total header to tell the caller (The UI really) the total number available to be displayed as the total number of pages.  To accomplish this, the hub executes the query 2 times.  First to get the count(*), again to fetch the data.  This doubles the latency and overhead in the hub for each request.  Unfortunately, the sq.Rows does not provide the count.

Better performance iterating the _cursor_ (sql.Rows) instead of running the query twice. This also eliminates the race condition between the count (query) and fetch query.

Adds a new _cursor_ object used to consistently:
- execute the query
- iterate the sql.Rows
- scan
- paginate
- count

The count is capped at 50,000 because for tables (like incident) the total can be tens-hundreds of millions.  Iterating the rows to determine the count becomes expensive (cpu/time) with those numbers. The X-Total header is only used to support/improve pagination.  After a certain point, extremely large numbers become meaningless  since users will never page though them. After a discussion with @mturley,  the hub will set X-Total with a leading `>` when capped.  Example: `X-Total: >50000`.  The UI will display accordingly.

50,000 may/may-not be the appropriate number.

PoC using the largest table `Incident` and one of the reports:  RuleReport.