### PR TITLE
:seedling: Add Questionnaire to binding and API test

### DIFF
--- a/binding/questionnaire.go
+++ b/binding/questionnaire.go
@@ -1,0 +1,50 @@
+package binding
+
+import (
+	"github.com/konveyor/tackle2-hub/api"
+)
+
+//
+// Questionnaire API.
+type Questionnaire struct {
+	client *Client
+}
+
+//
+// Create a Questionnaire.
+func (h *Questionnaire) Create(r *api.Questionnaire) (err error) {
+	err = h.client.Post(api.QuestionnairesRoot, &r)
+	return
+}
+
+//
+// Get a Questionnaire by ID.
+func (h *Questionnaire) Get(id uint) (r *api.Questionnaire, err error) {
+	r = &api.Questionnaire{}
+	path := Path(api.QuestionnaireRoot).Inject(Params{api.ID: id})
+	err = h.client.Get(path, r)
+	return
+}
+
+//
+// List Questionnaires.
+func (h *Questionnaire) List() (list []api.Questionnaire, err error) {
+	list = []api.Questionnaire{}
+	err = h.client.Get(api.QuestionnairesRoot, &list)
+	return
+}
+
+//
+// Update a Questionnaire.
+func (h *Questionnaire) Update(r *api.Questionnaire) (err error) {
+	path := Path(api.QuestionnaireRoot).Inject(Params{api.ID: r.ID})
+	err = h.client.Put(path, r)
+	return
+}
+
+//
+// Delete a Questionnaire.
+func (h *Questionnaire) Delete(id uint) (err error) {
+	err = h.client.Delete(Path(api.QuestionnaireRoot).Inject(Params{api.ID: id}))
+	return
+}

