### PR TITLE
:bug: [MTA-1349] Fix Questionnaire/Assessment validation

### DIFF
--- a/api/assessment.go
+++ b/api/assessment.go
@@ -155,7 +155,7 @@ type Assessment struct {
 	Application       *Ref                 `json:"application,omitempty" yaml:",omitempty" binding:"excluded_with=Archetype"`
 	Archetype         *Ref                 `json:"archetype,omitempty" yaml:",omitempty" binding:"excluded_with=Application"`
 	Questionnaire     Ref                  `json:"questionnaire" binding:"required"`
-	Sections          []assessment.Section `json:"sections"`
+	Sections          []assessment.Section `json:"sections" binding:"dive"`
 	Stakeholders      []Ref                `json:"stakeholders"`
 	StakeholderGroups []Ref                `json:"stakeholderGroups" yaml:"stakeholderGroups"`
 	// read only

--- a/api/questionnaire.go
+++ b/api/questionnaire.go
@@ -2,11 +2,12 @@ package api
 
 import (
 	"encoding/json"
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	"github.com/konveyor/tackle2-hub/assessment"
 	"github.com/konveyor/tackle2-hub/model"
 	"gorm.io/gorm/clause"
-	"net/http"
 )
 
 // Routes
@@ -192,7 +193,7 @@ type Questionnaire struct {
 	Name         string                  `json:"name" yaml:"name" binding:"required"`
 	Description  string                  `json:"description" yaml:"description"`
 	Required     bool                    `json:"required" yaml:"required"`
-	Sections     []assessment.Section    `json:"sections" yaml:"sections" binding:"required"`
+	Sections     []assessment.Section    `json:"sections" yaml:"sections" binding:"required,dive"`
 	Thresholds   assessment.Thresholds   `json:"thresholds" yaml:"thresholds" binding:"required"`
 	RiskMessages assessment.RiskMessages `json:"riskMessages" yaml:"riskMessages" binding:"required"`
 	Builtin      bool                    `json:"builtin,omitempty" yaml:"builtin,omitempty"`

--- a/assessment/assessment.go
+++ b/assessment/assessment.go
@@ -2,8 +2,9 @@ package assessment
 
 import (
 	"encoding/json"
-	"github.com/konveyor/tackle2-hub/model"
 	"math"
+
+	"github.com/konveyor/tackle2-hub/model"
 )
 
 //
@@ -129,7 +130,7 @@ func (r *Assessment) Confidence() (score int) {
 type Section struct {
 	Order     uint       `json:"order" yaml:"order" binding:"required"`
 	Name      string     `json:"name" yaml:"name"`
-	Questions []Question `json:"questions" yaml:"questions"`
+	Questions []Question `json:"questions" yaml:"questions" binding:"dive"`
 	Comment   string     `json:"comment,omitempty" yaml:"comment,omitempty"`
 }
 
@@ -183,7 +184,7 @@ type Question struct {
 	Explanation string           `json:"explanation" yaml:"explanation"`
 	IncludeFor  []CategorizedTag `json:"includeFor,omitempty" yaml:"includeFor,omitempty" binding:"excluded_with=ExcludeFor"`
 	ExcludeFor  []CategorizedTag `json:"excludeFor,omitempty" yaml:"excludeFor,omitempty" binding:"excluded_with=IncludeFor"`
-	Answers     []Answer         `json:"answers" yaml:"answers"`
+	Answers     []Answer         `json:"answers" yaml:"answers" binding:"dive"`
 }
 
 //
@@ -225,7 +226,7 @@ func (r *Question) Tags() (tags []CategorizedTag) {
 type Answer struct {
 	Order         uint             `json:"order" yaml:"order" binding:"required"`
 	Text          string           `json:"text" yaml:"text"`
-	Risk          string           `json:"risk" yaml:"risk" binding:"oneof=red,yellow,green,unknown"`
+	Risk          string           `json:"risk" yaml:"risk" binding:"oneof=red yellow green unknown"`
 	Rationale     string           `json:"rationale" yaml:"rationale"`
 	Mitigation    string           `json:"mitigation" yaml:"mitigation"`
 	ApplyTags     []CategorizedTag `json:"applyTags,omitempty" yaml:"applyTags,omitempty"`


### PR DESCRIPTION
The validator used by Gin will validate nested structs, but will not validate a slice of structs unless the binding field tag specifies the `dive` keyword. This needs to be present on every level of nested slices of structs.

Fixes https://issues.redhat.com/browse/MTA-1349