### PR TITLE
:seedling: Stabilize API tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,6 +58,7 @@ jobs:
           DISCONNECTED=1 make run &
           sleep 15  # probably a dirty solution
           HUB_BASE_URL=http://localhost:8080 make test-api
+          HUB_BASE_URL=http://localhost:8080 make test-api  # Intentionaly run 2x to catch data left in Hub DB.
 
   test-e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -26,3 +26,4 @@ jobs:
           DISCONNECTED=1 make run &
           sleep 15  # probably a dirty solution
           HUB_BASE_URL=http://localhost:8080 make test-api
+          HUB_BASE_URL=http://localhost:8080 make test-api  # Intentionaly run 2x to catch data left in Hub DB.

--- a/Makefile
+++ b/Makefile
@@ -135,7 +135,7 @@ test:
 
 # Run Hub REST API tests.
 test-api:
-	HUB_BASE_URL=${HUB_BASE_URL} go test -count=1 -v ./test/api/...
+	HUB_BASE_URL=${HUB_BASE_URL} go test -count=1 -p=1 -v ./test/api/...
 
 # Run Hub test suite.
 test-all: test-unit test-api

--- a/test/api/review/api_test.go
+++ b/test/api/review/api_test.go
@@ -46,10 +46,11 @@ func TestReviewCRUD(t *testing.T) {
 			// Check if the unchanged values remain same or not.
 			AssertEqualReviews(t, got, r)
 
-			// Delete Related Applications.
-			assert.Must(t, Application.Delete(app.ID))
 			// Delete Review.
 			assert.Must(t, Review.Delete(r.ID))
+
+			// Delete Related Applications.
+			assert.Must(t, Application.Delete(app.ID))
 
 			// Check if the review is present even after deletion or not.
 			_, err = Review.Get(r.ID)
@@ -76,9 +77,6 @@ func TestReviewCRUD(t *testing.T) {
 			destApp := api.Application{
 				Name:        "New Application",
 				Description: "Application for Review",
-				Review: &api.Ref{
-					ID: r.ID,
-				},
 			}
 			assert.Must(t, Application.Create(&destApp))
 
@@ -87,7 +85,8 @@ func TestReviewCRUD(t *testing.T) {
 				t.Errorf(err.Error())
 			}
 
-			gotReview, err := Review.Get(destApp.Review.ID)
+			destAppRef, _ := Application.Get(destApp.ID)
+			gotReview, err := Review.Get(destAppRef.Review.ID)
 			if err != nil {
 				fmt.Println(err.Error())
 				t.Errorf(err.Error())
@@ -98,6 +97,7 @@ func TestReviewCRUD(t *testing.T) {
 
 			// Delete Review.
 			assert.Must(t, Review.Delete(r.ID))
+			assert.Must(t, Review.Delete(gotReview.ID))
 
 			// Delete Applications.
 			assert.Must(t, Application.Delete(srcApp.ID))


### PR DESCRIPTION
Addressing few issues in Hub API tests execution that cause rare/random failures.
- Force serial API test execution (-p=1,weird: looked like time.Sleep e.g. in importcsv test, continue with other tests while the sleep).
- Run API tests 2x in github action (failure in 1st run means a bug, failure only in 2nd run means likely leftover test data). Together with forcing serial test execution, this should help with test failures debugging.
- Updated data cleanup in Review test.