### PR TITLE
:bug: Pod snapshot best effort when canceled.

### DIFF
--- a/task/manager.go
+++ b/task/manager.go
@@ -255,10 +255,10 @@ func (m *Manager) Cancel(db *gorm.DB, id uint) (err error) {
 			}
 			pod, found := m.cluster.pods[path.Base(task.Pod)]
 			if found {
-				err = m.podSnapshot(task, pod)
-				if err != nil {
-					return
-				}
+				snErr := m.podSnapshot(task, pod)
+				Log.Error(
+					snErr,
+					"Snapshot not created.")
 			}
 			err = task.Cancel(m.Client)
 			if err != nil {


### PR DESCRIPTION
Pod snapshot can fail when canceling a task with _damaged_ pod.  As a result, the cancel itself should not fail.
Pods usually damaged beyond use when image pull errors.