### PR TITLE
:bug: [MTA-1883] Jira ticket links should point to UI

### DIFF
--- a/tracker/jira.go
+++ b/tracker/jira.go
@@ -75,7 +75,7 @@ func (r *JiraConnector) Create(t *model.Ticket) (err error) {
 	t.Error = false
 	t.Message = ""
 	t.Reference = i.Key
-	t.Link = i.Self
+	t.Link = fmt.Sprintf("%s/browse/%s", r.tracker.URL, i.Key)
 	t.LastUpdated = time.Now()
 	metrics.IssuesExported.Inc()
 


### PR DESCRIPTION
Fixes the Jira integration to generate and store a link to the created issue's UI location rather than its API location.

Fixes https://issues.redhat.com/browse/MTA-1883