### PR TITLE
:bug: Protect builtin questionnaires from update/delete

### DIFF
--- a/api/questionnaire.go
+++ b/api/questionnaire.go
@@ -195,6 +195,7 @@ type Questionnaire struct {
 	Sections     []assessment.Section    `json:"sections" yaml:"sections" binding:"required"`
 	Thresholds   assessment.Thresholds   `json:"thresholds" yaml:"thresholds" binding:"required"`
 	RiskMessages assessment.RiskMessages `json:"riskMessages" yaml:"riskMessages" binding:"required"`
+	Builtin      bool                    `json:"builtin,omitempty" yaml:"builtin,omitempty"`
 }
 
 // With updates the resource with the model.
@@ -203,6 +204,7 @@ func (r *Questionnaire) With(m *model.Questionnaire) {
 	r.Name = m.Name
 	r.Description = m.Description
 	r.Required = m.Required
+	r.Builtin = m.Builtin()
 	_ = json.Unmarshal(m.Sections, &r.Sections)
 	_ = json.Unmarshal(m.Thresholds, &r.Thresholds)
 	_ = json.Unmarshal(m.RiskMessages, &r.RiskMessages)

--- a/migration/v10/model/assessment.go
+++ b/migration/v10/model/assessment.go
@@ -12,6 +12,12 @@ type Questionnaire struct {
 	Assessments  []Assessment `gorm:"constraint:OnDelete:CASCADE"`
 }
 
+//
+// Builtin returns true if this is a Konveyor-provided questionnaire.
+func (r *Questionnaire) Builtin() bool {
+	return r.UUID != nil
+}
+
 type Assessment struct {
 	Model
 	ApplicationID     *uint `gorm:"uniqueIndex:AssessmentA"`


### PR DESCRIPTION
Only changing the `required` field is permitted for builtin questionnaires, all other changes and deletion are disallowed.