### PR TITLE
:bug: Questionnaire validation should tolerate `order` fields having value 0

### DIFF
--- a/assessment/assessment.go
+++ b/assessment/assessment.go
@@ -128,7 +128,7 @@ func (r *Assessment) Confidence() (score int) {
 //
 // Section represents a group of questions in a questionnaire.
 type Section struct {
-	Order     uint       `json:"order" yaml:"order" binding:"required"`
+	Order     *uint      `json:"order" yaml:"order" binding:"required"`
 	Name      string     `json:"name" yaml:"name"`
 	Questions []Question `json:"questions" yaml:"questions" binding:"dive"`
 	Comment   string     `json:"comment,omitempty" yaml:"comment,omitempty"`
@@ -179,11 +179,11 @@ func (r *Section) Tags() (tags []CategorizedTag) {
 //
 // Question represents a question in a questionnaire.
 type Question struct {
-	Order       uint             `json:"order" yaml:"order" binding:"required"`
+	Order       *uint            `json:"order" yaml:"order" binding:"required"`
 	Text        string           `json:"text" yaml:"text"`
 	Explanation string           `json:"explanation" yaml:"explanation"`
-	IncludeFor  []CategorizedTag `json:"includeFor,omitempty" yaml:"includeFor,omitempty" binding:"excluded_with=ExcludeFor"`
-	ExcludeFor  []CategorizedTag `json:"excludeFor,omitempty" yaml:"excludeFor,omitempty" binding:"excluded_with=IncludeFor"`
+	IncludeFor  []CategorizedTag `json:"includeFor,omitempty" yaml:"includeFor,omitempty"`
+	ExcludeFor  []CategorizedTag `json:"excludeFor,omitempty" yaml:"excludeFor,omitempty"`
 	Answers     []Answer         `json:"answers" yaml:"answers" binding:"dive"`
 }
 
@@ -224,7 +224,7 @@ func (r *Question) Tags() (tags []CategorizedTag) {
 //
 // Answer represents an answer to a question in a questionnaire.
 type Answer struct {
-	Order         uint             `json:"order" yaml:"order" binding:"required"`
+	Order         *uint            `json:"order" yaml:"order" binding:"required"`
 	Text          string           `json:"text" yaml:"text"`
 	Risk          string           `json:"risk" yaml:"risk" binding:"oneof=red yellow green unknown"`
 	Rationale     string           `json:"rationale" yaml:"rationale"`

--- a/test/api/questionnaire/samples.go
+++ b/test/api/questionnaire/samples.go
@@ -15,26 +15,26 @@ var (
 		RiskMessages: assessment.RiskMessages{},
 		Sections: []assessment.Section{
 			{
-				Order: 1,
+				Order: uint2ptr(1),
 				Name:  "Section 1",
 				Questions: []assessment.Question{
 					{
-						Order:       1,
+						Order:       uint2ptr(1),
 						Text:        "What is your favorite color?",
 						Explanation: "Please tell us your favorite color.",
 						Answers: []assessment.Answer{
 							{
-								Order: 1,
+								Order: uint2ptr(1),
 								Text:  "Red",
 								Risk:  "red",
 							},
 							{
-								Order: 2,
+								Order: uint2ptr(2),
 								Text:  "Green",
 								Risk:  "green",
 							},
 							{
-								Order:    3,
+								Order:    uint2ptr(3),
 								Text:     "Blue",
 								Risk:     "yellow",
 								Selected: true,
@@ -47,3 +47,7 @@ var (
 	}
 	Samples = []api.Questionnaire{Questionnaire1}
 )
+
+func uint2ptr(u uint) *uint {
+	return &u
+}


### PR DESCRIPTION
The `required` binding validation can't differentiate an int with value 0 from a value that isn't present. Update `order` fields on questionnaire structs to be represented as a pointer that must not be nil. Also disable `excluded_with` validations that don't work on 0 length slices.