### PR TITLE
:bug: Bucket getdir

### DIFF
--- a/api/bucket.go
+++ b/api/bucket.go
@@ -325,11 +325,10 @@ func (h *BucketOwner) getDir(ctx *gin.Context, input string, filter tar.Filter) 
 	if err != nil {
 		_ = ctx.Error(err)
 		return
-	} else {
-		h.Attachment(ctx, pathlib.Base(input)+".tar.gz")
-		ctx.Writer.Header().Set(Directory, DirectoryExpand)
-		ctx.Status(http.StatusOK)
 	}
+	h.Attachment(ctx, pathlib.Base(input)+".tar.gz")
+	ctx.Writer.Header().Set(Directory, DirectoryExpand)
+	ctx.Status(http.StatusOK)
 	_ = tarWriter.AddDir(input)
 	return
 }

--- a/api/bucket.go
+++ b/api/bucket.go
@@ -327,6 +327,7 @@ func (h *BucketOwner) getDir(ctx *gin.Context, input string, filter tar.Filter) 
 		return
 	} else {
 		h.Attachment(ctx, pathlib.Base(input)+".tar.gz")
+		ctx.Writer.Header().Set(Directory, DirectoryExpand)
 		ctx.Status(http.StatusOK)
 	}
 	_ = tarWriter.AddDir(input)

--- a/test/api/bucket/sample/sample2.txt
+++ b/test/api/bucket/sample/sample2.txt
@@ -1,0 +1,1 @@
+The second file.

--- a/test/api/task/bucket_test.go
+++ b/test/api/task/bucket_test.go
@@ -1,4 +1,4 @@
-package application
+package task
 
 import (
 	"io/ioutil"
@@ -8,13 +8,10 @@ import (
 	"github.com/konveyor/tackle2-hub/test/assert"
 )
 
-func TestApplicationBucket(t *testing.T) {
-	// Test Facts subresource on the first sample application only.
-	application := Minimal
-
+func TestTaskBucket(t *testing.T) {
+	task := Windup
 	// Create the application.
-	assert.Must(t, Application.Create(&application))
-
+	assert.Must(t, Task.Create(&task))
 	// Get the bucket to check if it was created.
 	destDir, err := ioutil.TempDir("", "destDir")
 	if err != nil {
@@ -23,12 +20,11 @@ func TestApplicationBucket(t *testing.T) {
 	defer func() {
 		_ = os.RemoveAll(destDir)
 	}()
-	bucket := RichClient.Application.Bucket(application.ID)
+	bucket := RichClient.Task.Bucket(task.ID)
 	err = bucket.Get("", destDir)
 	if err != nil {
 		t.Errorf(err.Error())
 	}
-
 	// Clean the application.
-	assert.Must(t, Application.Delete(application.ID))
+	assert.Must(t, Task.Delete(task.ID))
 }


### PR DESCRIPTION
The refactor to using the new `tar` package accidentally removed setting the X-Directory:Expand.
As a result, the client is not expanding downloaded directory (tarball).

---

Fixed API tests.  The bucket directory test really needs 2+ files to be accurate. It missed this issue.
Added the task bucket (subresource) test for symmetry.