### PR TITLE
:sparkles: Better support for addon failed. 

### DIFF
--- a/addon/adapter.go
+++ b/addon/adapter.go
@@ -101,11 +101,7 @@ func (h *Adapter) Run(addon func() error) {
 	case task.Failed,
 		task.Succeeded:
 	default:
-		if len(h.report.Errors) > 0 {
-			h.Failed("Addon reported errors.")
-		} else {
-			h.Succeeded()
-		}
+		h.Succeeded()
 	}
 }
 

--- a/addon/adapter.go
+++ b/addon/adapter.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jortel/go-utils/logr"
 	"github.com/konveyor/tackle2-hub/binding"
 	"github.com/konveyor/tackle2-hub/settings"
+	"github.com/konveyor/tackle2-hub/task"
 	"golang.org/x/sys/unix"
 	"os"
 )
@@ -95,8 +96,17 @@ func (h *Adapter) Run(addon func() error) {
 		return
 	}
 	//
-	// Report addon succeeded.
-	h.Succeeded()
+	// Report addon status.
+	switch h.report.Status {
+	case task.Failed,
+		task.Succeeded:
+	default:
+		if len(h.report.Errors) > 0 {
+			h.Failed("Addon reported errors.")
+		} else {
+			h.Succeeded()
+		}
+	}
 }
 
 //

--- a/addon/task.go
+++ b/addon/task.go
@@ -113,6 +113,7 @@ func (h *Task) Failed(reason string, x ...interface{}) {
 // Error report addon error.
 // The description can be a printf style format.
 func (h *Task) Error(severity, description string, x ...interface{}) {
+	h.report.Status = task.Failed
 	description = fmt.Sprintf(description, x...)
 	h.report.Errors = append(
 		h.report.Errors,


### PR DESCRIPTION
Better support for addon failed with reported errors (not returned _error_).