### PR TITLE
:bug: Fix yaml task data

### DIFF
--- a/api/base.go
+++ b/api/base.go
@@ -503,7 +503,7 @@ func (r *Cursor) pageLimited() (b bool) {
 
 //
 // StrMap returns a map[string]any.
-// YAML decoder can produce map[any]any which is not valid for json.
+// The YAML decoder can produce map[any]any which is not valid for json.
 func StrMap(in any) (out any) {
 	out = in
 	if d, cast := in.(map[any]any); cast {

--- a/api/base.go
+++ b/api/base.go
@@ -504,6 +504,7 @@ func (r *Cursor) pageLimited() (b bool) {
 //
 // StrMap returns a map[string]any.
 // The YAML decoder can produce map[any]any which is not valid for json.
+// Converts map[any]any to map[string]any as needed.
 func StrMap(in any) (out any) {
 	out = in
 	if d, cast := in.(map[any]any); cast {

--- a/api/base.go
+++ b/api/base.go
@@ -500,3 +500,19 @@ func (r *Cursor) pageLimited() (b bool) {
 	b = r.Index > int64(r.Limit)
 	return
 }
+
+//
+// StrMap returns a map[string]any.
+// YAML decoder can produce map[any]any which is not valid for json.
+func StrMap(in any) (out any) {
+	out = in
+	if d, cast := in.(map[any]any); cast {
+		mp := make(map[string]any)
+		for k, v := range d {
+			s := fmt.Sprintf("%v", k)
+			mp[s] = StrMap(v)
+		}
+		out = mp
+	}
+	return
+}

--- a/api/task.go
+++ b/api/task.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/gin-gonic/gin"
 	"github.com/konveyor/tackle2-hub/model"
 	tasking "github.com/konveyor/tackle2-hub/task"
@@ -586,10 +587,25 @@ func (r *Task) Model() (m *model.Task) {
 		State:         r.State,
 		ApplicationID: r.idPtr(r.Application),
 	}
-	m.Data, _ = json.Marshal(r.Data)
+	m.Data, _ = json.Marshal(r.strMap(r.Data))
 	m.ID = r.ID
 	if r.TTL != nil {
 		m.TTL, _ = json.Marshal(r.TTL)
+	}
+	return
+}
+
+//
+// strMap returns a map[string]any.
+// YAML decoder can produce map[any]any which is not valid for json.
+func (r *Task) strMap(in any) (out any) {
+	if d, cast := in.(map[any]any); cast {
+		mp := make(map[string]any)
+		for k, v := range d {
+			s := fmt.Sprintf("%v", k)
+			mp[s] = r.strMap(v)
+		}
+		r.Data = mp
 	}
 	return
 }

--- a/api/task.go
+++ b/api/task.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"encoding/json"
-	"fmt"
 	"github.com/gin-gonic/gin"
 	"github.com/konveyor/tackle2-hub/model"
 	tasking "github.com/konveyor/tackle2-hub/task"
@@ -587,25 +586,10 @@ func (r *Task) Model() (m *model.Task) {
 		State:         r.State,
 		ApplicationID: r.idPtr(r.Application),
 	}
-	m.Data, _ = json.Marshal(r.strMap(r.Data))
+	m.Data, _ = json.Marshal(StrMap(r.Data))
 	m.ID = r.ID
 	if r.TTL != nil {
 		m.TTL, _ = json.Marshal(r.TTL)
-	}
-	return
-}
-
-//
-// strMap returns a map[string]any.
-// YAML decoder can produce map[any]any which is not valid for json.
-func (r *Task) strMap(in any) (out any) {
-	if d, cast := in.(map[any]any); cast {
-		mp := make(map[string]any)
-		for k, v := range d {
-			s := fmt.Sprintf("%v", k)
-			mp[s] = r.strMap(v)
-		}
-		r.Data = mp
 	}
 	return
 }
@@ -658,7 +642,7 @@ func (r *TaskReport) Model() (m *model.TaskReport) {
 		m.Activity, _ = json.Marshal(r.Activity)
 	}
 	if r.Result != nil {
-		m.Result, _ = json.Marshal(r.Result)
+		m.Result, _ = json.Marshal(StrMap(r.Result))
 	}
 	if r.Errors != nil {
 		m.Errors, _ = json.Marshal(r.Errors)

--- a/api/taskgroup.go
+++ b/api/taskgroup.go
@@ -399,7 +399,7 @@ func (r *TaskGroup) Model() (m *model.TaskGroup) {
 		State: r.State,
 	}
 	m.ID = r.ID
-	m.Data, _ = json.Marshal(r.Data)
+	m.Data, _ = json.Marshal(StrMap(r.Data))
 	m.List, _ = json.Marshal(r.Tasks)
 	if r.Bucket != nil {
 		m.BucketID = &r.Bucket.ID


### PR DESCRIPTION
Fix JSON encoding of resources fields of type _any_.
When the `content-type` is YAML, the decoded resource fields of type _any_ will be unmarshalled as `map[any]any`.  This is legal for YAML but not JSON.  As a result, the JSON encoding fails and the field value is NOT stored.