### PR TITLE
:sparkles: Allow creating assessments "as-is"

### DIFF
--- a/api/application.go
+++ b/api/application.go
@@ -1069,18 +1069,20 @@ func (h ApplicationHandler) AssessmentCreate(ctx *gin.Context) {
 		return
 	}
 	m := r.Model()
-	m.Sections = q.Sections
 	m.Thresholds = q.Thresholds
 	m.RiskMessages = q.RiskMessages
 	m.CreateUser = h.CurrentUser(ctx)
-
-	resolver, err := assessment.NewTagResolver(h.DB(ctx))
-	if err != nil {
-		_ = ctx.Error(err)
-		return
+	// if sections aren't nil that indicates that this assessment is being
+	// created "as-is" and should not have its sections populated or autofilled.
+	if m.Sections == nil {
+		m.Sections = q.Sections
+		resolver, rErr := assessment.NewTagResolver(h.DB(ctx))
+		if rErr != nil {
+			_ = ctx.Error(rErr)
+			return
+		}
+		assessment.PrepareForApplication(resolver, application, m)
 	}
-	assessment.PrepareForApplication(resolver, application, m)
-
 	result = h.DB(ctx).Create(m)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)


### PR DESCRIPTION
If the "sections" field of the assessment resource is populated when POSTing an assessment, then the
sections will not be overridden by values from the questionnaire and the assessment will not be autofilled.