### PR TITLE
:ghost: Remove Ruleset seed test

### DIFF
--- a/test/api/ruleset/api_test.go
+++ b/test/api/ruleset/api_test.go
@@ -73,13 +73,3 @@ func TestRuleSetCRUD(t *testing.T) {
 		})
 	}
 }
-
-func TestRuleSetListSeed(t *testing.T) {
-	got, err := RuleSet.List()
-	if err != nil {
-		t.Errorf(err.Error())
-	}
-	if len(got) < 1 {
-		t.Errorf("Seed looks empty, but it shouldn't.")
-	}
-}


### PR DESCRIPTION
API tests failed on Ruleset empty seed check. Removing Ruleset seed check for now (until we have tackle2-seed related test requirements).

```
=== RUN   TestRuleSetListSeed
time=2023-07-25T09:37:02+02:00 level=info msg=[binding] |200|  GET /rulesets
    api_test.go:83: Seed looks empty, but it shouldn't.
--- FAIL: TestRuleSetListSeed (0.00s)
```

Related to https://github.com/konveyor/tackle2-hub/pull/450 and https://github.com/konveyor/tackle2-seed