### PR TITLE
:sparkles: Better pod OOM reporting.

### DIFF
--- a/settings/hub.go
+++ b/settings/hub.go
@@ -106,8 +106,6 @@ func (r *Hub) Load() (err error) {
 	if found {
 		b, _ := strconv.ParseBool(s)
 		r.Cache.RWX = b
-	} else {
-		r.Cache.RWX = true
 	}
 	r.Cache.PVC, found = os.LookupEnv(EnvCachePvc)
 	if !found {

--- a/task/manager.go
+++ b/task/manager.go
@@ -356,7 +356,7 @@ func (r *Task) Reflect(client k8s.Client) (err error) {
 		r.State = Succeeded
 		r.Terminated = &mark
 	case core.PodFailed:
-		r.Error("Error", "Pod failed: %s", pod.Status.Message)
+		r.Error("Error", "Pod failed: %s", pod.Status.ContainerStatuses[0].State.Terminated.Reason)
 		switch pod.Status.ContainerStatuses[0].State.Terminated.ExitCode {
 		case 137: // Killed.
 			if r.Retries < Settings.Hub.Task.Retries {

--- a/task/manager.go
+++ b/task/manager.go
@@ -356,7 +356,10 @@ func (r *Task) Reflect(client k8s.Client) (err error) {
 		r.State = Succeeded
 		r.Terminated = &mark
 	case core.PodFailed:
-		r.Error("Error", "Pod failed: %s", pod.Status.ContainerStatuses[0].State.Terminated.Reason)
+		r.Error(
+			"Error",
+			"Pod failed: %s",
+			pod.Status.ContainerStatuses[0].State.Terminated.Reason)
 		switch pod.Status.ContainerStatuses[0].State.Terminated.ExitCode {
 		case 137: // Killed.
 			if r.Retries < Settings.Hub.Task.Retries {


### PR DESCRIPTION
Using the container status `Reason` for more accurate reporting.
```
state: Failed
image: quay.io/jortel/tackle2-addon-analyzer:debug
pod: konveyor-tackle/task-13-gcmjs
retries: 1
started: 2023-10-16T10:36:30.221282042-07:00
terminated: 2023-10-16T10:36:40.301254088-07:00
bucket:
    id: 17
    name: ""
errors:
    - severity: Error
      description: 'Pod failed: OOMKilled'
```

Also, the RWX should be disabled by default.