### PR TITLE
:bug: Preload assessment stakeholder relationships

### DIFF
--- a/api/application.go
+++ b/api/application.go
@@ -949,7 +949,7 @@ func (h ApplicationHandler) StakeholdersUpdate(ctx *gin.Context) {
 func (h ApplicationHandler) AssessmentList(ctx *gin.Context) {
 	m := &model.Application{}
 	id := h.pk(ctx)
-	db := h.preLoad(h.DB(ctx), clause.Associations)
+	db := h.preLoad(h.DB(ctx), clause.Associations, "Assessments.Stakeholders", "Assessments.Stakeholders")
 	db = db.Omit("Analyses")
 	result := db.First(m, id)
 	if result.Error != nil {

--- a/assessment/membership.go
+++ b/assessment/membership.go
@@ -87,6 +87,8 @@ func (r *MembershipResolver) cacheArchetypes() (err error) {
 
 	list := []model.Archetype{}
 	db := r.db.Preload(clause.Associations)
+	db = db.Preload("Assessments.Stakeholders")
+	db = db.Preload("Assessments.StakeholderGroups")
 	result := db.Find(&list)
 	if result.Error != nil {
 		err = liberr.Wrap(err)


### PR DESCRIPTION
The assessment stakeholder relationships need to be preloaded so that the `applications/id/assessments` and `archetypes/id/assessments` subresources populate their association fields properly.