### PR TITLE
:bug: Add `yaml:"inline"` to Resource field tags

### DIFF
--- a/api/application.go
+++ b/api/application.go
@@ -1058,7 +1058,7 @@ func (h ApplicationHandler) AssessmentCreate(ctx *gin.Context) {
 //
 // Application REST resource.
 type Application struct {
-	Resource
+	Resource        `yaml:",inline"`
 	Name            string      `json:"name" binding:"required"`
 	Description     string      `json:"description"`
 	Bucket          *Ref        `json:"bucket"`

--- a/api/archetype.go
+++ b/api/archetype.go
@@ -331,7 +331,7 @@ func (h ArchetypeHandler) AssessmentCreate(ctx *gin.Context) {
 //
 // Archetype REST resource.
 type Archetype struct {
-	Resource
+	Resource          `yaml:",inline"`
 	Name              string   `json:"name" yaml:"name"`
 	Description       string   `json:"description" yaml:"description"`
 	Comments          string   `json:"comments" yaml:"comments"`

--- a/api/assessment.go
+++ b/api/assessment.go
@@ -150,7 +150,7 @@ func (h AssessmentHandler) Update(ctx *gin.Context) {
 //
 // Assessment REST resource.
 type Assessment struct {
-	Resource
+	Resource          `yaml:",inline"`
 	Application       *Ref                 `json:"application,omitempty" yaml:",omitempty" binding:"excluded_with=Archetype"`
 	Archetype         *Ref                 `json:"archetype,omitempty" yaml:",omitempty" binding:"excluded_with=Application"`
 	Questionnaire     Ref                  `json:"questionnaire" binding:"required"`

--- a/api/bucket.go
+++ b/api/bucket.go
@@ -192,7 +192,7 @@ func (h BucketHandler) BucketDelete(ctx *gin.Context) {
 //
 // Bucket REST resource.
 type Bucket struct {
-	Resource
+	Resource   `yaml:",inline"`
 	Path       string     `json:"path"`
 	Expiration *time.Time `json:"expiration,omitempty"`
 }

--- a/api/businessservice.go
+++ b/api/businessservice.go
@@ -167,7 +167,7 @@ func (h BusinessServiceHandler) Update(ctx *gin.Context) {
 //
 // BusinessService REST resource.
 type BusinessService struct {
-	Resource
+	Resource    `yaml:",inline"`
 	Name        string `json:"name" binding:"required"`
 	Description string `json:"description"`
 	Stakeholder *Ref   `json:"owner"`

--- a/api/dependency.go
+++ b/api/dependency.go
@@ -148,9 +148,9 @@ func (h DependencyHandler) Delete(ctx *gin.Context) {
 //
 // Dependency REST resource.
 type Dependency struct {
-	Resource
-	To   Ref `json:"to"`
-	From Ref `json:"from"`
+	Resource `yaml:",inline"`
+	To       Ref `json:"to"`
+	From     Ref `json:"from"`
 }
 
 //

--- a/api/group.go
+++ b/api/group.go
@@ -179,7 +179,7 @@ func (h StakeholderGroupHandler) Update(ctx *gin.Context) {
 //
 // StakeholderGroup REST resource.
 type StakeholderGroup struct {
-	Resource
+	Resource       `yaml:",inline"`
 	Name           string `json:"name" binding:"required"`
 	Description    string `json:"description"`
 	Stakeholders   []Ref  `json:"stakeholders"`

--- a/api/identity.go
+++ b/api/identity.go
@@ -231,7 +231,7 @@ func (h *IdentityHandler) setDecrypted(ctx *gin.Context) {
 //
 // Identity REST resource.
 type Identity struct {
-	Resource
+	Resource    `yaml:",inline"`
 	Kind        string `json:"kind" binding:"required"`
 	Name        string `json:"name" binding:"required"`
 	Description string `json:"description"`

--- a/api/import.go
+++ b/api/import.go
@@ -419,7 +419,7 @@ type Import map[string]interface{}
 //
 // ImportSummary REST resource.
 type ImportSummary struct {
-	Resource
+	Resource       `yaml:",inline"`
 	Filename       string    `json:"filename"`
 	ImportStatus   string    `json:"importStatus" yaml:"importStatus"`
 	ImportTime     time.Time `json:"importTime" yaml:"importTime"`

--- a/api/jobfunction.go
+++ b/api/jobfunction.go
@@ -167,7 +167,7 @@ func (h JobFunctionHandler) Update(ctx *gin.Context) {
 //
 // JobFunction REST resource.
 type JobFunction struct {
-	Resource
+	Resource     `yaml:",inline"`
 	Name         string `json:"name" binding:"required"`
 	Stakeholders []Ref  `json:"stakeholders"`
 }

--- a/api/migrationwave.go
+++ b/api/migrationwave.go
@@ -183,7 +183,7 @@ func (h MigrationWaveHandler) Delete(ctx *gin.Context) {
 //
 // MigrationWave REST Resource
 type MigrationWave struct {
-	Resource
+	Resource          `yaml:",inline"`
 	Name              string    `json:"name"`
 	StartDate         time.Time `json:"startDate" yaml:"startDate"`
 	EndDate           time.Time `json:"endDate" yaml:"endDate"`

--- a/api/proxy.go
+++ b/api/proxy.go
@@ -174,7 +174,7 @@ func (h ProxyHandler) Update(ctx *gin.Context) {
 //
 // Proxy REST resource.
 type Proxy struct {
-	Resource
+	Resource `yaml:",inline"`
 	Enabled  bool     `json:"enabled"`
 	Kind     string   `json:"kind" binding:"oneof=http https"`
 	Host     string   `json:"host"`

--- a/api/questionnaire.go
+++ b/api/questionnaire.go
@@ -188,7 +188,7 @@ func (h QuestionnaireHandler) Update(ctx *gin.Context) {
 }
 
 type Questionnaire struct {
-	Resource
+	Resource     `yaml:",inline"`
 	Name         string                  `json:"name" yaml:"name" binding:"required"`
 	Description  string                  `json:"description" yaml:"description"`
 	Required     bool                    `json:"required" yaml:"required"`

--- a/api/review.go
+++ b/api/review.go
@@ -224,7 +224,7 @@ func (h ReviewHandler) CopyReview(ctx *gin.Context) {
 //
 // Review REST resource.
 type Review struct {
-	Resource
+	Resource            `yaml:",inline"`
 	BusinessCriticality uint   `json:"businessCriticality" yaml:"businessCriticality"`
 	EffortEstimate      string `json:"effortEstimate" yaml:"effortEstimate"`
 	ProposedAction      string `json:"proposedAction" yaml:"proposedAction"`

--- a/api/ruleset.go
+++ b/api/ruleset.go
@@ -301,7 +301,7 @@ func (h *RuleSetHandler) delete(ctx *gin.Context, id uint) (err error) {
 //
 // RuleSet REST resource.
 type RuleSet struct {
-	Resource
+	Resource    `yaml:",inline"`
 	Kind        string      `json:"kind,omitempty"`
 	Name        string      `json:"name"`
 	Description string      `json:"description"`
@@ -380,7 +380,7 @@ func (r *RuleSet) HasRule(id uint) (b bool) {
 //
 // Rule - REST Resource.
 type Rule struct {
-	Resource
+	Resource    `yaml:",inline"`
 	Name        string   `json:"name,omitempty"`
 	Description string   `json:"description,omitempty"`
 	Labels      []string `json:"labels,omitempty"`

--- a/api/stakeholder.go
+++ b/api/stakeholder.go
@@ -190,7 +190,7 @@ func (h StakeholderHandler) Update(ctx *gin.Context) {
 //
 // Stakeholder REST resource.
 type Stakeholder struct {
-	Resource
+	Resource         `yaml:",inline"`
 	Name             string `json:"name" binding:"required"`
 	Email            string `json:"email" binding:"required"`
 	Groups           []Ref  `json:"stakeholderGroups" yaml:"stakeholderGroups"`

--- a/api/tag.go
+++ b/api/tag.go
@@ -167,7 +167,7 @@ func (h TagHandler) Update(ctx *gin.Context) {
 //
 // Tag REST resource.
 type Tag struct {
-	Resource
+	Resource `yaml:",inline"`
 	Name     string `json:"name" binding:"required"`
 	Category Ref    `json:"category" binding:"required"`
 }

--- a/api/tagcategory.go
+++ b/api/tagcategory.go
@@ -212,7 +212,7 @@ func (h TagCategoryHandler) TagList(ctx *gin.Context) {
 //
 // TagCategory REST resource.
 type TagCategory struct {
-	Resource
+	Resource `yaml:",inline"`
 	Name     string `json:"name" binding:"required"`
 	Username string `json:"username"`
 	Rank     uint   `json:"rank"`

--- a/api/target.go
+++ b/api/target.go
@@ -238,7 +238,7 @@ func (h TargetHandler) Update(ctx *gin.Context) {
 //
 // Target REST resource.
 type Target struct {
-	Resource
+	Resource    `yaml:",inline"`
 	Name        string   `json:"name"`
 	Description string   `json:"description"`
 	Provider    string   `json:"provider,omitempty" yaml:",omitempty"`

--- a/api/taskgroup.go
+++ b/api/taskgroup.go
@@ -354,13 +354,13 @@ func (h TaskGroupHandler) BucketDelete(ctx *gin.Context) {
 //
 // TaskGroup REST resource.
 type TaskGroup struct {
-	Resource
-	Name   string      `json:"name"`
-	Addon  string      `json:"addon"`
-	Data   interface{} `json:"data" swaggertype:"object" binding:"required"`
-	Bucket *Ref        `json:"bucket,omitempty"`
-	State  string      `json:"state"`
-	Tasks  []Task      `json:"tasks"`
+	Resource `yaml:",inline"`
+	Name     string      `json:"name"`
+	Addon    string      `json:"addon"`
+	Data     interface{} `json:"data" swaggertype:"object" binding:"required"`
+	Bucket   *Ref        `json:"bucket,omitempty"`
+	State    string      `json:"state"`
+	Tasks    []Task      `json:"tasks"`
 }
 
 //

--- a/api/ticket.go
+++ b/api/ticket.go
@@ -146,7 +146,7 @@ func (h TicketHandler) Delete(ctx *gin.Context) {
 
 // Ticket API Resource
 type Ticket struct {
-	Resource
+	Resource    `yaml:",inline"`
 	Kind        string    `json:"kind" binding:"required"`
 	Reference   string    `json:"reference"`
 	Link        string    `json:"link"`

--- a/api/tracker.go
+++ b/api/tracker.go
@@ -311,7 +311,7 @@ func (h TrackerHandler) ProjectIssueTypeList(ctx *gin.Context) {
 
 // Tracker API Resource
 type Tracker struct {
-	Resource
+	Resource    `yaml:",inline"`
 	Name        string    `json:"name" binding:"required"`
 	URL         string    `json:"url" binding:"required"`
 	Kind        string    `json:"kind" binding:"required,oneof=jira-cloud jira-onprem"`


### PR DESCRIPTION
The yaml encoder/decoder needs to be explicitly told inline the `Resource` struct's fields on each of the API resources, otherwise attempts to bind requests that include Resource fields (`id`, `createTime`, `createUser`, `updateUser`) fail. 