### PR TITLE
:bug: Fix loop variable pointer bug in assessment logic

### DIFF
--- a/assessment/application.go
+++ b/assessment/application.go
@@ -15,9 +15,10 @@ type Application struct {
 // With updates the Application with the db model and deserializes its assessments.
 func (r *Application) With(m *model.Application) {
 	r.Application = m
-	for _, a := range m.Assessments {
+	for i := range m.Assessments {
+		a := &m.Assessments[i]
 		assessment := Assessment{}
-		assessment.With(&a)
+		assessment.With(a)
 		r.Assessments = append(r.Assessments, assessment)
 	}
 }

--- a/assessment/archetype.go
+++ b/assessment/archetype.go
@@ -13,9 +13,10 @@ type Archetype struct {
 // With updates the Archetype with the db model and deserializes its assessments.
 func (r *Archetype) With(m *model.Archetype) {
 	r.Archetype = m
-	for _, a := range m.Assessments {
+	for i := range m.Assessments {
+		a := &m.Assessments[i]
 		assessment := Assessment{}
-		assessment.With(&a)
+		assessment.With(a)
 		r.Assessments = append(r.Assessments, assessment)
 	}
 }

--- a/assessment/questionnaire.go
+++ b/assessment/questionnaire.go
@@ -46,15 +46,11 @@ func (r *QuestionnaireResolver) cacheQuestionnaires() (err error) {
 // questionnaires.
 func (r *QuestionnaireResolver) Assessed(assessments []Assessment) (assessed bool) {
 	answered := NewSet()
-loop:
 	for _, a := range assessments {
 		if r.requiredQuestionnaires.Contains(a.QuestionnaireID) {
-			for _, s := range a.Sections {
-				if !s.Complete() {
-					continue loop
-				}
+			if a.Complete() {
+				answered.Add(a.QuestionnaireID)
 			}
-			answered.Add(a.QuestionnaireID)
 		}
 	}
 	assessed = answered.Superset(r.requiredQuestionnaires, false)


### PR DESCRIPTION
This bug was causing the slice of application/archetype assessments to be populated with copies of the last assessment, breaking the assessment status check and likely other things as well.