### PR TITLE
:bug: Hide Epic issue type for On Prem trackers

### DIFF
--- a/tracker/jira.go
+++ b/tracker/jira.go
@@ -15,6 +15,8 @@ import (
 	"time"
 )
 
+const IssueTypeEpic = "Epic"
+
 //
 // JiraConnector for the Jira Cloud API
 type JiraConnector struct {
@@ -171,6 +173,9 @@ func (r *JiraConnector) IssueTypes(id string) (issueTypes []IssueType, err error
 	}
 	for _, i := range project.IssueTypes {
 		if i.Subtask {
+			continue
+		}
+		if r.tracker.Kind == JiraOnPrem && i.Name == IssueTypeEpic {
 			continue
 		}
 		issueType := IssueType{


### PR DESCRIPTION
The Epic issue type has an additional required field for Server/Datacenter instances. We don't currently have a solution in place for dealing with additional required fields, so hide that issue type on on-prem instances for now.

Fixes https://issues.redhat.com/browse/MTA-873