### PR TITLE
:bug: Fix DepReport sort.

### DIFF
--- a/api/analysis.go
+++ b/api/analysis.go
@@ -1362,6 +1362,7 @@ func (h AnalysisHandler) DepReports(ctx *gin.Context) {
 	db = db.Select("*")
 	db = db.Table("(?)", q)
 	db = filter.Where(db)
+	db = sort.Sorted(db)
 	var list []M
 	var m M
 	page := Page{}


### PR DESCRIPTION
Missed this endpoint during one of the sort/pagination refactors.
Just needs to be _wired up_ properly.