### PR TITLE
:bug: TechDependencies deduplicated with direct taking priority.

### DIFF
--- a/api/analysis.go
+++ b/api/analysis.go
@@ -369,7 +369,7 @@ func (h AnalysisHandler) AppCreate(ctx *gin.Context) {
 		deps = append(deps, r)
 	}
 	sort.Slice(deps, func(i, _ int) bool {
-		return deps[i].Indirect
+		return !deps[i].Indirect
 	})
 	for _, r := range deps {
 		m := r.Model()

--- a/api/analysis.go
+++ b/api/analysis.go
@@ -353,6 +353,7 @@ func (h AnalysisHandler) AppCreate(ctx *gin.Context) {
 		_ = ctx.Error(err)
 		return
 	}
+	var deps []*TechDependency
 	for {
 		r := &TechDependency{}
 		err = d.Decode(r)
@@ -365,8 +366,15 @@ func (h AnalysisHandler) AppCreate(ctx *gin.Context) {
 				return
 			}
 		}
+		deps = append(deps, r)
+	}
+	sort.Slice(deps, func(i, _ int) bool {
+		return deps[i].Indirect
+	})
+	for _, r := range deps {
 		m := r.Model()
 		m.AnalysisID = analysis.ID
+		db := db.Clauses(clause.OnConflict{DoNothing: true})
 		err = db.Create(m).Error
 		if err != nil {
 			_ = ctx.Error(err)

--- a/hack/add/analysis.sh
+++ b/hack/add/analysis.sh
@@ -188,6 +188,10 @@ name: github.com/java
 indirect: "true"
 version: 8
 " >> ${file}
+echo -n "---
+name: github.com/java
+version: 8
+" >> ${file}
 #
 # Analysis
 #


### PR DESCRIPTION
TechDependencies deduplicated with direct taking priority.
The solution is to sort the dependencies with DIRECT first. Then relax the Create() to ignore dups on conflict.
The dependencies are not a memory concern.

fixes: #572 