### PR TITLE
:bug: [MTA-1879] Fix Risk/Confidence calculations to only count responses to required questionnaires.

### DIFF
--- a/assessment/archetype.go
+++ b/assessment/archetype.go
@@ -66,16 +66,27 @@ func (r *ArchetypeResolver) AssessmentTags() (tags []model.Tag) {
 }
 
 //
+// RequiredAssessments returns the slice of assessments that are for required questionnaires.
+func (r *ArchetypeResolver) RequiredAssessments() (required []Assessment) {
+	for _, a := range r.archetype.Assessments {
+		if r.questionnaire.Required(a.QuestionnaireID) {
+			required = append(required, a)
+		}
+	}
+	return
+}
+
+//
 // Risk returns the overall risk level for the archetypes' assessments.
 func (r *ArchetypeResolver) Risk() (risk string) {
-	risk = Risk(r.archetype.Assessments)
+	risk = Risk(r.RequiredAssessments())
 	return
 }
 
 //
 // Confidence returns the archetype's overall assessment confidence score.
 func (r *ArchetypeResolver) Confidence() (confidence int) {
-	confidence = Confidence(r.archetype.Assessments)
+	confidence = Confidence(r.RequiredAssessments())
 	return
 }
 
@@ -85,7 +96,7 @@ func (r *ArchetypeResolver) Assessed() (assessed bool) {
 	if r.questionnaire == nil {
 		return
 	}
-	assessed = r.questionnaire.Assessed(r.archetype.Assessments)
+	assessed = r.questionnaire.Assessed(r.RequiredAssessments())
 	return
 }
 

--- a/assessment/questionnaire.go
+++ b/assessment/questionnaire.go
@@ -42,6 +42,12 @@ func (r *QuestionnaireResolver) cacheQuestionnaires() (err error) {
 }
 
 //
+// Required returns whether a questionnaire is required.
+func (r *QuestionnaireResolver) Required(id uint) (required bool) {
+	return r.requiredQuestionnaires.Contains(id)
+}
+
+//
 // Assessed returns whether a slice contains a completed assessment for each of the required
 // questionnaires.
 func (r *QuestionnaireResolver) Assessed(assessments []Assessment) (assessed bool) {


### PR DESCRIPTION
This PR fixes two problems:

1) Application `Risk` and `Confidence` will be `"unknown"` and `0` respectively until all required questionnaires are answered.
2) Answers to archived questionnaires will be ignored while performing the calculation.

Fixes https://issues.redhat.com/browse/MTA-1879