### PR TITLE
:bug: token authenticate

### DIFF
--- a/auth/builtin_test.go
+++ b/auth/builtin_test.go
@@ -1,0 +1,58 @@
+package auth
+
+import "testing"
+
+func TestParseToken(t *testing.T) {
+	type args struct {
+		requestToken string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "Valid Bearer token",
+			args:    args{requestToken: "Bearer AAAAAAAAAAAAAAAAAAAAMLheAAAAAAA0%2BuSeid%2BULvsea4JtiGRiSDSJSI%3DEUifiRBkKG5E2XzMDjRfl76ZC9Ub0wnz4XsNiRVBChTYbJcE3F"},
+			want:    "AAAAAAAAAAAAAAAAAAAAMLheAAAAAAA0%2BuSeid%2BULvsea4JtiGRiSDSJSI%3DEUifiRBkKG5E2XzMDjRfl76ZC9Ub0wnz4XsNiRVBChTYbJcE3F",
+			wantErr: false,
+		},
+		{
+			name: "Empty Bearer token",
+			args: args{
+				requestToken: "Bearer ",
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "Empty request Token",
+			args: args{
+				requestToken: "",
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "Misspelled Bearer",
+			args: args{
+				requestToken: "Bearr AAAAAAAAAAAAAAAAAAAAMLheAAAAAAA0%2BuSeid%2BULvsea4JtiGRiSDSJSI%3DEUifiRBkKG5E2XzMDjRfl76ZC9Ub0wnz4XsNiRVBChTYbJcE3F",
+			},
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseToken(tt.args.requestToken)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ParseToken() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ParseToken() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/auth/builtin_test.go
+++ b/auth/builtin_test.go
@@ -27,6 +27,14 @@ func TestParseToken(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "Empty Bearer token no whitespace",
+			args: args{
+				requestToken: "Bearer",
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
 			name: "Empty request Token",
 			args: args{
 				requestToken: "",
@@ -45,13 +53,13 @@ func TestParseToken(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ParseToken(tt.args.requestToken)
+			got, err := parseToken(tt.args.requestToken)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("ParseToken() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("parseToken() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if got != tt.want {
-				t.Errorf("ParseToken() = %v, want %v", got, tt.want)
+				t.Errorf("parseToken() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/binding/client.go
+++ b/binding/client.go
@@ -636,7 +636,7 @@ func (r *Client) send(rb func() (*http.Request, error)) (response *http.Response
 		if err != nil {
 			return
 		}
-		request.Header.Set(api.Authorization, r.token.Token)
+		request.Header.Set(api.Authorization, "Bearer "+r.token.Token)
 		client := http.Client{Transport: r.transport}
 		response, err = client.Do(request)
 		if err != nil {


### PR DESCRIPTION
fix for issue / #619 
Missing Bearer token return error instead of panicking. 
Also updated [Client.send() method](https://github.com/konveyor/tackle2-hub/blob/main/binding/client.go#L639) to work with bearer tokens.