### PR TITLE
:ghost: SoftError deprecated.

### DIFF
--- a/addon/adapter.go
+++ b/addon/adapter.go
@@ -42,7 +42,6 @@ type Field = binding.Field
 
 //
 // Error
-type SoftError = binding.SoftError
 type ResetError = binding.RestError
 type Conflict = binding.Conflict
 type NotFound = binding.NotFound
@@ -105,11 +104,8 @@ func (h *Adapter) Run(addon func() error) {
 			}
 		}
 		if err != nil {
-			if _, soft := err.(interface{ Soft() *SoftError }); !soft {
-				Log.Error(err, "Addon failed.")
-				os.Exit(1)
-			}
 			h.Failed(err.Error())
+			os.Exit(1)
 		}
 	}()
 	//

--- a/addon/error.go
+++ b/addon/error.go
@@ -1,0 +1,21 @@
+package addon
+
+//
+// SoftError A "soft" anticipated error.
+// Deprecated:
+type SoftError struct {
+	Reason string
+}
+
+func (e *SoftError) Error() (s string) {
+	return e.Reason
+}
+
+func (e *SoftError) Is(err error) (matched bool) {
+	_, matched = err.(*SoftError)
+	return
+}
+
+func (e *SoftError) Soft() *SoftError {
+	return e
+}

--- a/binding/application.go
+++ b/binding/application.go
@@ -2,6 +2,7 @@ package binding
 
 import (
 	"bytes"
+	"errors"
 	mime "github.com/gin-gonic/gin/binding"
 	liberr "github.com/jortel/go-utils/error"
 	"github.com/konveyor/tackle2-hub/api"
@@ -171,7 +172,7 @@ func (h *AppTags) List() (list []api.TagRef, err error) {
 }
 
 //
-// Add ensures tag is associated with the application.
+// Add associates a tag with the application.
 func (h *AppTags) Add(id uint) (err error) {
 	path := Path(api.ApplicationTagsRoot).Inject(Params{api.ID: h.appId})
 	tag := api.TagRef{ID: id}
@@ -179,6 +180,16 @@ func (h *AppTags) Add(id uint) (err error) {
 		tag.Source = *h.source
 	}
 	err = h.client.Post(path, &tag)
+	return
+}
+
+//
+// Ensure ensures tag is associated with the application.
+func (h *AppTags) Ensure(id uint) (err error) {
+	err = h.Add(id)
+	if errors.Is(err, &Conflict{}) {
+		err = nil
+	}
 	return
 }
 

--- a/binding/client.go
+++ b/binding/client.go
@@ -775,13 +775,16 @@ func (r *Client) restError(response *http.Response) (err error) {
 	switch status {
 	case http.StatusConflict:
 		restError := &Conflict{}
-		err = restError.With(response)
+		restError.With(response)
+		err = restError
 	case http.StatusNotFound:
 		restError := &NotFound{}
-		err = restError.With(response)
+		restError.With(response)
+		err = restError
 	default:
 		restError := &RestError{}
-		err = restError.With(response)
+		restError.With(response)
+		err = restError
 	}
 	return
 }

--- a/binding/error.go
+++ b/binding/error.go
@@ -8,28 +8,9 @@ import (
 )
 
 //
-// SoftError A "soft" anticipated error.
-type SoftError struct {
-	Reason string
-}
-
-func (e *SoftError) Error() (s string) {
-	return e.Reason
-}
-
-func (e *SoftError) Is(err error) (matched bool) {
-	_, matched = err.(*SoftError)
-	return
-}
-
-func (e *SoftError) Soft() *SoftError {
-	return e
-}
-
-//
 // RestError reports REST errors.
 type RestError struct {
-	SoftError
+	Reason string
 	Method string
 	Path   string
 	Status int

--- a/binding/error.go
+++ b/binding/error.go
@@ -27,7 +27,7 @@ func (e *RestError) Error() (s string) {
 	return
 }
 
-func (e *RestError) With(r *http.Response) *RestError {
+func (e *RestError) With(r *http.Response) {
 	e.Method = r.Request.Method
 	e.Path = r.Request.URL.Path
 	e.Status = r.StatusCode
@@ -50,7 +50,6 @@ func (e *RestError) With(r *http.Response) *RestError {
 		s += e.Body
 	}
 	e.Reason = s
-	return e
 }
 
 //

--- a/hack/cmd/addon/main.go
+++ b/hack/cmd/addon/main.go
@@ -98,8 +98,6 @@ func main() {
 		}
 		return
 	})
-
-	addon.Errorf("Warning", "Test warning.")
 }
 
 //
@@ -331,7 +329,7 @@ func addTags(application *api.Application, source string, names ...string) (err 
 	tags := addon.Application.Tags(application.ID)
 	tags.Source(source)
 	for _, id := range wanted {
-		err = tags.Add(id)
+		err = tags.Ensure(id)
 		if err != nil {
 			return
 		}

--- a/hack/cmd/addon/main.go
+++ b/hack/cmd/addon/main.go
@@ -32,8 +32,6 @@ const (
 	TmpDir    = "/tmp/list"
 )
 
-type SoftError = hub.SoftError
-
 //
 // main
 func main() {


### PR DESCRIPTION
The SoftError was originally intended to support addons returning an error that would not be stack traced and not trigger a task (pod) retry.  However, in practice:
- almost all errors should not be retried.
- SoftError has not been consistently adopted.

As a result, SoftError has been all but removed and **deprecated**.  Leaving it in the addon binding for backwards compat.

Further, the adapter Run() will no longer trace caught errors because there cannot be any expectation that addon writers will _wrap_ errors and logging errors in Run() is useless.  The addon returning an error will always result in exit(1) - 
 _application failed_.  The task manager will retry for: code=137 (SIGKILL) Only.

Fixed binding Client.restError() for issue found while testing.