### PR TITLE
[release-0.2] :bug: metrics: only count the first time a task starts

### DIFF
--- a/task/manager.go
+++ b/task/manager.go
@@ -152,7 +152,9 @@ func (m *Manager) startReady() {
 				Log.Error(sErr, "")
 				continue
 			}
-			metrics.TasksInitiated.Inc()
+			if ready.Retries == 0 {
+				metrics.TasksInitiated.Inc()
+			}
 			rt := Task{ready}
 			err := rt.Run(m.Client)
 			if err != nil {


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/MTA-894

Backport of #438 