### PR TITLE
:ghost: Relation renamed.

### DIFF
--- a/api/analysis.go
+++ b/api/analysis.go
@@ -405,7 +405,7 @@ func (h AnalysisHandler) AppDeps(ctx *gin.Context) {
 			{Field: "version", Kind: qf.STRING},
 			{Field: "sha", Kind: qf.STRING},
 			{Field: "indirect", Kind: qf.STRING},
-			{Field: "labels", Kind: qf.STRING, Relation: true},
+			{Field: "labels", Kind: qf.STRING, And: true},
 		})
 	if err != nil {
 		_ = ctx.Error(err)
@@ -488,7 +488,7 @@ func (h AnalysisHandler) AppIssues(ctx *gin.Context) {
 			{Field: "name", Kind: qf.STRING},
 			{Field: "category", Kind: qf.STRING},
 			{Field: "effort", Kind: qf.LITERAL},
-			{Field: "labels", Kind: qf.STRING, Relation: true},
+			{Field: "labels", Kind: qf.STRING, And: true},
 		})
 	if err != nil {
 		_ = ctx.Error(err)
@@ -566,10 +566,10 @@ func (h AnalysisHandler) Issues(ctx *gin.Context) {
 			{Field: "name", Kind: qf.STRING},
 			{Field: "category", Kind: qf.STRING},
 			{Field: "effort", Kind: qf.LITERAL},
-			{Field: "labels", Kind: qf.STRING, Relation: true},
+			{Field: "labels", Kind: qf.STRING, And: true},
 			{Field: "application.id", Kind: qf.LITERAL},
 			{Field: "application.name", Kind: qf.STRING},
-			{Field: "tag.id", Kind: qf.LITERAL, Relation: true},
+			{Field: "tag.id", Kind: qf.LITERAL, And: true},
 		})
 	if err != nil {
 		_ = ctx.Error(err)
@@ -751,13 +751,13 @@ func (h AnalysisHandler) RuleReports(ctx *gin.Context) {
 			{Field: "rule", Kind: qf.STRING},
 			{Field: "category", Kind: qf.STRING},
 			{Field: "effort", Kind: qf.LITERAL},
-			{Field: "labels", Kind: qf.STRING, Relation: true},
+			{Field: "labels", Kind: qf.STRING, And: true},
 			{Field: "applications", Kind: qf.LITERAL},
 			{Field: "application.id", Kind: qf.STRING},
 			{Field: "application.name", Kind: qf.STRING},
 			{Field: "businessService.id", Kind: qf.LITERAL},
 			{Field: "businessService.name", Kind: qf.STRING},
-			{Field: "tag.id", Kind: qf.LITERAL, Relation: true},
+			{Field: "tag.id", Kind: qf.LITERAL, And: true},
 		})
 	if err != nil {
 		_ = ctx.Error(err)
@@ -880,7 +880,7 @@ func (h AnalysisHandler) AppIssueReports(ctx *gin.Context) {
 			{Field: "rule", Kind: qf.STRING},
 			{Field: "category", Kind: qf.STRING},
 			{Field: "effort", Kind: qf.LITERAL},
-			{Field: "labels", Kind: qf.STRING, Relation: true},
+			{Field: "labels", Kind: qf.STRING, And: true},
 		})
 	if err != nil {
 		_ = ctx.Error(err)
@@ -1029,12 +1029,12 @@ func (h AnalysisHandler) IssueAppReports(ctx *gin.Context) {
 			{Field: "issue.rule", Kind: qf.STRING},
 			{Field: "issue.category", Kind: qf.STRING},
 			{Field: "issue.effort", Kind: qf.LITERAL},
-			{Field: "issue.labels", Kind: qf.STRING, Relation: true},
+			{Field: "issue.labels", Kind: qf.STRING, And: true},
 			{Field: "application.id", Kind: qf.LITERAL},
 			{Field: "application.name", Kind: qf.STRING},
 			{Field: "businessService.id", Kind: qf.LITERAL},
 			{Field: "businessService.name", Kind: qf.STRING},
-			{Field: "tag.id", Kind: qf.LITERAL, Relation: true},
+			{Field: "tag.id", Kind: qf.LITERAL, And: true},
 		})
 	if err != nil {
 		_ = ctx.Error(err)
@@ -1246,10 +1246,10 @@ func (h AnalysisHandler) Deps(ctx *gin.Context) {
 			{Field: "version", Kind: qf.STRING},
 			{Field: "sha", Kind: qf.STRING},
 			{Field: "indirect", Kind: qf.STRING},
-			{Field: "labels", Kind: qf.STRING, Relation: true},
+			{Field: "labels", Kind: qf.STRING, And: true},
 			{Field: "application.id", Kind: qf.LITERAL},
 			{Field: "application.name", Kind: qf.STRING},
-			{Field: "tag.id", Kind: qf.LITERAL, Relation: true},
+			{Field: "tag.id", Kind: qf.LITERAL, And: true},
 		})
 	if err != nil {
 		_ = ctx.Error(err)
@@ -1337,13 +1337,13 @@ func (h AnalysisHandler) DepReports(ctx *gin.Context) {
 			{Field: "version", Kind: qf.STRING},
 			{Field: "sha", Kind: qf.STRING},
 			{Field: "indirect", Kind: qf.STRING},
-			{Field: "labels", Kind: qf.STRING, Relation: true},
+			{Field: "labels", Kind: qf.STRING, And: true},
 			{Field: "applications", Kind: qf.LITERAL},
 			{Field: "application.id", Kind: qf.LITERAL},
 			{Field: "application.name", Kind: qf.STRING},
 			{Field: "businessService.id", Kind: qf.LITERAL},
 			{Field: "businessService.name", Kind: qf.STRING},
-			{Field: "tag.id", Kind: qf.LITERAL, Relation: true},
+			{Field: "tag.id", Kind: qf.LITERAL, And: true},
 		})
 	if err != nil {
 		_ = ctx.Error(err)
@@ -1482,12 +1482,12 @@ func (h AnalysisHandler) DepAppReports(ctx *gin.Context) {
 			{Field: "dep.version", Kind: qf.LITERAL},
 			{Field: "dep.sha", Kind: qf.LITERAL},
 			{Field: "dep.indirect", Kind: qf.LITERAL},
-			{Field: "dep.labels", Kind: qf.STRING, Relation: true},
+			{Field: "dep.labels", Kind: qf.STRING, And: true},
 			{Field: "application.id", Kind: qf.LITERAL},
 			{Field: "application.name", Kind: qf.STRING},
 			{Field: "businessService.id", Kind: qf.LITERAL},
 			{Field: "businessService.name", Kind: qf.STRING},
-			{Field: "tag.id", Kind: qf.LITERAL, Relation: true},
+			{Field: "tag.id", Kind: qf.LITERAL, And: true},
 		})
 	if err != nil {
 		_ = ctx.Error(err)

--- a/api/filter/filter.go
+++ b/api/filter/filter.go
@@ -355,9 +355,9 @@ func (f *Field) operator() (s string) {
 //
 // Assert -
 type Assert struct {
-	Field    string
-	Kind     byte
-	Relation bool
+	Field string
+	Kind  byte
+	And   bool
 }
 
 //
@@ -372,7 +372,7 @@ func (r *Assert) assert(p *Predicate) (err error) {
 			return
 		}
 	}
-	if !r.Relation {
+	if !r.And {
 		if (&Field{*p}).Value.Operator(AND) {
 			err = Errorf("(,,) cannot be used with '%s'.", name)
 			return

--- a/api/ruleset.go
+++ b/api/ruleset.go
@@ -64,6 +64,7 @@ func (h RuleSetHandler) Get(ctx *gin.Context) {
 // @summary List all bindings.
 // @description List all bindings.
 // @description filters:
+// @description - name
 // @description - labels
 // @tags rulesets
 // @produce json
@@ -79,7 +80,7 @@ func (h RuleSetHandler) List(ctx *gin.Context) {
 	filter, err := qf.New(ctx,
 		[]qf.Assert{
 			{Field: "name", Kind: qf.STRING},
-			{Field: "labels", Kind: qf.STRING},
+			{Field: "labels", Kind: qf.STRING, And: true},
 		})
 	if err != nil {
 		_ = ctx.Error(err)


### PR DESCRIPTION
The `Relation` validation was originally added to support:
```
tag=(A,B,C)
```
Where tag = A **and** B **and** C which is implemented as an SQL INTERSECT.
However, it seems the `Labels` use cases are implemented as JSON query.  This PR attempts to provide a more intuitive name.

Replaces:
```
{Field: "Labels", Kind: qf.STRING, Relation: true}, 
```
With
```
{Field: "Labels", Kind: qf.STRING, And: true}, 
```