### PR TITLE
:bug: Fix dep report filter depIDs(); add lables to dep apps report.

### DIFF
--- a/hack/add/analysis.sh
+++ b/hack/add/analysis.sh
@@ -158,6 +158,8 @@ file=${dPath}
 echo -n "---
 name: github.com/jboss
 version: 5.0
+labels:
+- konveyor.io/dep-source
 " > ${file}
 echo -n "---
 name: github.com/hybernate


### PR DESCRIPTION
When labels filter specified, the inner query was overwriting the outer (main) query.
Few other fixes.
Adds labels to resource returned by /report/dependencies/applications.
Adds sample label to one of the deps in hack.