### PR TITLE
:sparkles: Add raw methods for error and activity reporting by addons.

### DIFF
--- a/addon/adapter.go
+++ b/addon/adapter.go
@@ -114,6 +114,7 @@ func (h *Adapter) Run(addon func() error) {
 	}()
 	//
 	// Report addon started.
+	h.Load()
 	h.Started()
 	//
 	// Run addon.

--- a/addon/task.go
+++ b/addon/task.go
@@ -89,8 +89,8 @@ func (h *Task) Succeeded() {
 //
 // Failed report addon failed.
 // The reason can be a printf style format.
-func (h *Task) Failed(reason string, x ...interface{}) {
-	reason = fmt.Sprintf(reason, x...)
+func (h *Task) Failed(reason string, v ...interface{}) {
+	reason = fmt.Sprintf(reason, v...)
 	h.report.Status = task.Failed
 	h.report.Errors = append(
 		h.report.Errors,
@@ -109,8 +109,8 @@ func (h *Task) Failed(reason string, x ...interface{}) {
 //
 // Error report addon error.
 // The description can be a printf style format.
-func (h *Task) Error(severity, description string, x ...interface{}) {
-	description = fmt.Sprintf(description, x...)
+func (h *Task) Error(severity, description string, v ...interface{}) {
+	description = fmt.Sprintf(description, v...)
 	h.RawError(
 		api.TaskError{
 			Severity:    severity,

--- a/hack/cmd/addon/main.go
+++ b/hack/cmd/addon/main.go
@@ -38,8 +38,6 @@ type SoftError = hub.SoftError
 // main
 func main() {
 	addon.Run(func() (err error) {
-		_, _ = addon.Identity.List()
-		_, _ = addon.Identity.Get(1)
 		//
 		// Get the addon data associated with the task.
 		d := &Data{}


### PR DESCRIPTION
Add _raw_ methods used by addons to report both errors and activity. The reason is to reduce the number of API calls when reporting large numbers.
For example, the _addon.command_ package reports stdout/stderr for failed commands which can be hundreds (or thousands of lines).  Calling Activity() hundreds of times result in hundreds of API calls.
Another example is the reported analyzer errors.

Another aspect is to formalize multi-line activity.  This PR codifies the convention of:
```
- This is a list of:
- > One
- > Two
- > Three
```
and, simplifies the API.

The tackle2-addon _command_ package will need to be updated once this merges to use RawActivity() for stdout/stderr. reporting.
The tackle2-addon-analyzer will need to updated to use both methods in select places as well.