### PR TITLE
:ghost: Fix Ruleset API test after refactoring

### DIFF
--- a/test/api/ruleset/samples.go
+++ b/test/api/ruleset/samples.go
@@ -8,18 +8,12 @@ import (
 var (
 	Minimal = api.RuleSet{
 		Name: "Minimal no rules",
-		Image: api.Ref{
-			ID: 1,
-		},
 		Rules: []api.Rule{},
 	}
 
 	Hazelcast = api.RuleSet{
 		Name:        "Hazelcast",
 		Description: "Hazelcast Java distributed session store ruleset.",
-		Image: api.Ref{
-			ID: 1,
-		},
 		Rules: []api.Rule{
 			{
 				File: &api.Ref{


### PR DESCRIPTION
Image is not part of Ruleset anymore, removing from sample Rulesets.

Related to https://github.com/konveyor/tackle2-hub/pull/464