### PR TITLE
:seedling: Fix PR ref passed to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,4 +94,4 @@ jobs:
     uses: konveyor/ci/.github/workflows/global-ci.yml@main
     with:
       component_name: tackle2-hub
-      api_hub_tests_ref: ${{ github.ref_name }}
+      api_hub_tests_ref: refs/pull/${{ github.ref_name }}


### PR DESCRIPTION
Fixing PR ref used to execute CI tests with up-to-date Hub API tests suite. This issue caused E2E API test failures on recent Hub PRs.