### PR TITLE
:bug: Better reporting of REST errors.

### DIFF
--- a/binding/client.go
+++ b/binding/client.go
@@ -140,7 +140,7 @@ func (r *Client) Get(path string, object interface{}, params ...Param) (err erro
 			return
 		}
 	default:
-		err = r.newError(reply)
+		err = r.restError(reply)
 	}
 
 	return
@@ -186,7 +186,7 @@ func (r *Client) Post(path string, object interface{}) (err error) {
 		}
 	case http.StatusNoContent:
 	default:
-		err = r.newError(reply)
+		err = r.restError(reply)
 	}
 	return
 }
@@ -238,7 +238,7 @@ func (r *Client) Put(path string, object interface{}, params ...Param) (err erro
 			return
 		}
 	default:
-		err = r.newError(reply)
+		err = r.restError(reply)
 	}
 
 	return
@@ -275,7 +275,7 @@ func (r *Client) Delete(path string, params ...Param) (err error) {
 	case http.StatusOK,
 		http.StatusNoContent:
 	default:
-		err = r.newError(reply)
+		err = r.restError(reply)
 	}
 
 	return
@@ -312,7 +312,7 @@ func (r *Client) BucketGet(source, destination string) (err error) {
 			err = r.getFile(reply.Body, source, destination)
 		}
 	default:
-		err = r.newError(reply)
+		err = r.restError(reply)
 	}
 	return
 }
@@ -373,7 +373,7 @@ func (r *Client) BucketPut(source, destination string) (err error) {
 		http.StatusCreated,
 		http.StatusAccepted:
 	default:
-		err = r.newError(reply)
+		err = r.restError(reply)
 	}
 	return
 }
@@ -404,7 +404,7 @@ func (r *Client) FileGet(path, destination string) (err error) {
 	case http.StatusOK:
 		err = r.getFile(reply.Body, "", destination)
 	default:
-		err = r.newError(reply)
+		err = r.restError(reply)
 	}
 	return
 }
@@ -516,7 +516,7 @@ func (r *Client) FileSend(path, method string, fields []Field, object interface{
 			return
 		}
 	default:
-		err = r.newError(reply)
+		err = r.restError(reply)
 	}
 	return
 }
@@ -766,22 +766,22 @@ func (r *Client) join(path string) (parsedURL *url.URL) {
 }
 
 //
-// newError returns an error based on status.
-func (r *Client) newError(response *http.Response) (err error) {
+// restError returns an error based on status.
+func (r *Client) restError(response *http.Response) (err error) {
 	status := response.StatusCode
 	if status < 400 {
 		return
 	}
 	switch status {
 	case http.StatusConflict:
-		restErr := &Conflict{}
-		err = restErr.With(response)
+		restError := &Conflict{}
+		err = restError.With(response)
 	case http.StatusNotFound:
-		restErr := &NotFound{}
-		err = restErr.With(response)
+		restError := &NotFound{}
+		err = restError.With(response)
 	default:
-		restErr := &RestError{}
-		err = restErr.With(response)
+		restError := &RestError{}
+		err = restError.With(response)
 	}
 	return
 }

--- a/binding/client.go
+++ b/binding/client.go
@@ -21,7 +21,7 @@ import (
 	pathlib "path"
 	"path/filepath"
 	"strings"
-	"time"	
+	"time"
 )
 
 const (
@@ -140,9 +140,9 @@ func (r *Client) Get(path string, object interface{}, params ...Param) (err erro
 			return
 		}
 	case http.StatusNotFound:
-		err = &NotFound{Path: path}
+		err = (&NotFound{}).With(reply)
 	default:
-		err = liberr.New(http.StatusText(status))
+		err = (&RestError{}).With(reply)
 	}
 
 	return
@@ -188,9 +188,9 @@ func (r *Client) Post(path string, object interface{}) (err error) {
 		}
 	case http.StatusNoContent:
 	case http.StatusConflict:
-		err = &Conflict{Path: path}
+		err = (&Conflict{}).With(reply)
 	default:
-		err = liberr.New(http.StatusText(status))
+		err = (&RestError{}).With(reply)
 	}
 	return
 }
