### PR TITLE
:seedling: Add api_hub_tests_ref to CI on PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,3 +94,4 @@ jobs:
     uses: konveyor/ci/.github/workflows/global-ci.yml@main
     with:
       component_name: tackle2-hub
+      api_hub_tests_ref: ${{ github.head_ref }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,4 +94,4 @@ jobs:
     uses: konveyor/ci/.github/workflows/global-ci.yml@main
     with:
       component_name: tackle2-hub
-      api_hub_tests_ref: ${{ github.head_ref }}
+      api_hub_tests_ref: ${{ github.ref_name }}


### PR DESCRIPTION
In order to run E2E API tests with tackle2-hub API tests on matching branches, adding name of PR branch as a variable passed to CI workflow.

Depends on https://github.com/konveyor/ci/pull/23

Related to https://github.com/konveyor/ci/issues/22 and https://github.com/konveyor/go-konveyor-tests/pull/61