### PR TITLE
Add auth token refresh to Binding

### DIFF
--- a/addon/adapter.go
+++ b/addon/adapter.go
@@ -5,13 +5,15 @@ Tackle hub/addon integration.
 package addon
 
 import (
+	"os"
+
 	logapi "github.com/go-logr/logr"
 	"github.com/jortel/go-utils/logr"
+	"github.com/konveyor/tackle2-hub/api"
 	"github.com/konveyor/tackle2-hub/binding"
 	"github.com/konveyor/tackle2-hub/settings"
 	"github.com/konveyor/tackle2-hub/task"
 	"golang.org/x/sys/unix"
-	"os"
 )
 
 var (
@@ -138,7 +140,7 @@ func (h *Adapter) Run(addon func() error) {
 // newAdapter builds a new Addon Adapter object.
 func newAdapter() (adapter *Adapter) {
 	richClient := binding.New(Settings.Addon.Hub.URL)
-	richClient.Client.SetToken(Settings.Addon.Hub.Token)
+	richClient.Client.SetToken(api.Login{Token: Settings.Addon.Hub.Token})
 	adapter = &Adapter{
 		client: richClient.Client,
 		Task: Task{

--- a/binding/richclient.go
+++ b/binding/richclient.go
@@ -53,7 +53,7 @@ type RichClient struct {
 func New(baseUrl string) (r *RichClient) {
 	//
 	// Build REST client.
-	client := NewClient(baseUrl, "")
+	client := NewClient(baseUrl, api.Login{})
 
 	//
 	// Build RichClient.
@@ -143,6 +143,18 @@ func (r *RichClient) Login(user, password string) (err error) {
 	if err != nil {
 		return
 	}
-	r.Client.SetToken(login.Token)
+	r.Client.SetToken(login)
+	return
+}
+
+//
+// Refresh client token.
+func (r *RichClient) RefreshToken() (err error) {
+	login := api.Login{Refresh: r.Client.token.Refresh}
+	err = r.Client.Post(api.AuthRefreshRoot, &login)
+	if err != nil {
+		return
+	}
+	r.Client.SetToken(login)
 	return
 }

--- a/test/api/client/client.go
+++ b/test/api/client/client.go
@@ -3,6 +3,7 @@ package client
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/konveyor/tackle2-hub/binding"
 	"github.com/konveyor/tackle2-hub/settings"
@@ -22,6 +23,12 @@ func PrepareRichClient() (richClient *binding.RichClient) {
 		// Prepare RichClient and login to Hub API
 		richClient = binding.New(settings.Settings.Addon.Hub.URL)
 		err := richClient.Login(os.Getenv(Username), os.Getenv(Password))
+		
+		// Start goroutine with token refresh.
+		go func ()  {
+			time.Sleep(1 * time.Minute)	// TODO: base sleep time on token expiration
+			richClient.RefreshToken()
+		}()
 
 		if err != nil {
 		  panic(fmt.Sprintf("Cannot login to API: %v.", err.Error()))

--- a/test/api/client/client.go
+++ b/test/api/client/client.go
@@ -3,7 +3,6 @@ package client
 import (
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/konveyor/tackle2-hub/binding"
 	"github.com/konveyor/tackle2-hub/settings"
@@ -23,16 +22,13 @@ func PrepareRichClient() (richClient *binding.RichClient) {
 		// Prepare RichClient and login to Hub API
 		richClient = binding.New(settings.Settings.Addon.Hub.URL)
 		err := richClient.Login(os.Getenv(Username), os.Getenv(Password))
-		
-		// Start goroutine with token refresh.
-		go func ()  {
-			time.Sleep(1 * time.Minute)	// TODO: base sleep time on token expiration
-			richClient.RefreshToken()
-		}()
 
 		if err != nil {
 		  panic(fmt.Sprintf("Cannot login to API: %v.", err.Error()))
 		}
+
+		// Start goroutine with token refresh.
+		richClient.KeepFreshToken()
 	
 		// Disable HTTP requests retry for network-related errors to fail quickly.
 		richClient.Client.Retry = 0


### PR DESCRIPTION
There is an issue with long-time running tests e.g. for analysis on Konveyor with enabled Auth feature. Keycloak allows to refresh auth token, however the token for refresh was not stored in `binding.Client` and `binding.RichClient.Login` method didn't return the Login struct with Refresh and Expiry fields.

Main changes in this PR
- binding.client keeps api.Login struct instead of string token to allow use Refresh token to get a new one
- a new method KeepFreshToken was added to binding.RichClient to start a goroutine that runs the token refresh

Other options I was thinking about were
- not start goroutine with automatic token refresh, but check remaining token expiration time and potentialy refresh it in binding.client.send method after each API call (sounds strange, but typical token expiration is 5 minutes and wait time between API calls e.g. in tests is no more than few seconds, so e.g. 1 minute threshold might work)
- just update/add binding.RichClient.Login method to return the api.Login struct and let run refresh token loop outside of binding package and use binding.Client.SetToken to update it

This is a Draft PR to discuss&find the right solution with @jortel and @mansam 

For visibility @mguetta1 

Related to https://github.com/konveyor/go-konveyor-tests/issues/71