### PR TITLE
:seedling: Delete identity associated with tracker

### DIFF
--- a/test/api/tracker/api_test.go
+++ b/test/api/tracker/api_test.go
@@ -160,7 +160,7 @@ func TestTrackerList(t *testing.T) {
 	// Delete related trackers and identities.
 	for _, tracker := range createdTrackers {
 		assert.Must(t, Tracker.Delete(tracker.ID))
-		assert.Must(t, Identity.Delete(tracker.ID))
+		assert.Must(t, Identity.Delete(tracker.Identity.ID))
 	}
 }
 


### PR DESCRIPTION
Fixing resources cleanup at the end of the test, by sending the identity's ID to `Identity.Delete`  instead of the tracker's ID