### PR TITLE
:ghost: Add questionnare required field to assessment (#588)

### DIFF
--- a/api/application.go
+++ b/api/application.go
@@ -959,7 +959,7 @@ func (h ApplicationHandler) StakeholdersUpdate(ctx *gin.Context) {
 func (h ApplicationHandler) AssessmentList(ctx *gin.Context) {
 	m := &model.Application{}
 	id := h.pk(ctx)
-	db := h.preLoad(h.DB(ctx), clause.Associations, "Assessments.Stakeholders", "Assessments.StakeholderGroups")
+	db := h.preLoad(h.DB(ctx), clause.Associations, "Assessments.Stakeholders", "Assessments.StakeholderGroups", "Assessments.Questionnaire")
 	db = db.Omit("Analyses")
 	result := db.First(m, id)
 	if result.Error != nil {

--- a/api/archetype.go
+++ b/api/archetype.go
@@ -254,7 +254,7 @@ func (h ArchetypeHandler) Update(ctx *gin.Context) {
 func (h ArchetypeHandler) AssessmentList(ctx *gin.Context) {
 	m := &model.Archetype{}
 	id := h.pk(ctx)
-	db := h.preLoad(h.DB(ctx), clause.Associations, "Assessments.Stakeholders", "Assessments.StakeholderGroups")
+	db := h.preLoad(h.DB(ctx), clause.Associations, "Assessments.Stakeholders", "Assessments.StakeholderGroups", "Assessments.Questionnaire")
 	result := db.First(m, id)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)

--- a/api/assessment.go
+++ b/api/assessment.go
@@ -164,6 +164,7 @@ type Assessment struct {
 	Status       string                  `json:"status"`
 	Thresholds   assessment.Thresholds   `json:"thresholds"`
 	RiskMessages assessment.RiskMessages `json:"riskMessages" yaml:"riskMessages"`
+	Required     bool                    `json:"required"`
 }
 
 //
@@ -187,6 +188,7 @@ func (r *Assessment) With(m *model.Assessment) {
 	}
 	a := assessment.Assessment{}
 	a.With(m)
+	r.Required = a.Questionnaire.Required
 	r.Risk = a.Risk()
 	r.Confidence = a.Confidence()
 	r.RiskMessages = a.RiskMessages


### PR DESCRIPTION
This is needed to aid UI in computing status for an assessment given a questionnaire is marked as not required. If an assessment exists for an archived questionnaire on an app or archetype, the assessment status is no longer valid & the assessment will need to be filtered from status consideration.

https://issues.redhat.com/browse/MTA-1956