### PR TITLE
:bug: [MTA-1455] Fix typo in tackle-migrator role yaml

### DIFF
--- a/auth/role.go
+++ b/auth/role.go
@@ -1,11 +1,12 @@
 package auth
 
 import (
+	"io"
+	"os"
+
 	liberr "github.com/jortel/go-utils/error"
 	"github.com/konveyor/tackle2-hub/settings"
 	"gopkg.in/yaml.v2"
-	"io"
-	"os"
 )
 
 var Settings = &settings.Settings
@@ -36,15 +37,15 @@ var AddonRole = []string{
 // Role represents a RBAC role which grants
 // access to particular resources in the hub.
 type Role struct {
-	Name      string     `yaml:"role"`
-	Resources []Resource `yaml:"resources"`
+	Name      string     `yaml:"role" validate:"required"`
+	Resources []Resource `yaml:"resources" validate:"required"`
 }
 
 //
 // Resource is a set of permissions for a hub resource that a role may have.
 type Resource struct {
-	Name  string   `yaml:"name"`
-	Verbs []string `yaml:"verbs"`
+	Name  string   `yaml:"name" validate:"required"`
+	Verbs []string `yaml:"verbs" validate:"required,dive,oneof=get post put patch delete"`
 }
 
 //
@@ -75,7 +76,7 @@ func LoadRoles(path string) (roles []Role, err error) {
 		return
 	}
 
-	err = yaml.Unmarshal(yamlBytes, &roles)
+	err = yaml.UnmarshalStrict(yamlBytes, &roles)
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
@@ -100,7 +101,7 @@ func LoadUsers(path string) (users []User, err error) {
 		return
 	}
 
-	err = yaml.Unmarshal(yamlBytes, &users)
+	err = yaml.UnmarshalStrict(yamlBytes, &users)
 	if err != nil {
 		err = liberr.Wrap(err)
 		return

--- a/auth/role_test.go
+++ b/auth/role_test.go
@@ -1,0 +1,36 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/onsi/gomega"
+)
+
+func TestLoadYaml(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	roles, err := LoadRoles("./roles.yaml")
+	g.Expect(err).To(gomega.BeNil())
+	users, err := LoadUsers("./users.yaml")
+	g.Expect(err).To(gomega.BeNil())
+
+	validate := validator.New()
+	var roleNames []string
+	for _, role := range roles {
+		err = validate.Struct(role)
+		g.Expect(err).To(gomega.BeNil())
+		for _, resource := range role.Resources {
+			err = validate.Struct(resource)
+			g.Expect(err).To(gomega.BeNil())
+		}
+		roleNames = append(roleNames, role.Name)
+	}
+
+	for _, user := range users {
+		err = validate.Struct(user)
+		g.Expect(err).To(gomega.BeNil())
+		for _, role := range user.Roles {
+			g.Expect(role).To(gomega.BeElementOf(roleNames))
+		}
+	}
+}

--- a/auth/roles.yaml
+++ b/auth/roles.yaml
@@ -498,7 +498,7 @@
       verbs:
         - get
     - name: targets
-      verb:
+      verbs:
         - get
     - name: analyses
       verbs:


### PR DESCRIPTION
The migrator role was not able to access the `targets` resource correctly due to a keyname typo in `roles.yaml`. The incorrectly named `verb` key was ignored by the unmarshaller, which resulted in there being no verbs permitted for the resource. This fixes the typo in the yaml, turns on strict unmarshalling in the `LoadUsers` and `LoadRoles` functions, and then adds a unit test to catch future typos.

The tests will catch key typos, typos in http verbs, and typos in user role mappings.

Fixes https://issues.redhat.com/browse/MTA-1455