### PR TITLE
:warning: Disable seed versioning

### DIFF
--- a/seed/pkg.go
+++ b/seed/pkg.go
@@ -40,12 +40,7 @@ func Seed() (err error) {
 		}
 	}()
 
-	v, err := migrationVersion(db)
-	if err != nil {
-		return
-	}
-
-	seeds, checksum, err := libseed.ReadFromDir(settings.Settings.Hub.DB.SeedPath, v)
+	seeds, checksum, err := libseed.ReadFromDir(settings.Settings.Hub.DB.SeedPath, libseed.AllVersions)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			log.Info("Seed directory not found.")


### PR DESCRIPTION
The seed versioning capability is not necessary and complicates keeping the seed and hub repos in sync. If this is needed in the future, the design should be reevaluated.