### PR TITLE
:bug: Don't return issueTypes with the subtask flag set

### DIFF
--- a/tracker/jira.go
+++ b/tracker/jira.go
@@ -170,6 +170,9 @@ func (r *JiraConnector) IssueTypes(id string) (issueTypes []IssueType, err error
 		return
 	}
 	for _, i := range project.IssueTypes {
+		if i.Subtask {
+			continue
+		}
 		issueType := IssueType{
 			ID:   i.ID,
 			Name: i.Name,


### PR DESCRIPTION
New issues that belong to issue types with the `subtask` flag set (including the "Sub-task" built in issue type) are required to have a parent issue set. We don't support setting the parent issue, so exporting migration waves as issues of such types will fail. To fix this, avoid returning issue types with the `subtask` flag set from the `/trackers/:id/projects/:pid/issuetypes` endpoint.

Fixes https://issues.redhat.com/browse/MTA-870 by removing the option to export as a Sub-task.