### PR TITLE
:bug: Add missing Archetype scopes to Architect role

### DIFF
--- a/auth/roles.yaml
+++ b/auth/roles.yaml
@@ -383,7 +383,10 @@
         - put
     - name: archetypes
       verbs:
+        - delete
         - get
+        - post
+        - put
     - name: archetypes.assessments
       verbs:
         - get


### PR DESCRIPTION
Fixes https://issues.redhat.com/projects/MTA/issues/MTA-1606