### PR TITLE
:bug: [MTA-1907] Questionnaires require at least one section/question/answer

### DIFF
--- a/api/questionnaire.go
+++ b/api/questionnaire.go
@@ -193,7 +193,7 @@ type Questionnaire struct {
 	Name         string                  `json:"name" yaml:"name" binding:"required"`
 	Description  string                  `json:"description" yaml:"description"`
 	Required     bool                    `json:"required" yaml:"required"`
-	Sections     []assessment.Section    `json:"sections" yaml:"sections" binding:"required,dive"`
+	Sections     []assessment.Section    `json:"sections" yaml:"sections" binding:"required,min=1,dive"`
 	Thresholds   assessment.Thresholds   `json:"thresholds" yaml:"thresholds" binding:"required"`
 	RiskMessages assessment.RiskMessages `json:"riskMessages" yaml:"riskMessages" binding:"required"`
 	Builtin      bool                    `json:"builtin,omitempty" yaml:"builtin,omitempty"`

--- a/assessment/assessment.go
+++ b/assessment/assessment.go
@@ -130,7 +130,7 @@ func (r *Assessment) Confidence() (score int) {
 type Section struct {
 	Order     *uint      `json:"order" yaml:"order" binding:"required"`
 	Name      string     `json:"name" yaml:"name"`
-	Questions []Question `json:"questions" yaml:"questions" binding:"dive"`
+	Questions []Question `json:"questions" yaml:"questions" binding:"min=1,dive"`
 	Comment   string     `json:"comment,omitempty" yaml:"comment,omitempty"`
 }
 
@@ -184,7 +184,7 @@ type Question struct {
 	Explanation string           `json:"explanation" yaml:"explanation"`
 	IncludeFor  []CategorizedTag `json:"includeFor,omitempty" yaml:"includeFor,omitempty"`
 	ExcludeFor  []CategorizedTag `json:"excludeFor,omitempty" yaml:"excludeFor,omitempty"`
-	Answers     []Answer         `json:"answers" yaml:"answers" binding:"dive"`
+	Answers     []Answer         `json:"answers" yaml:"answers" binding:"min=1,dive"`
 }
 
 //


### PR DESCRIPTION
Adds validation to ensure that Questionnaires have at least one section, each section has at least one question, and each question has at least one answer. Fixes a problem where submitting a questionnaire with a question with no answers would break the UI.

Fixes https://issues.redhat.com/browse/MTA-1907