### PR TITLE
:bug: Fix logged attach message.

### DIFF
--- a/addon/task.go
+++ b/addon/task.go
@@ -171,9 +171,11 @@ func (h *Task) AttachAt(f *api.File, activity int) {
 		}
 	}
 	Log.Info(
-		"Addon attached: %s",
-		"path",
-		f.Path,
+		"Addon attached.",
+		"ID",
+		f.ID,
+		"name",
+		f.Name,
 		"activity",
 		activity)
 	h.report.Attached = append(


### PR DESCRIPTION
Fix `%s` in logged attach message.  Replace _path_ with _name_ which is more relevant.
```
msg=[addon] Addon attached: %s activity=54 path=/buckets/.file/8a4978b1-69b3-48c8-b98b-5cd6093c3d0d
```
Should be:
```
msg=[addon] Addon attached. ID=433 name=analyzer-lsp.output activity=54
```