### PR TITLE
:sparkles: Merge task (kind) data.

### DIFF
--- a/api/base.go
+++ b/api/base.go
@@ -278,6 +278,38 @@ func (h *BaseHandler) Attachment(ctx *gin.Context, name string) {
 		attachment)
 }
 
+// Merge maps B into A.
+// The B map is the authority.
+func (h *BaseHandler) Merge(a, b map[string]any) (out map[string]any) {
+	if a == nil {
+		a = map[string]any{}
+	}
+	if b == nil {
+		b = map[string]any{}
+	}
+	out = map[string]any{}
+	for k, v := range a {
+		out[k] = v
+		if bv, found := b[k]; found {
+			out[k] = bv
+			if av, cast := v.(map[string]any); cast {
+				if bv, cast := bv.(map[string]any); cast {
+					out[k] = h.Merge(av, bv)
+				} else {
+					out[k] = bv
+				}
+			}
+		}
+	}
+	for k, v := range b {
+		if _, found := a[k]; !found {
+			out[k] = v
+		}
+	}
+
+	return
+}
+
 // REST resource.
 type Resource struct {
 	ID         uint      `json:"id,omitempty" yaml:"id,omitempty"`

--- a/api/base.go
+++ b/api/base.go
@@ -311,10 +311,11 @@ func (h *BaseHandler) Merge(a, b map[string]any) (out map[string]any) {
 }
 
 // AsMap returns the object as a map.
-func (h *BaseHandler) AsMap(object any) (mp map[string]any) {
+func (h *BaseHandler) AsMap(object any) (mp map[string]any, isMap bool) {
 	b, _ := json.Marshal(object)
 	mp = make(map[string]any)
-	_ = json.Unmarshal(b, &mp)
+	err := json.Unmarshal(b, &mp)
+	isMap = err == nil
 	return
 }
 

--- a/api/base.go
+++ b/api/base.go
@@ -310,6 +310,14 @@ func (h *BaseHandler) Merge(a, b map[string]any) (out map[string]any) {
 	return
 }
 
+// AsMap returns the object as a map.
+func (h *BaseHandler) AsMap(object any) (mp map[string]any) {
+	b, _ := json.Marshal(object)
+	mp = make(map[string]any)
+	_ = json.Unmarshal(b, &mp)
+	return
+}
+
 // REST resource.
 type Resource struct {
 	ID         uint      `json:"id,omitempty" yaml:"id,omitempty"`

--- a/api/task.go
+++ b/api/task.go
@@ -671,13 +671,13 @@ func (h *TaskHandler) findRefs(ctx *gin.Context, r *Task) (err error) {
 		}
 		if r.Priority == 0 {
 			r.Priority = kind.Spec.Priority
-			mA, castA := h.AsMap(kind.Spec.Data)
-			mB, castB := r.Data.(map[string]any)
-			if castA && castB {
-				r.Data = h.Merge(mA, mB)
-			} else {
-				r.Data = mA
-			}
+		}
+		mA, castA := h.AsMap(kind.Spec.Data)
+		mB, castB := r.Data.(map[string]any)
+		if castA && castB {
+			r.Data = h.Merge(mA, mB)
+		} else {
+			r.Data = mA
 		}
 	}
 	return

--- a/api/task.go
+++ b/api/task.go
@@ -671,6 +671,14 @@ func (h *TaskHandler) findRefs(ctx *gin.Context, r *Task) (err error) {
 		}
 		if r.Priority == 0 {
 			r.Priority = kind.Spec.Priority
+			kindData := h.AsMap(kind.Spec.Data)
+			mA := kindData
+			mB, castB := r.Data.(map[string]any)
+			if castB {
+				r.Data = h.Merge(mA, mB)
+			} else {
+				r.Data = mA
+			}
 		}
 	}
 	return

--- a/api/task.go
+++ b/api/task.go
@@ -671,10 +671,9 @@ func (h *TaskHandler) findRefs(ctx *gin.Context, r *Task) (err error) {
 		}
 		if r.Priority == 0 {
 			r.Priority = kind.Spec.Priority
-			kindData := h.AsMap(kind.Spec.Data)
-			mA := kindData
+			mA, castA := h.AsMap(kind.Spec.Data)
 			mB, castB := r.Data.(map[string]any)
-			if castB {
+			if castA && castB {
 				r.Data = h.Merge(mA, mB)
 			} else {
 				r.Data = mA

--- a/api/taskgroup.go
+++ b/api/taskgroup.go
@@ -462,10 +462,9 @@ func (h *TaskGroupHandler) findRefs(ctx *gin.Context, r *TaskGroup) (err error) 
 		}
 		if r.Priority == 0 {
 			r.Priority = kind.Spec.Priority
-			kindData := h.AsMap(kind.Spec.Data)
-			mA := kindData
+			mA, castA := h.AsMap(kind.Spec.Data)
 			mB, castB := r.Data.(map[string]any)
-			if castB {
+			if castA && castB {
 				r.Data = h.Merge(mA, mB)
 			} else {
 				r.Data = mA

--- a/api/taskgroup.go
+++ b/api/taskgroup.go
@@ -462,13 +462,13 @@ func (h *TaskGroupHandler) findRefs(ctx *gin.Context, r *TaskGroup) (err error) 
 		}
 		if r.Priority == 0 {
 			r.Priority = kind.Spec.Priority
-			mA, castA := h.AsMap(kind.Spec.Data)
-			mB, castB := r.Data.(map[string]any)
-			if castA && castB {
-				r.Data = h.Merge(mA, mB)
-			} else {
-				r.Data = mA
-			}
+		}
+		mA, castA := h.AsMap(kind.Spec.Data)
+		mB, castB := r.Data.(map[string]any)
+		if castA && castB {
+			r.Data = h.Merge(mA, mB)
+		} else {
+			r.Data = mA
 		}
 	}
 	return

--- a/api/taskgroup.go
+++ b/api/taskgroup.go
@@ -132,7 +132,7 @@ func (h TaskGroupHandler) Create(ctx *gin.Context) {
 			return
 		}
 	case tasking.Ready:
-		err := m.Propagate()
+		err := h.Propagate(m)
 		if err != nil {
 			return
 		}
@@ -217,7 +217,7 @@ func (h TaskGroupHandler) Update(ctx *gin.Context) {
 				return
 			}
 		}
-		err := m.Propagate()
+		err := h.Propagate(m)
 		if err != nil {
 			return
 		}
@@ -462,8 +462,41 @@ func (h *TaskGroupHandler) findRefs(ctx *gin.Context, r *TaskGroup) (err error) 
 		}
 		if r.Priority == 0 {
 			r.Priority = kind.Spec.Priority
+			kindData := h.AsMap(kind.Spec.Data)
+			mA := kindData
+			mB, castB := r.Data.(map[string]any)
+			if castB {
+				r.Data = h.Merge(mA, mB)
+			} else {
+				r.Data = mA
+			}
 		}
 	}
+	return
+}
+
+// Propagate group data into the task.
+func (h *TaskGroupHandler) Propagate(m *model.TaskGroup) (err error) {
+	for i := range m.Tasks {
+		task := &m.Tasks[i]
+		task.Kind = m.Kind
+		task.Addon = m.Addon
+		task.Extensions = m.Extensions
+		task.Priority = m.Priority
+		task.Policy = m.Policy
+		task.State = m.State
+		task.SetBucket(m.BucketID)
+		if m.Data.Any != nil {
+			mA, castA := m.Data.Any.(map[string]any)
+			mB, castB := task.Data.Any.(map[string]any)
+			if castA && castB {
+				task.Data.Any = h.Merge(mA, mB)
+			} else {
+				task.Data.Any = m.Data
+			}
+		}
+	}
+
 	return
 }
 

