### PR TITLE
:bug: ENVAR replaced when defined.

### DIFF
--- a/addon/injector.go
+++ b/addon/injector.go
@@ -62,10 +62,15 @@ func (r *EnvInjector) inject(in any) (out any) {
 			if len(match) < 3 {
 				break
 			}
+			k := match[2]
+			v := r.env[k]
+			if v == "" {
+				break
+			}
 			node = strings.Replace(
 				node,
 				match[0],
-				r.env[match[2]],
+				v,
 				-1)
 		}
 		out = node


### PR DESCRIPTION
ENVAR replaced (only) when defined.  This prevents replacing variables not associated with ENVAR.  For example, in the addon-analyzer, requested resources are expressed in the metadata as $(var).