@@ -242,9 +242,9 @@ func (r *Client) Put(path string, object interface{}, params ...Param) (err erro
 			return
 		}
 	case http.StatusNotFound:
-		err = &NotFound{Path: path}
+		err = (&NotFound{}).With(reply)
 	default:
-		err = liberr.New(http.StatusText(status))
+		err = (&RestError{}).With(reply)
 	}
 
 	return
@@ -281,9 +281,9 @@ func (r *Client) Delete(path string, params ...Param) (err error) {
 	case http.StatusOK,
 		http.StatusNoContent:
 	case http.StatusNotFound:
-		err = &NotFound{Path: path}
+		err = (&NotFound{}).With(reply)
 	default:
-		err = liberr.New(http.StatusText(status))
+		err = (&RestError{}).With(reply)
 	}
 
 	return
@@ -320,9 +320,9 @@ func (r *Client) BucketGet(source, destination string) (err error) {
 			err = r.getFile(reply.Body, source, destination)
 		}
 	case http.StatusNotFound:
-		err = &NotFound{Path: source}
+		err = (&NotFound{}).With(reply)
 	default:
-		err = liberr.New(http.StatusText(status))
+		err = (&RestError{}).With(reply)
 	}
 	return
 }
@@ -383,9 +383,9 @@ func (r *Client) BucketPut(source, destination string) (err error) {
 		http.StatusCreated,
 		http.StatusAccepted:
 	case http.StatusNotFound:
-		err = &NotFound{Path: destination}
+		err = (&NotFound{}).With(reply)
 	default:
-		err = liberr.New(http.StatusText(status))
+		err = (&RestError{}).With(reply)
 	}
 	return
 }
@@ -416,9 +416,9 @@ func (r *Client) FileGet(path, destination string) (err error) {
 	case http.StatusOK:
 		err = r.getFile(reply.Body, "", destination)
 	case http.StatusNotFound:
-		err = &NotFound{Path: path}
+		err = (&NotFound{}).With(reply)
 	default:
-		err = liberr.New(http.StatusText(status))
+		err = (&RestError{}).With(reply)
 	}
 	return
 }
@@ -530,9 +530,9 @@ func (r *Client) FileSend(path, method string, fields []Field, object interface{
 			return
 		}
 	case http.StatusConflict:
-		err = &Conflict{Path: path}
+		err = (&Conflict{}).With(reply)
 	default:
-		err = liberr.New(http.StatusText(status))
+		err = (&RestError{}).With(reply)
 	}
 	return
 }

--- a/binding/client.go
+++ b/binding/client.go
@@ -118,18 +118,18 @@ func (r *Client) Get(path string, object interface{}, params ...Param) (err erro
 		}
 		return
 	}
-	reply, err := r.send(request)
+	response, err := r.send(request)
 	if err != nil {
 		return
 	}
 	defer func() {
-		_ = reply.Body.Close()
+		_ = response.Body.Close()
 	}()
