### PR TITLE
:bug: [MTA-1640] Remove write perms on Review from migrator role

### DIFF
--- a/auth/roles.yaml
+++ b/auth/roles.yaml
@@ -447,8 +447,6 @@
     - name: reviews
       verbs:
         - get
-        - post
-        - put
     - name: settings
       verbs:
         - get


### PR DESCRIPTION
Partial fix for [MTA-1640](https://issues.redhat.com/browse/MTA-1640).