### PR TITLE
:sparkles: Add filter/sort/pagination to /tasks.

### DIFF
--- a/api/filter/filter.go
+++ b/api/filter/filter.go
@@ -127,6 +127,21 @@ func (f *Filter) With(selector ...string) (out Filter) {
 	return
 }
 
+// Renamed filter with predicate field renamed.
+func (f *Filter) Renamed(name, renamed string) (out Filter) {
+	var predicates []Predicate
+	for _, p := range f.predicates {
+		if p.Field.Value == name {
+			p.Field.Value = renamed
+		}
+		predicates = append(
+			predicates,
+			p)
+	}
+	out.predicates = predicates
+	return
+}
+
 // Delete specified fields.
 func (f *Filter) Delete(name string) (found bool) {
 	var wanted []Predicate

--- a/api/filter/filter.go
+++ b/api/filter/filter.go
@@ -127,12 +127,27 @@ func (f *Filter) With(selector ...string) (out Filter) {
 	return
 }
 
-// Renamed filter with predicate field renamed.
+// Renamed return a filter with predicate field renamed.
 func (f *Filter) Renamed(name, renamed string) (out Filter) {
 	var predicates []Predicate
 	for _, p := range f.predicates {
 		if p.Field.Value == name {
 			p.Field.Value = renamed
+		}
+		predicates = append(
+			predicates,
+			p)
+	}
+	out.predicates = predicates
+	return
+}
+
+// Revalued return a filter with the named field value replaced.
+func (f *Filter) Revalued(name string, value Value) (out Filter) {
+	var predicates []Predicate
+	for _, p := range f.predicates {
+		if p.Field.Value == name {
+			p.Value = value
 		}
 		predicates = append(
 			predicates,

--- a/api/filter/parser.go
+++ b/api/filter/parser.go
@@ -97,6 +97,17 @@ func (r *Value) Operator(operator byte) (matched bool) {
 	return
 }
 
+// Join values with operator.
+func (r *Value) Join(operator byte) (out Value) {
+	for i := range r.ByKind(LITERAL, STRING) {
+		if i > 0 {
+			out = append(out, Token{Kind: OPERATOR, Value: string(operator)})
+		}
+		out = append(out, (*r)[i])
+	}
+	return
+}
+
 // List construct.
 // Example: (red|blue|green)
 type List struct {

--- a/api/task.go
+++ b/api/task.go
@@ -109,6 +109,13 @@ func (h TaskHandler) Get(ctx *gin.Context) {
 // List godoc
 // @summary List all tasks.
 // @description List all tasks.
+// @description Filters:
+// @description - kind
+// @description - addon
+// @description - name
+// @description - locator
+// @description - state
+// @description - application.id
 // @tags tasks
 // @produce json
 // @success 200 {object} []api.Task

--- a/api/task.go
+++ b/api/task.go
@@ -122,7 +122,6 @@ func (h TaskHandler) Get(ctx *gin.Context) {
 // @router /tasks [get]
 func (h TaskHandler) List(ctx *gin.Context) {
 	resources := []Task{}
-	// Filter
 	filter, err := qf.New(ctx,
 		[]qf.Assert{
 			{Field: "kind", Kind: qf.STRING},
@@ -136,7 +135,6 @@ func (h TaskHandler) List(ctx *gin.Context) {
 		_ = ctx.Error(err)
 		return
 	}
-	// Sort
 	sort := Sort{}
 	err = sort.With(ctx, &model.Issue{})
 	if err != nil {
@@ -149,7 +147,6 @@ func (h TaskHandler) List(ctx *gin.Context) {
 	db = sort.Sorted(db)
 	filter = filter.Renamed("application.id", "applicationId")
 	db = filter.Where(db)
-
 	var m model.Task
 	var list []model.Task
 	page := Page{}


### PR DESCRIPTION
Support: https://github.com/konveyor/tackle2-ui/issues/1931

Note: UI team requested alias for _queued_ states to be supported in filter.  Ex: `?filter=state:queued`.

closes: https://github.com/konveyor/tackle2-hub/issues/641