-	status := reply.StatusCode
+	status := response.StatusCode
 	switch status {
 	case http.StatusOK:
 		var body []byte
-		body, err = io.ReadAll(reply.Body)
+		body, err = io.ReadAll(response.Body)
 		if err != nil {
 			err = liberr.Wrap(err)
 			return
@@ -140,7 +140,7 @@ func (r *Client) Get(path string, object interface{}, params ...Param) (err erro
 			return
 		}
 	default:
-		err = r.restError(reply)
+		err = r.restError(response)
 	}
 
 	return
@@ -165,16 +165,16 @@ func (r *Client) Post(path string, object interface{}) (err error) {
 		request.Header.Set(api.Accept, binding.MIMEJSON)
 		return
 	}
-	reply, err := r.send(request)
+	response, err := r.send(request)
 	if err != nil {
 		return
 	}
-	status := reply.StatusCode
+	status := response.StatusCode
 	switch status {
 	case http.StatusOK,
 		http.StatusCreated:
 		var body []byte
-		body, err = io.ReadAll(reply.Body)
+		body, err = io.ReadAll(response.Body)
 		if err != nil {
 			err = liberr.Wrap(err)
 			return
@@ -186,7 +186,7 @@ func (r *Client) Post(path string, object interface{}) (err error) {
 		}
 	case http.StatusNoContent:
 	default:
-		err = r.restError(reply)
+		err = r.restError(response)
 	}
 	return
 }
@@ -217,17 +217,17 @@ func (r *Client) Put(path string, object interface{}, params ...Param) (err erro
 		}
 		return
 	}
-	reply, err := r.send(request)
+	response, err := r.send(request)
 	if err != nil {
 		return
 	}
-	status := reply.StatusCode
+	status := response.StatusCode
 	switch status {
 	case http.StatusNoContent:
 	case http.StatusOK,
 		http.StatusCreated:
 		var body []byte
-		body, err = io.ReadAll(reply.Body)
+		body, err = io.ReadAll(response.Body)
 		if err != nil {
 			err = liberr.Wrap(err)
 			return
@@ -238,7 +238,7 @@ func (r *Client) Put(path string, object interface{}, params ...Param) (err erro
 			return
 		}
 	default:
-		err = r.restError(reply)
+		err = r.restError(response)
 	}
 
 	return
@@ -263,19 +263,19 @@ func (r *Client) Delete(path string, params ...Param) (err error) {
 		}
 		return
 	}
-	reply, err := r.send(request)
+	response, err := r.send(request)
 	if err != nil {
 		return
 	}
 	defer func() {
-		_ = reply.Body.Close()
+		_ = response.Body.Close()
 	}()
-	status := reply.StatusCode
+	status := response.StatusCode
 	switch status {
 	case http.StatusOK,
 		http.StatusNoContent:
 	default:
-		err = r.restError(reply)
+		err = r.restError(response)
 	}
 
 	return
@@ -294,25 +294,25 @@ func (r *Client) BucketGet(source, destination string) (err error) {
 		request.Header.Set(api.Accept, api.MIMEOCTETSTREAM)
 		return
 	}
-	reply, err := r.send(request)
+	response, err := r.send(request)
 	if err != nil {
 		return
 	}
 	defer func() {
-		_ = reply.Body.Close()
+		_ = response.Body.Close()
 	}()
-	status := reply.StatusCode
+	status := response.StatusCode
 	switch status {
 	case http.StatusNoContent:
 		// Empty.
 	case http.StatusOK:
-		if reply.Header.Get(api.Directory) == api.DirectoryExpand {
-			err = r.getDir(reply.Body, destination)
+		if response.Header.Get(api.Directory) == api.DirectoryExpand {
+			err = r.getDir(response.Body, destination)
 		} else {
-			err = r.getFile(reply.Body, source, destination)
+			err = r.getFile(response.Body, source, destination)
 		}
 	default:
-		err = r.restError(reply)
+		err = r.restError(response)
 	}
 	return
 }
@@ -362,18 +362,18 @@ func (r *Client) BucketPut(source, destination string) (err error) {
 		}()
 		return
 	}
-	reply, err := r.send(request)
+	response, err := r.send(request)
 	if err != nil {
 		return
 	}
-	status := reply.StatusCode
+	status := response.StatusCode
 	switch status {
 	case http.StatusOK,
 		http.StatusNoContent,
 		http.StatusCreated,
 		http.StatusAccepted:
 	default:
-		err = r.restError(reply)
+		err = r.restError(response)
 	}
 	return
 }
