### PR TITLE
:bug: Fix task failed when not killed.

### DIFF
--- a/task/manager.go
+++ b/task/manager.go
@@ -369,8 +369,10 @@ func (r *Task) Reflect(client k8s.Client) (err error) {
 				r.State = Failed
 				r.Terminated = &mark
 			}
+		default:
+			r.State = Failed
+			r.Terminated = &mark
 		}
-
 	}
 
 	return


### PR DESCRIPTION
Task retry strategy improved in much earlier PR but missed this scenario.  The improvement was to adjust the retry logic to be more narrowly focus on only scenarios worth retrying.

Fixed.