### PR TITLE
:ghost: Change assessed logic for archetypes to handle zero required 

### DIFF
--- a/assessment/questionnaire.go
+++ b/assessment/questionnaire.go
@@ -47,6 +47,9 @@ func (r *QuestionnaireResolver) Required(id uint) (required bool) {
 // Assessed returns whether a slice contains a completed assessment for each of the required
 // questionnaires.
 func (r *QuestionnaireResolver) Assessed(assessments []Assessment) (assessed bool) {
+	if r.requiredQuestionnaires.Size() == 0 {
+		return false
+	}
 	answered := NewSet()
 	for _, a := range assessments {
 		if r.requiredQuestionnaires.Contains(a.QuestionnaireID) {


### PR DESCRIPTION
- Currently when no required questionnaires exist, archetypes are marked as `assessed:true` which results in additional UI code to rule out this case when calculating status. This PR aims to return `assessed: false` in the case of zero required assessments for an archetype.