### PR TITLE
:seedling: Clean up stakeholders after Import CSV API test

### DIFF
--- a/test/api/importcsv/api_test.go
+++ b/test/api/importcsv/api_test.go
@@ -173,6 +173,12 @@ func TestImportCSV(t *testing.T) {
 
 			// Delete imported Applications.
 			for _, apps := range gotApps {
+				if apps.Owner != nil {
+					assert.Must(t, Stakeholder.Delete(apps.Owner.ID))
+				}
+				for _, contributor := range apps.Contributors {
+					assert.Must(t, Stakeholder.Delete(contributor.ID))
+				}
 				assert.Must(t, Application.Delete(apps.ID))
 			}
 
@@ -180,6 +186,7 @@ func TestImportCSV(t *testing.T) {
 			for _, deps := range gotDeps {
 				assert.Must(t, Dependency.Delete(deps.ID))
 			}
+
 		})
 	}
 }

--- a/test/api/importcsv/pkg.go
+++ b/test/api/importcsv/pkg.go
@@ -10,6 +10,7 @@ var (
 	Client      *binding.Client
 	Application binding.Application
 	Dependency  binding.Dependency
+	Stakeholder binding.Stakeholder
 )
 
 func init() {
@@ -24,4 +25,7 @@ func init() {
 
 	// Access Dependency directly
 	Dependency = RichClient.Dependency
+
+	// Access Stakeholder directly
+	Stakeholder = RichClient.Stakeholder
 }


### PR DESCRIPTION
Fixes failing CI caused by Stakeholders lingering after the import test completes.