### PR TITLE
:bug: [MTA-1746] Omit thresholds from assessment update

### DIFF
--- a/api/assessment.go
+++ b/api/assessment.go
@@ -2,11 +2,12 @@ package api
 
 import (
 	"encoding/json"
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	"github.com/konveyor/tackle2-hub/assessment"
 	"github.com/konveyor/tackle2-hub/model"
 	"gorm.io/gorm/clause"
-	"net/http"
 )
 
 //
@@ -127,7 +128,7 @@ func (h AssessmentHandler) Update(ctx *gin.Context) {
 	m.ID = id
 	m.UpdateUser = h.CurrentUser(ctx)
 	db := h.DB(ctx).Model(m)
-	db = db.Omit(clause.Associations)
+	db = db.Omit(clause.Associations, "Thresholds", "RiskMessages")
 	result := db.Updates(h.fields(m))
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)


### PR DESCRIPTION
The `Model()` method on the Assessment resource ignores the RiskMessages and Thresholds fields, but they weren't being updated in the `Omit` call in the update handler. This meant that the fields were getting zeroed out, breaking the risk level calculation. 

Fixes https://issues.redhat.com/browse/MTA-1746