### PR TITLE
:bug: Fixes addon POST /files failing with 401.

### DIFF
--- a/auth/role.go
+++ b/auth/role.go
@@ -29,7 +29,7 @@ var AddonRole = []string{
 	"tasks:get",
 	"tasks.report:*",
 	"tasks.bucket:get",
-	"files:get",
+	"files:*",
 	"rulesets:get",
 }
 


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/MTA-1966

The new addon uploading of command output files (also) requires POST and PATCH on files/.