### PR TITLE
:bug: PrepareForArchetype should use criteria and tags

### DIFF
--- a/assessment/pkg.go
+++ b/assessment/pkg.go
@@ -103,6 +103,9 @@ func PrepareForArchetype(tagResolver *TagResolver, archetype *model.Archetype, a
 	for _, t := range archetype.CriteriaTags {
 		tagSet.Add(t.ID)
 	}
+	for _, t := range archetype.Tags {
+		tagSet.Add(t.ID)
+	}
 
 	assessment.Sections, _ = json.Marshal(prepareSections(tagResolver, tagSet, sections))
 


### PR DESCRIPTION
Previously PrepareForArchetype was using only the membership criteria to autofill assessments, but the enhancement specifies that it should use the archetype tags as well as the criteria tags.

Fixes https://issues.redhat.com/browse/MTA-1396