### PR TITLE
:seedling: Add Archetype to binding and API test

### DIFF
--- a/binding/archetype.go
+++ b/binding/archetype.go
@@ -1,0 +1,50 @@
+package binding
+
+import (
+	"github.com/konveyor/tackle2-hub/api"
+)
+
+//
+// Archetype API.
+type Archetype struct {
+	client *Client
+}
+
+//
+// Create a Archetype.
+func (h *Archetype) Create(r *api.Archetype) (err error) {
+	err = h.client.Post(api.ArchetypesRoot, &r)
+	return
+}
+
+//
+// Get a Archetype by ID.
+func (h *Archetype) Get(id uint) (r *api.Archetype, err error) {
+	r = &api.Archetype{}
+	path := Path(api.ArchetypeRoot).Inject(Params{api.ID: id})
+	err = h.client.Get(path, r)
+	return
+}
+
+//
+// List Archetypes.
+func (h *Archetype) List() (list []api.Archetype, err error) {
+	list = []api.Archetype{}
+	err = h.client.Get(api.ArchetypesRoot, &list)
+	return
+}
+
+//
+// Update a Archetype.
+func (h *Archetype) Update(r *api.Archetype) (err error) {
+	path := Path(api.ArchetypeRoot).Inject(Params{api.ID: r.ID})
+	err = h.client.Put(path, r)
+	return
+}
+
+//
+// Delete a Archetype.
+func (h *Archetype) Delete(id uint) (err error) {
+	err = h.client.Delete(Path(api.ArchetypeRoot).Inject(Params{api.ID: id}))
+	return
+}

--- a/binding/richclient.go
+++ b/binding/richclient.go
@@ -22,6 +22,7 @@ func init() {
 type RichClient struct {
 	// Resources APIs.
 	Application      Application
+	Archetype        Archetype
 	Bucket           Bucket
 	BusinessService  BusinessService
 	Dependency       Dependency
@@ -57,6 +58,9 @@ func New(baseUrl string) (r *RichClient) {
 	// Build RichClient.
 	r = &RichClient{
 		Application: Application{
+			client: client,
+		},
+		Archetype: Archetype{
 			client: client,
 		},
 		Bucket: Bucket{

--- a/test/api/archetype/api_test.go
+++ b/test/api/archetype/api_test.go
@@ -74,5 +74,3 @@ func TestArchetypeList(t *testing.T) {
 		assert.Must(t, Archetype.Delete(r.ID))
 	}
 }
-
-// TODO(maufart): Add assessment POST&GET methods

--- a/test/api/archetype/api_test.go
+++ b/test/api/archetype/api_test.go
@@ -1,0 +1,78 @@
+package archetype
+
+import (
+	"testing"
+
+	"github.com/konveyor/tackle2-hub/test/assert"
+)
+
+func TestArchetypeCRUD(t *testing.T) {
+	for _, r := range Samples {
+		t.Run(r.Name, func(t *testing.T) {
+			// Create.
+			err := Archetype.Create(&r)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+
+			// Get.
+			got, err := Archetype.Get(r.ID)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+			if assert.FlatEqual(got, r) {
+				t.Errorf("Different response error. Got %v, expected %v", got, r)
+			}
+
+			// Update.
+			r.Name = "Updated " + r.Name
+			err = Archetype.Update(&r)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+
+			got, err = Archetype.Get(r.ID)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+			if got.Name != r.Name {
+				t.Errorf("Different response error. Got %s, expected %s", got.Name, r.Name)
+			}
+
+			// Delete.
+			err = Archetype.Delete(r.ID)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+
+			_, err = Archetype.Get(r.ID)
+			if err == nil {
+				t.Errorf("Resource exits, but should be deleted: %v", r)
+			}
+		})
+	}
+}
+
+func TestArchetypeList(t *testing.T) {
+	samples := Samples
+
+	for name := range samples {
+		sample := samples[name]
+		assert.Must(t, Archetype.Create(&sample))
+		samples[name] = sample
+	}
+
+	got, err := Archetype.List()
+	if err != nil {
+		t.Errorf(err.Error())
+	}
+	if assert.FlatEqual(got, &samples) {
+		t.Errorf("Different response error. Got %v, expected %v", got, samples)
+	}
+
+	for _, r := range samples {
+		assert.Must(t, Archetype.Delete(r.ID))
+	}
+}
+
+// TODO(maufart): Add assessment POST&GET methods

--- a/test/api/archetype/pkg.go
+++ b/test/api/archetype/pkg.go
@@ -1,0 +1,20 @@
+package archetype
+
+import (
+	"github.com/konveyor/tackle2-hub/binding"
+	"github.com/konveyor/tackle2-hub/test/api/client"
+)
+
+var (
+	RichClient *binding.RichClient
+	Archetype binding.Archetype
+)
+
+
+func init() {
+	// Prepare RichClient and login to Hub API (configured from env variables).
+	RichClient = client.PrepareRichClient()
+
+	// Shortcut for Archetype-related RichClient methods.
+	Archetype = RichClient.Archetype
+}

--- a/test/api/archetype/samples.go
+++ b/test/api/archetype/samples.go
@@ -1,0 +1,15 @@
+package archetype
+
+import (
+	"github.com/konveyor/tackle2-hub/api"
+)
+
+// Set of valid resources for tests and reuse.
+var (
+	MinimalArchetype = api.Archetype{
+		Name:        "Minimal Archetype",
+		Description: "Archetype minimal sample 1",
+		Comments:    "Archetype comments",
+	}
+	Samples = []api.Archetype{MinimalArchetype}
+)


### PR DESCRIPTION
Adding Archetype endpoint to binding and basic API test.

Related to https://github.com/konveyor/tackle2-hub/issues/494