### PR TITLE
:sparkles: add addon Adapter.Log.

### DIFF
--- a/addon/adapter.go
+++ b/addon/adapter.go
@@ -5,6 +5,7 @@ Tackle hub/addon integration.
 package addon
 
 import (
+	logapi "github.com/go-logr/logr"
 	"github.com/jortel/go-utils/logr"
 	"github.com/konveyor/tackle2-hub/binding"
 	"github.com/konveyor/tackle2-hub/settings"
@@ -67,6 +68,8 @@ type Filter = binding.Filter
 type Adapter struct {
 	// Task API.
 	Task
+	// Log API.
+	Log logapi.Logger
 	// Settings API.
 	Setting Setting
 	// Application API.
@@ -141,6 +144,7 @@ func newAdapter() (adapter *Adapter) {
 		Task: Task{
 			richClient: richClient,
 		},
+		Log:         Log,
 		Setting:     richClient.Setting,
 		Application: richClient.Application,
 		Identity:    richClient.Identity,


### PR DESCRIPTION
Add support for Adapter.Log to complement addon.Activity.  This provides convenient way for addons to include information in the pod log but not the task activity (which is also logged).  Add writers do not need to construct their own logger.

Used in addons as:
```
addon.Log.Info("Something secret.")
```