--- a/binding/richclient.go
+++ b/binding/richclient.go
@@ -24,11 +24,13 @@ type RichClient struct {
 	Application      Application
 	Bucket           Bucket
 	BusinessService  BusinessService
+	Dependency       Dependency
 	File             File
 	Identity         Identity
 	JobFunction      JobFunction
 	MigrationWave    MigrationWave
 	Proxy            Proxy
+	Questionnaire    Questionnaire
 	Review           Review
 	RuleSet          RuleSet
 	Setting          Setting
@@ -39,7 +41,6 @@ type RichClient struct {
 	Target           Target
 	Task             Task
 	Tracker          Tracker
-	Dependency       Dependency
 
 	// A REST client.
 	Client *Client
@@ -79,6 +80,9 @@ func New(baseUrl string) (r *RichClient) {
 			client: client,
 		},
 		Proxy: Proxy{
+			client: client,
+		},
+		Questionnaire: Questionnaire{
 			client: client,
 		},
 		Review: Review{

--- a/docs/test-api-matrix.md
+++ b/docs/test-api-matrix.md
@@ -27,6 +27,10 @@ batch||||
 migrationwave|:heavy_check_mark:|:heavy_check_mark:||
 ticket||||
 tracker|:heavy_check_mark:|:heavy_check_mark:||
+**Assessments**||||
+archetype||||
+assessment||||
+questionnaire|:heavy_check_mark:|:heavy_check_mark:||
 **Other**||||
 addon || | |
 auth||||

--- a/test/api/questionnaire/api_test.go
+++ b/test/api/questionnaire/api_test.go
@@ -1,0 +1,109 @@
+package questionnaire
+
+import (
+	"testing"
+
+	"github.com/konveyor/tackle2-hub/test/assert"
+)
+
+func TestQuestionnaireCRUD(t *testing.T) {
+	for _, r := range Samples {
+		t.Run(r.Name, func(t *testing.T) {
+			// Create.
+			err := Questionnaire.Create(&r)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+
+			// Get.
+			got, err := Questionnaire.Get(r.ID)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+			if assert.FlatEqual(got, r) {
+				t.Errorf("Different response error. Got %v, expected %v", got, r)
+			}
+
+			// Update.
+			r.Name = "Updated " + r.Name
+			r.Required = false
+			err = Questionnaire.Update(&r)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+
+			got, err = Questionnaire.Get(r.ID)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+			if got.Name != r.Name {
+				t.Errorf("Different response error. Got %s, expected %s", got.Name, r.Name)
+			}
+			if got.Required != false {
+				t.Errorf("Required should be false after update. Got %+v, expected %+v", got, r)
+			}
+
+			// Delete.
+			err = Questionnaire.Delete(r.ID)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+
+			_, err = Questionnaire.Get(r.ID)
+			if err == nil {
+				t.Errorf("Resource exits, but should be deleted: %v", r)
+			}
+		})
+	}
+}
+
+func TestQuestionnaireList(t *testing.T) {
+	samples := Samples
+
+	for name := range samples {
+		sample := samples[name]
+		assert.Must(t, Questionnaire.Create(&sample))
+		samples[name] = sample
+	}
+
+	got, err := Questionnaire.List()
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if assert.FlatEqual(got, &samples) {
+		t.Errorf("Different response error. Got %v, expected %v", got, samples)
+	}
+
+	for _, r := range samples {
+		assert.Must(t, Questionnaire.Delete(r.ID))
+	}
+}
+
+//func TestQuestionnaireNotCreateDuplicates(t *testing.T) {
+//	r := GitPw
+//
+//	// Create sample.
+//	assert.Should(t, Questionnaire.Create(&r))
+//
+//	// Try duplicate with the same and different Kind
+//	for _, kind := range []string{r.Kind, "mvn"} {
+//		t.Run(kind, func(t *testing.T) {
+//			// Prepare Questionnaire with duplicate Name.
+//			dup := &api.Questionnaire{
+//				Name: r.Name,
+//			}
+//
+//			// Try create the duplicate.
+//			err := Questionnaire.Create(dup)
+//			if err == nil {
+//				t.Errorf("Created duplicate Questionnaire: %v", dup)
+//
+//				// Clean the duplicate.
+//				assert.Must(t, Questionnaire.Delete(dup.ID))
+//			}
+//		})
+//	}
+//
+//	// Clean.
+//	assert.Must(t, Questionnaire.Delete(r.ID))
+//}

--- a/test/api/questionnaire/api_test.go
+++ b/test/api/questionnaire/api_test.go
@@ -78,32 +78,3 @@ func TestQuestionnaireList(t *testing.T) {
 		assert.Must(t, Questionnaire.Delete(r.ID))
 	}
 }
-
-//func TestQuestionnaireNotCreateDuplicates(t *testing.T) {
-//	r := GitPw
-//
-//	// Create sample.
-//	assert.Should(t, Questionnaire.Create(&r))
-//
-//	// Try duplicate with the same and different Kind
-//	for _, kind := range []string{r.Kind, "mvn"} {
-//		t.Run(kind, func(t *testing.T) {
-//			// Prepare Questionnaire with duplicate Name.
-//			dup := &api.Questionnaire{
-//				Name: r.Name,
-//			}
-//
-//			// Try create the duplicate.
-//			err := Questionnaire.Create(dup)
-//			if err == nil {
-//				t.Errorf("Created duplicate Questionnaire: %v", dup)
-//
-//				// Clean the duplicate.
-//				assert.Must(t, Questionnaire.Delete(dup.ID))
-//			}
-//		})
-//	}
-//
-//	// Clean.
-//	assert.Must(t, Questionnaire.Delete(r.ID))
-//}

--- a/test/api/questionnaire/pkg.go
+++ b/test/api/questionnaire/pkg.go
@@ -1,0 +1,20 @@
+package questionnaire
+
+import (
+	"github.com/konveyor/tackle2-hub/binding"
+	"github.com/konveyor/tackle2-hub/test/api/client"
+)
+
+var (
+	RichClient *binding.RichClient
+	Questionnaire binding.Questionnaire
+)
+
+
+func init() {
+	// Prepare RichClient and login to Hub API (configured from env variables).
+	RichClient = client.PrepareRichClient()
+
+	// Shortcut for Questionnaire-related RichClient methods.
+	Questionnaire = RichClient.Questionnaire
+}

--- a/test/api/questionnaire/samples.go
+++ b/test/api/questionnaire/samples.go
@@ -1,0 +1,49 @@
+package questionnaire
+
+import (
+	"github.com/konveyor/tackle2-hub/api"
+	"github.com/konveyor/tackle2-hub/assessment"
+)
+
+// Set of valid resources for tests and reuse.
+var (
+	Questionnaire1 = api.Questionnaire{
+		Name:         "Questionnaire1",
+		Description:  "Questionnaire minimal sample 1",
+		Required:     true,
+		Thresholds:   assessment.Thresholds{},
+		RiskMessages: assessment.RiskMessages{},
+		Sections: []assessment.Section{
+			{
+				Order: 1,
+				Name:  "Section 1",
+				Questions: []assessment.Question{
+					{
+						Order:       1,
+						Text:        "What is your favorite color?",
+						Explanation: "Please tell us your favorite color.",
+						Answers: []assessment.Answer{
+							{
+								Order: 1,
+								Text:  "Red",
+								Risk:  "red",
+							},
+							{
+								Order: 2,
+								Text:  "Green",
+								Risk:  "green",
+							},
+							{
+								Order:    3,
+								Text:     "Blue",
+								Risk:     "yellow",
+								Selected: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	Samples = []api.Questionnaire{Questionnaire1}
+)


### PR DESCRIPTION
Adding Questionnaire endpoint to binding and basic API test.

Started looking on Pathfinder export/Assessment import (via CLI), adding basic API test as a side-effect.

Related to https://github.com/konveyor/tackle2-hub/pull/492