### PR TITLE
:sparkles: Add `comment` string field to Section

### DIFF
--- a/assessment/section.go
+++ b/assessment/section.go
@@ -6,6 +6,7 @@ type Section struct {
 	Order     uint       `json:"order" yaml:"order" binding:"required"`
 	Name      string     `json:"name" yaml:"name"`
 	Questions []Question `json:"questions" yaml:"questions"`
+	Comment   string     `json:"comment,omitempty" yaml:"comment,omitempty"`
 }
 
 //


### PR DESCRIPTION
This was missing from the Assessment/Questionnaire sections and is necessary to completely implement the enhancement.