--- a/migration/v14/model/core.go
+++ b/migration/v14/model/core.go
@@ -228,67 +228,6 @@ type TaskGroup struct {
 	Tasks      []Task     `gorm:"constraint:OnDelete:CASCADE"`
 }
 
-// Propagate group data into the task.
-func (m *TaskGroup) Propagate() (err error) {
-	for i := range m.Tasks {
-		task := &m.Tasks[i]
-		task.Kind = m.Kind
-		task.Addon = m.Addon
-		task.Extensions = m.Extensions
-		task.Priority = m.Priority
-		task.Policy = m.Policy
-		task.State = m.State
-		task.SetBucket(m.BucketID)
-		if m.Data.Any != nil {
-			mA, castA := m.Data.Any.(map[string]any)
-			mB, castB := task.Data.Any.(map[string]any)
-			if castA && castB {
-				task.Data.Any = m.merge(mA, mB)
-			} else {
-				task.Data.Any = m.Data
-			}
-		}
-	}
-
-	return
-}
-
-// merge maps B into A.
-// The B map is the authority.
-func (m *TaskGroup) merge(a, b Map) (out Map) {
-	if a == nil {
-		a = Map{}
-	}
-	if b == nil {
-		b = Map{}
-	}
-	out = Map{}
-	//
-	// Merge-in elements found in B and in A.
-	for k, v := range a {
-		out[k] = v
-		if bv, found := b[k]; found {
-			out[k] = bv
-			if av, cast := v.(Map); cast {
-				if bv, cast := bv.(Map); cast {
-					out[k] = m.merge(av, bv)
-				} else {
-					out[k] = bv
-				}
-			}
-		}
-	}
-	//
-	// Add elements found only in B.
-	for k, v := range b {
-		if _, found := a[k]; !found {
-			out[k] = v
-		}
-	}
-
-	return
-}
-
 // Proxy configuration.
 // kind = (http|https)
 type Proxy struct {


### PR DESCRIPTION
Merge Task (kind) data into Task model data.  This is to support defining data properties in the task kind to be inherrited by models. Properties in Task (model) data have priority.
In the interest of keeping models simple, moves TaskGroup.Propagate() to the api.  No need for it to be in the model. To support this, the Merge() method was also moved to BaseHandler as it is used by multiple handlers.

Example:
```
---
kind: Task
apiVersion: tackle.konveyor.io/v1alpha1
metadata:
  namespace: konveyor-tackle
  name: tech-discovery
spec:
  data:
    mode:
      discovery: true
    rules:
      labels:
        included:
          - techA
          - techB
```