### PR TITLE
Surface assessment tags on Archetype resource

### DIFF
--- a/assessment/archetype.go
+++ b/assessment/archetype.go
@@ -1,0 +1,38 @@
+package assessment
+
+import "github.com/konveyor/tackle2-hub/model"
+
+//
+// NewArchetypeResolver creates a new ArchetypeResolver.
+func NewArchetypeResolver(archetype *model.Archetype, tags *TagResolver) (a *ArchetypeResolver) {
+	a = &ArchetypeResolver{
+		archetype:   archetype,
+		tagResolver: tags,
+	}
+	return
+}
+
+//
+// ArchetypeResolver wraps an Archetype model
+// with assessment-related functionality.
+type ArchetypeResolver struct {
+	archetype   *model.Archetype
+	tagResolver *TagResolver
+}
+
+//
+// AssessmentTags returns the list of tags that the archetype should
+// inherit from the answers given to its assessments.
+func (r *ArchetypeResolver) AssessmentTags() (tags []model.Tag) {
+	seenTags := make(map[uint]bool)
+	for _, assessment := range r.archetype.Assessments {
+		aTags := r.tagResolver.Assessment(&assessment)
+		for _, t := range aTags {
+			if _, found := seenTags[t.ID]; !found {
+				seenTags[t.ID] = true
+				tags = append(tags, t)
+			}
+		}
+	}
+	return
+}

--- a/assessment/membership.go
+++ b/assessment/membership.go
@@ -54,7 +54,7 @@ func (r *MembershipResolver) Archetypes(m *model.Application) (archetypes []mode
 
 	matches := []model.Archetype{}
 	for _, a := range r.archetypes {
-		if appTags.Superset(r.tagSets[a.ID]) {
+		if appTags.Superset(r.tagSets[a.ID], false) {
 			matches = append(matches, a)
 		}
 	}
@@ -69,7 +69,7 @@ loop:
 			}
 			a1tags := r.tagSets[a1.ID]
 			a2tags := r.tagSets[a2.ID]
-			if a1tags.Subset(a2tags) {
+			if a1tags.Subset(a2tags, true) {
 				continue loop
 			}
 		}

--- a/assessment/questionnaire.go
+++ b/assessment/questionnaire.go
@@ -60,7 +60,7 @@ loop:
 			answered.Add(a.QuestionnaireID)
 		}
 	}
-	assessed = answered.Superset(r.requiredQuestionnaires)
+	assessed = answered.Superset(r.requiredQuestionnaires, false)
 
 	return
 }

--- a/assessment/set.go
+++ b/assessment/set.go
@@ -23,8 +23,10 @@ func (r Set) Size() int {
 
 //
 // Add a member to the set.
-func (r Set) Add(member uint) {
-	r.members[member] = true
+func (r Set) Add(members ...uint) {
+	for _, member := range members {
+		r.members[member] = true
+	}
 }
 
 //
@@ -35,7 +37,10 @@ func (r Set) Contains(element uint) bool {
 
 //
 // Superset tests whether every element of other is in the set.
-func (r Set) Superset(other Set) bool {
+func (r Set) Superset(other Set, strict bool) bool {
+	if strict && r.Size() <= other.Size() {
+		return false
+	}
 	for m := range other.members {
 		if !r.Contains(m) {
 			return false
@@ -46,8 +51,8 @@ func (r Set) Superset(other Set) bool {
 
 //
 // Subset tests whether every element of this set is in the other.
-func (r Set) Subset(other Set) bool {
-	return other.Superset(r)
+func (r Set) Subset(other Set, strict bool) bool {
+	return other.Superset(r, strict)
 }
 
 //

--- a/assessment/set_test.go
+++ b/assessment/set_test.go
@@ -1,0 +1,46 @@
+package assessment
+
+import (
+	"github.com/onsi/gomega"
+	"testing"
+)
+
+func TestSet_Superset(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	a := NewSet()
+	b := NewSet()
+	a.Add(1, 2, 3, 4)
+	b.Add(1, 2, 3, 4)
+
+	g.Expect(a.Superset(b, false)).To(gomega.BeTrue())
+	g.Expect(b.Superset(a, false)).To(gomega.BeTrue())
+	g.Expect(a.Superset(b, true)).To(gomega.BeFalse())
+	g.Expect(b.Superset(a, true)).To(gomega.BeFalse())
+
+	a.Add(5)
+	g.Expect(a.Superset(b, false)).To(gomega.BeTrue())
+	g.Expect(a.Superset(b, true)).To(gomega.BeTrue())
+	g.Expect(b.Superset(a, false)).To(gomega.BeFalse())
+	g.Expect(b.Superset(a, true)).To(gomega.BeFalse())
+}
+
+func TestSet_Subset(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	a := NewSet()
+	b := NewSet()
+	a.Add(1, 2, 3, 4)
+	b.Add(1, 2, 3, 4)
+
+	g.Expect(a.Subset(b, false)).To(gomega.BeTrue())
+	g.Expect(b.Subset(a, false)).To(gomega.BeTrue())
+	g.Expect(a.Subset(b, true)).To(gomega.BeFalse())
+	g.Expect(b.Subset(a, true)).To(gomega.BeFalse())
+
+	b.Add(5)
+	g.Expect(a.Subset(b, false)).To(gomega.BeTrue())
+	g.Expect(a.Subset(b, true)).To(gomega.BeTrue())
+	g.Expect(b.Subset(a, false)).To(gomega.BeFalse())
+	g.Expect(b.Subset(a, true)).To(gomega.BeFalse())
+}


### PR DESCRIPTION
* added `assessmentTags` field to Archetype resource to display the tags that would be inherited by member applications.
* Fixed a bug where an application would be denied membership in an archetype that wasn't a strict subset of another archetype.