### PR TITLE
:bug: Update export/import CLI no-auth

### DIFF
--- a/hack/tool/tackle
+++ b/hack/tool/tackle
@@ -162,7 +162,7 @@ class TackleTool:
         self.dataDir      = dataDir
         self.Url   = tackle2Url
         # Gather Keycloak access token for Tackle
-        self.Token =  getHubToken(tackle2Url, c['username'], c['password'], tackle2Token)
+        self.Token =  getHubToken(tackle2Url, c.get('username', ''), c.get('password', ''), tackle2Token)
         self.TokenRenewAfter = int(time.time()) + TOKEN_REFRESH_SECONDS
 
         self.encKeyVerified = False
@@ -191,7 +191,7 @@ class TackleTool:
 
     def checkTokenLifetime(self):
         if self.TokenRenewAfter < int(time.time()):
-             self.Token =  getHubToken(self.Url, c['username'], c['password'], False)
+             self.Token =  getHubToken(self.Url, c.get('username', ''), c.get('password', ''), False)
              self.TokenRenewAfter = int(time.time()) + TOKEN_REFRESH_SECONDS
 
     def apiJSON(self, url, data=None, method='GET', ignoreErrors=False):


### PR DESCRIPTION
Updating export/import CLI config file parsing to not fail on parsing config file without username or password fields.

Not a blocker, but installations without auth enabled still needed keep username and password fields in config (even with a random content), after this PR they don't have to be there.