### PR TITLE
:bug: Fix dangling ruleset ref to image File.

### DIFF
--- a/api/ruleset.go
+++ b/api/ruleset.go
@@ -121,7 +121,7 @@ func (h RuleSetHandler) Create(ctx *gin.Context) {
 		_ = ctx.Error(err)
 		return
 	}
-	
+
 	h.Respond(ctx, http.StatusCreated, ruleset)
 }
 

--- a/migration/v8/migrate.go
+++ b/migration/v8/migrate.go
@@ -67,6 +67,21 @@ func (r Migration) Apply(db *gorm.DB) (err error) {
 			return
 		}
 	}
+	err = db.Migrator().DropConstraint(&model.RuleSet{}, "fk_RuleSet_Image")
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	err = db.Migrator().DropColumn(&model.RuleSet{}, "ImageID")
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	err = db.Migrator().DropColumn(&model.RuleSet{}, "Custom")
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
 
 	return
 }


### PR DESCRIPTION
Removes unwanted RuleSet columns that should have been removed in model version:8:
- Custom
- ImageID

The imageID causes problems for the File reaper.  The reaper no longer recognizes RuleSet as a file _owner_ and tries to delete the associated image `File`.  This fails due to the FK constraint.