### PR TITLE
:sparkles: RawError, RawActivity simplified.

### DIFF
--- a/hack/cmd/addon/main.go
+++ b/hack/cmd/addon/main.go
@@ -101,7 +101,7 @@ func main() {
 		return
 	})
 
-	addon.Error("Warning", "Test warning.")
+	addon.Errorf("Warning", "Test warning.")
 }
 
 //


### PR DESCRIPTION
This PR simplifies the API for use cases for which the _new_ RawError() and RawActivity() were meant to support.  

Especially the RawActivity().  The main case here is to report multi-line activity. In this case the activity is reporting something followed by multiple lines.  The first line is the-activity followed by multiple-lines of detail.  This PR simplifies this more than the RawActivity() because it can be achieved in (1) addon.Activity() call.

For example:
```
addon.Activity("Doing something with a list of things:\n%s", "One\nTwo\nThree")
```
Results  in:
```
- Doing something with a list of things:
- > One
- > Two
- > Three
```

The Error and RawError is achieved by reversing which is the edge case.  Errorf() is added (instead of RawError) which makes for a more intuitive API.