@@ -390,21 +390,21 @@ func (r *Client) FileGet(path, destination string) (err error) {
 		request.Header.Set(api.Accept, api.MIMEOCTETSTREAM)
 		return
 	}
-	reply, err := r.send(request)
+	response, err := r.send(request)
 	if err != nil {
 		return
 	}
 	defer func() {
-		_ = reply.Body.Close()
+		_ = response.Body.Close()
 	}()
-	status := reply.StatusCode
+	status := response.StatusCode
 	switch status {
 	case http.StatusNoContent:
 		// Empty.
 	case http.StatusOK:
-		err = r.getFile(reply.Body, "", destination)
+		err = r.getFile(response.Body, "", destination)
 	default:
-		err = r.restError(reply)
+		err = r.restError(response)
 	}
 	return
 }
@@ -496,16 +496,16 @@ func (r *Client) FileSend(path, method string, fields []Field, object interface{
 		}()
 		return
 	}
-	reply, err := r.send(request)
+	response, err := r.send(request)
 	if err != nil {
 		return
 	}
-	status := reply.StatusCode
+	status := response.StatusCode
 	switch status {
 	case http.StatusOK,
 		http.StatusCreated:
 		var body []byte
-		body, err = io.ReadAll(reply.Body)
+		body, err = io.ReadAll(response.Body)
 		if err != nil {
 			err = liberr.Wrap(err)
 			return
@@ -516,7 +516,7 @@ func (r *Client) FileSend(path, method string, fields []Field, object interface{
 			return
 		}
 	default:
-		err = r.restError(reply)
+		err = r.restError(response)
 	}
 	return
 }

--- a/binding/error.go
+++ b/binding/error.go
@@ -1,7 +1,10 @@
 package binding
 
 import (
-	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
 )
 
 //
@@ -24,14 +27,55 @@ func (e *SoftError) Soft() *SoftError {
 }
 
 //
-// Conflict reports 409 error.
-type Conflict struct {
+// RestError reports REST errors.
+type RestError struct {
 	SoftError
-	Path string
+	Method string
+	Path   string
+	Status int
+	Body   string
 }
 
-func (e Conflict) Error() string {
-	return fmt.Sprintf("POST: path:%s (conflict)", e.Path)
+func (e *RestError) Is(err error) (matched bool) {
+	_, matched = err.(*RestError)
+	return
+}
+
+func (e *RestError) Error() (s string) {
+	s = e.Reason
+	return
+}
+
+func (e *RestError) With(r *http.Response) *RestError {
+	e.Method = r.Request.Method
+	e.Path = r.Request.URL.Path
+	e.Status = r.StatusCode
+	if r.Body != nil {
+		body, err := io.ReadAll(r.Body)
+		if err == nil {
+			e.Body = string(body)
+		}
+	}
+	s := strings.ToUpper(e.Method)
+	s += " "
+	s += e.Path
+	s += " failed: "
+	s += strconv.Itoa(e.Status)
+	s += "("
+	s += http.StatusText(e.Status)
+	s += ")"
+	if e.Body != "" {
+		s += " body: "
+		s += e.Body
+	}
+	e.Reason = s
+	return e
+}
+
+//
+// Conflict reports 409 error.
+type Conflict struct {
+	RestError
 }
 
 func (e *Conflict) Is(err error) (matched bool) {
@@ -42,12 +86,7 @@ func (e *Conflict) Is(err error) (matched bool) {
 //
 // NotFound reports 404 error.
 type NotFound struct {
-	SoftError
-	Path string
-}
-
-func (e NotFound) Error() string {
-	return fmt.Sprintf("HTTP path:%s (not-found)", e.Path)
+	RestError
 }
 
 func (e *NotFound) Is(err error) (matched bool) {


### PR DESCRIPTION
Add RestError for generic REST errors.

Produces errors with descriptions like:
```
GET /hub/applications/34 failed: 404(Not Found) body: {"error":"record not found"}
```