### PR TITLE
:bug: Only marshal assessment sections if not empty

### DIFF
--- a/api/application.go
+++ b/api/application.go
@@ -1072,9 +1072,9 @@ func (h ApplicationHandler) AssessmentCreate(ctx *gin.Context) {
 	m.Thresholds = q.Thresholds
 	m.RiskMessages = q.RiskMessages
 	m.CreateUser = h.CurrentUser(ctx)
-	// if sections aren't nil that indicates that this assessment is being
+	// if sections aren't empty that indicates that this assessment is being
 	// created "as-is" and should not have its sections populated or autofilled.
-	if m.Sections == nil {
+	if len(m.Sections) == 0 {
 		m.Sections = q.Sections
 		resolver, rErr := assessment.NewTagResolver(h.DB(ctx))
 		if rErr != nil {

--- a/api/archetype.go
+++ b/api/archetype.go
@@ -315,9 +315,9 @@ func (h ArchetypeHandler) AssessmentCreate(ctx *gin.Context) {
 	m.Thresholds = q.Thresholds
 	m.RiskMessages = q.RiskMessages
 	m.CreateUser = h.CurrentUser(ctx)
-	// if sections aren't nil that indicates that this assessment is being
+	// if sections aren't empty that indicates that this assessment is being
 	// created "as-is" and should not have its sections populated or autofilled.
-	if m.Sections == nil {
+	if len(m.Sections) == 0 {
 		m.Sections = q.Sections
 		resolver, rErr := assessment.NewTagResolver(h.DB(ctx))
 		if rErr != nil {

--- a/api/assessment.go
+++ b/api/assessment.go
@@ -220,7 +220,9 @@ func (r *Assessment) With(m *model.Assessment) {
 func (r *Assessment) Model() (m *model.Assessment) {
 	m = &model.Assessment{}
 	m.ID = r.ID
-	m.Sections, _ = json.Marshal(r.Sections)
+	if r.Sections != nil {
+		m.Sections, _ = json.Marshal(r.Sections)
+	}
 	m.QuestionnaireID = r.Questionnaire.ID
 	if r.Archetype != nil {
 		m.ArchetypeID = &r.Archetype.ID


### PR DESCRIPTION
Marshalling the Assessment resource's `Sections` field unconditionally results in populating the model's `Sections` with the byte string `null`, which breaks the test for empty sections, making it always look like the assessment is being imported with sections "as-is". To fix this, only marshal the sections in the Assessment's `Model()` method if they are not empty. Additionally, replace the `if m.Sections == nil` test with a test for length, which works on nil as well as empty slices.