### PR TITLE
:sparkles: Add links to rules and issues reports.

### DIFF
--- a/api/analysis.go
+++ b/api/analysis.go
@@ -768,6 +768,7 @@ func (h AnalysisHandler) RuleReports(ctx *gin.Context) {
 		"i.Category",
 		"i.Effort",
 		"i.Labels",
+		"i.Links",
 		"COUNT(distinct a.ID) Applications")
 	q = q.Table("Issue i,")
 	q = q.Joins("Analysis a")
@@ -815,6 +816,9 @@ func (h AnalysisHandler) RuleReports(ctx *gin.Context) {
 		resources = append(resources, r)
 		if m.Labels != nil {
 			_ = json.Unmarshal(m.Labels, &r.Labels)
+		}
+		if m.Links != nil {
+			_ = json.Unmarshal(m.Links, &r.Links)
 		}
 		r.Effort += m.Effort
 	}
@@ -888,6 +892,7 @@ func (h AnalysisHandler) AppIssueReports(ctx *gin.Context) {
 		"i.Category",
 		"i.Effort",
 		"i.Labels",
+		"i.Links",
 		"COUNT(distinct n.File) Files")
 	q = q.Table("Issue i,")
 	q = q.Joins("Incident n")
@@ -936,6 +941,9 @@ func (h AnalysisHandler) AppIssueReports(ctx *gin.Context) {
 		resources = append(resources, r)
 		if m.Labels != nil {
 			_ = json.Unmarshal(m.Labels, &r.Labels)
+		}
+		if m.Links != nil {
+			_ = json.Unmarshal(m.Links, &r.Links)
 		}
 		r.Effort += m.Effort
 	}
@@ -1884,6 +1892,7 @@ type RuleReport struct {
 	Category     string   `json:"category"`
 	Effort       int      `json:"effort"`
 	Labels       []string `json:"labels"`
+	Links        []Link   `json:"links"`
 	Applications int      `json:"applications"`
 }
 
@@ -1898,6 +1907,7 @@ type IssueReport struct {
 	Category    string   `json:"category"`
 	Effort      int      `json:"effort"`
 	Labels      []string `json:"labels"`
+	Links       []Link   `json:"links"`
 	Files       int      `json:"files"`
 }
 

--- a/hack/add/analysis.sh
+++ b/hack/add/analysis.sh
@@ -76,7 +76,18 @@ echo -n "---
 ruleset: ruleSet-${r}
 rule: rule-${i}
 name: Rule-${r}.${i}-Violated
-description: This is a test ${r}/${i} violation.
+description: |
+  This is a test ${r}/${i} violation.
+    This is a **description** of the issue in markdown*.
+    Here's how to fix the issue.
+    
+    For example:
+    
+        This is some bad code.
+    
+    Should become:
+    
+        This is some good code.
 category: warning
 effort: 10
 labels:
@@ -84,6 +95,11 @@ labels:
 - RULESET-${r}
 - ${sources[$((${i}%${#sources[@]}))]}
 - ${targets[$((${i}%${#targets[@]}))]}
+links:
+- title: Document A
+  url: http://ruleset/${r}/rule/${i}/documentA.html
+- title: Document B
+  url: http://ruleset/${r}/rule/${i}/documentB.html
 incidents:
 " >> ${file}
 for n in $(seq 1 ${nIncident})


### PR DESCRIPTION
Adds `Links` to both: /rules and /applications/:id/issues reports.
hack script adds markdown issue description and links.