### PR TITLE
:bug: Fix task filtering and sorting.

### DIFF
--- a/api/filter/filter.go
+++ b/api/filter/filter.go
@@ -332,11 +332,16 @@ func (f *Field) Expand() (expanded []Field) {
 // split field name.
 // format: resource.name
 // The resource may be "" (anonymous).
+// The (.) separator is escaped when preceded by (\).
 func (f *Field) split() (relation string, name string) {
 	s := f.Field.Value
 	mark := strings.Index(s, ".")
 	if mark == -1 {
 		name = s
+		return
+	}
+	if mark > 0 && s[mark-1] == '\\' {
+		name = s[:mark-1] + s[mark:]
 		return
 	}
 	relation = s[:mark]

--- a/api/task.go
+++ b/api/task.go
@@ -114,11 +114,13 @@ func (h TaskHandler) Get(ctx *gin.Context) {
 // @description List all tasks.
 // @description Filters:
 // @description - kind
+// @description - createUser
 // @description - addon
 // @description - name
 // @description - locator
 // @description - state
 // @description - application.id
+// @description - application.name
 // @description The state=queued is an alias for queued states.
 // @tags tasks
 // @produce json
@@ -130,12 +132,14 @@ func (h TaskHandler) List(ctx *gin.Context) {
 	filter, err := qf.New(ctx,
 		[]qf.Assert{
 			{Field: "id", Kind: qf.LITERAL},
+			{Field: "createUser", Kind: qf.STRING},
 			{Field: "kind", Kind: qf.STRING},
 			{Field: "addon", Kind: qf.STRING},
 			{Field: "name", Kind: qf.STRING},
 			{Field: "locator", Kind: qf.STRING},
 			{Field: "state", Kind: qf.STRING},
 			{Field: "application.id", Kind: qf.STRING},
+			{Field: "application.name", Kind: qf.STRING},
 		})
 	if err != nil {
 		_ = ctx.Error(err)
@@ -161,8 +165,10 @@ func (h TaskHandler) List(ctx *gin.Context) {
 	}
 	filter = filter.Renamed("application.id", "application__id")
 	filter = filter.Renamed("application.name", "application__name")
+	filter = filter.Renamed("createUser", "task\\.createUser")
 	// sort
 	sort := Sort{}
+	sort.Add("task.createUser", "createUser")
 	sort.Add("application__name", "application.name")
 	err = sort.With(ctx, &model.Task{})
 	if err != nil {

--- a/api/task.go
+++ b/api/task.go
@@ -166,9 +166,13 @@ func (h TaskHandler) List(ctx *gin.Context) {
 	filter = filter.Renamed("application.id", "application__id")
 	filter = filter.Renamed("application.name", "application__name")
 	filter = filter.Renamed("createUser", "task\\.createUser")
+	filter = filter.Renamed("id", "task\\.id")
+	filter = filter.Renamed("name", "task\\.name")
 	// sort
 	sort := Sort{}
+	sort.Add("task.id", "id")
 	sort.Add("task.createUser", "createUser")
+	sort.Add("task.name", "name")
 	sort.Add("application__name", "application.name")
 	err = sort.With(ctx, &model.Task{})
 	if err != nil {

--- a/api/task.go
+++ b/api/task.go
@@ -173,6 +173,7 @@ func (h TaskHandler) List(ctx *gin.Context) {
 	sort.Add("task.id", "id")
 	sort.Add("task.createUser", "createUser")
 	sort.Add("task.name", "name")
+	sort.Add("application__id", "application.id")
 	sort.Add("application__name", "application.name")
 	err = sort.With(ctx, &model.Task{})
 	if err != nil {


### PR DESCRIPTION
Fix issues reported [here](https://github.com/konveyor/tackle2-ui/issues/1931#issuecomment-2163782267).
1. sorting seems to work only for `id` field i.e. 
2. filtering not supported for `createUser` and `id` fields( both listed in the enhancement)
3.  application name is missing in the response and in filtering. Filtering by application ID works but this is not so nice.
4. `priority` is missing in the response and in the filtering
5.  for `kind`  the filtering is supported by the server but it seems it's not included in the response

---

Filter and sorting: needed to support GORM join queries which qualifies fields by table.

Example: For a task query joined with application, produces all of the task fields qualified as table.column:
```
SELECT task.id, task.name ...
```
And the (joined) application fields prefixed with `APPLICATION__`
```
SELECT APPLICATION__ID, APPLICATION__NAME ...
```