### PR TITLE
:ghost: add hack to generate jwt token.

### DIFF
--- a/auth/builtin.go
+++ b/auth/builtin.go
@@ -110,7 +110,7 @@ func (r *Builtin) Authenticate(request *Request) (jwToken *jwt.Token, err error)
 	if !found {
 		err = liberr.Wrap(
 			&NotValid{
-				Reason: "user not specified.",
+				Reason: "User not specified.",
 				Token:  token,
 			})
 		return
@@ -119,7 +119,7 @@ func (r *Builtin) Authenticate(request *Request) (jwToken *jwt.Token, err error)
 	if !cast {
 		err = liberr.Wrap(
 			&NotValid{
-				Reason: "user not string.",
+				Reason: "User not string.",
 				Token:  token,
 			})
 		return
@@ -128,7 +128,7 @@ func (r *Builtin) Authenticate(request *Request) (jwToken *jwt.Token, err error)
 	if !found {
 		err = liberr.Wrap(
 			&NotValid{
-				Reason: "scope not specified.",
+				Reason: "Scope not specified.",
 				Token:  token,
 			})
 		return
@@ -137,7 +137,7 @@ func (r *Builtin) Authenticate(request *Request) (jwToken *jwt.Token, err error)
 	if !cast {
 		err = liberr.Wrap(
 			&NotValid{
-				Reason: "scope not string.",
+				Reason: "Scope not string.",
 				Token:  token,
 			})
 		return

--- a/auth/builtin.go
+++ b/auth/builtin.go
@@ -15,6 +15,9 @@ var Validators []Validator
 // Validator provides token validation.
 type Validator interface {
 	// Valid determines if the token is valid.
+	// When valid, return nil.
+	// When not valid, return NotValid error.
+	// On failure, return the (cause) error.
 	Valid(token *jwt.Token, db *gorm.DB) (err error)
 }
 

--- a/auth/builtin.go
+++ b/auth/builtin.go
@@ -71,7 +71,8 @@ type Builtin struct {
 //
 // Authenticate the token
 func (r *Builtin) Authenticate(request *Request) (jwToken *jwt.Token, err error) {
-	token := request.Token
+	token := strings.Replace(request.Token, "Bearer", "", 1)
+	token = strings.Fields(token)[0]
 	jwToken, err = jwt.Parse(
 		request.Token,
 		func(jwToken *jwt.Token) (secret interface{}, err error) {

--- a/auth/provider.go
+++ b/auth/provider.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"errors"
 	"fmt"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/jortel/go-utils/logr"
@@ -51,26 +52,29 @@ type NotAuthenticated struct {
 }
 
 func (e *NotAuthenticated) Error() (s string) {
-	return fmt.Sprintf("Token %s not-valid.", e.Token)
+	return fmt.Sprintf("Token [%s] not-authenticated.", e.Token)
 }
 
 func (e *NotAuthenticated) Is(err error) (matched bool) {
-	_, matched = err.(*NotAuthenticated)
+	notAuth := &NotAuthenticated{}
+	matched = errors.As(err, &notAuth)
 	return
 }
 
 //
 // NotValid is returned when a token is not valid.
 type NotValid struct {
-	Token string
+	Reason string
+	Token  string
 }
 
 func (e *NotValid) Error() (s string) {
-	return fmt.Sprintf("Token %s not-valid.", e.Token)
+	return fmt.Sprintf("Token [%s] not-valid: %s", e.Token, e.Reason)
 }
 
 func (e *NotValid) Is(err error) (matched bool) {
-	_, matched = err.(*NotValid)
+	notValid := &NotValid{}
+	matched = errors.As(err, &notValid)
 	return
 }
 

--- a/hack/jwt.sh
+++ b/hack/jwt.sh
@@ -4,7 +4,7 @@
 #
 key=$1
 header='{"alg":"HS512","typ":"JWT"}'
-payload='{"scope":"applicaions:get","user":"operator"}'
+payload='{"scope":"*:*","user":"operator"}'
 headerStr=$(echo -n ${header} \
   | base64 -w 0 \
   | sed s/\+/-/g \

--- a/hack/jwt.sh
+++ b/hack/jwt.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 #
-# Usage: jwt.sh <key>
+# Usage: jwt.sh <key> <scope>
+#
+# scope - (string) space-separated scopes. (default: *:*).
 #
 key=$1
-header='{"alg":"HS512","typ":"JWT"}'
-payload='{"scope":"*:*","user":"operator"}'
+scope="${2:-*:*}"
+header='{"typ":"JWT","alg":"HS512"}'
+payload="{\"user\":\"operator\",\"scope\":\"${scope}\"}"
 headerStr=$(echo -n ${header} \
   | base64 -w 0 \
   | sed s/\+/-/g \

--- a/hack/jwt.sh
+++ b/hack/jwt.sh
@@ -3,9 +3,6 @@
 # Usage: jwt.sh <key>
 #
 key=$1
-hexKey=$(echo -n "${key}" \
-  | xxd -p \
-  | tr -d '\n')
 header='{"alg":"HS512","typ":"JWT"}'
 payload='{"scope":"applicaions:get","user":"operator"}'
 headerStr=$(echo -n ${header} \
@@ -19,7 +16,7 @@ payloadStr=$(echo -n ${payload} \
   | sed 's/\//_/g' \
   | sed -E s/=+$//)
 signStr=$(echo -n "${headerStr}.${payloadStr}" \
-  | openssl dgst -sha512 -mac HMAC -macopt hexkey:${hexKey} -binary \
+  | openssl dgst -sha512 -mac HMAC -macopt key:${key} -binary \
   | base64  -w 0 \
   | sed s/\+/-/g \
   | sed 's/\//_/g' \

--- a/hack/jwt.sh
+++ b/hack/jwt.sh
@@ -3,11 +3,11 @@
 # Usage: jwt.sh <key>
 #
 key=$1
-hexKey=$(echo -n "key" \
+hexKey=$(echo -n "${key}" \
   | xxd -p \
   | tr -d '\n')
 header='{"alg":"HS512","typ":"JWT"}'
-payload='{"scope":"*:*","user":"operator"}'
+payload='{"scope":"applicaions:get","user":"operator"}'
 headerStr=$(echo -n ${header} \
   | base64 -w 0 \
   | sed s/\+/-/g \

--- a/hack/jwt.sh
+++ b/hack/jwt.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Usage: hubtoken.sh <key>
+# Usage: jwt.sh <key>
 #
 key=$1
 hexKey=$(echo -n "key" \

--- a/hack/jwt.sh
+++ b/hack/jwt.sh
@@ -16,7 +16,7 @@ payloadStr=$(echo -n ${payload} \
   | sed 's/\//_/g' \
   | sed -E s/=+$//)
 signStr=$(echo -n "${headerStr}.${payloadStr}" \
-  | openssl dgst -sha512 -mac HMAC -macopt key:${key} -binary \
+  | openssl dgst -sha512 -hmac ${key} -binary \
   | base64  -w 0 \
   | sed s/\+/-/g \
   | sed 's/\//_/g' \

--- a/hack/jwt.sh
+++ b/hack/jwt.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Usage: hubtoken.sh <key>
+#
+key=$1
+hexKey=$(echo -n "key" \
+  | xxd -p \
+  | tr -d '\n')
+header='{"alg":"HS512","typ":"JWT"}'
+payload='{"scope":"*:*","user":"operator"}'
+headerStr=$(echo -n ${header} \
+  | base64 -w 0 \
+  | sed s/\+/-/g \
+  | sed 's/\//_/g' \
+  | sed -E s/=+$//)
+payloadStr=$(echo -n ${payload} \
+  | base64 -w 0 \
+  | sed s/\+/-/g \
+  | sed 's/\//_/g' \
+  | sed -E s/=+$//)
+signStr=$(echo -n "${headerStr}.${payloadStr}" \
+  | openssl dgst -sha512 -mac HMAC -macopt hexkey:${hexKey} -binary \
+  | base64  -w 0 \
+  | sed s/\+/-/g \
+  | sed 's/\//_/g' \
+  | sed -E s/=+$//)
+token="${headerStr}.${payloadStr}.${signStr}"
+echo "${token}"

--- a/task/auth.go
+++ b/task/auth.go
@@ -29,7 +29,6 @@ func (r *Validator) Valid(token *jwt.Token, db *gorm.DB) (err error) {
 	v, found := claims["task"]
 	id, cast := v.(float64)
 	if !found || !cast {
-		// Not a task token.
 		return
 	}
 	task := &model.Task{}

--- a/task/auth.go
+++ b/task/auth.go
@@ -28,7 +28,7 @@ func (r *Validator) Valid(token *jwt.Token, db *gorm.DB) (valid bool) {
 	v, found := claims["task"]
 	id, cast := v.(float64)
 	if !found || !cast {
-		Log.Info("Task not referenced by token.")
+		valid = true
 		return
 	}
 	task := &model.Task{}

--- a/task/auth.go
+++ b/task/auth.go
@@ -79,7 +79,7 @@ func (r *Validator) Valid(token *jwt.Token, db *gorm.DB) (err error) {
 		err = &auth.NotValid{
 			Token: token.Raw,
 			Reason: fmt.Sprintf(
-				"Pod (%s) referenced by token: not running. Phase: %s",
+				"Pod (%s) referenced by token: not pending|running. Phase detected: %s",
 				task.Pod,
 				pod.Status.Phase),
 		}


### PR DESCRIPTION
Add hack script to generate jwt tokens for _builtin_ auth.  Likley used by actors such as the operator for migration related to upgrade.

Related:
- auth.Validator signature changed to return error.  This is more flexible and _failures_ can be propagated.
- auth.Builtin.Authenticate() returns NotAuthenticated when should have returned NotValid for clearity.
- auth.NotValid includes `Reason`.