### PR TITLE
:sparkles: Add /tasks patch; return 202 for task actions and updates.

### DIFF
--- a/api/base.go
+++ b/api/base.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"bytes"
 	"database/sql"
 	"encoding/json"
 	"errors"
@@ -96,33 +95,6 @@ func (h *BaseHandler) pk(ctx *gin.Context) (id uint) {
 	s := ctx.Param(ID)
 	n, _ := strconv.Atoi(s)
 	id = uint(n)
-	return
-}
-
-// modBody updates the body using the `mod` function.
-//  1. read the body.
-//  2. mod()
-//  3. write body.
-func (h *BaseHandler) modBody(
-	ctx *gin.Context,
-	r interface{},
-	mod func(bool) error) (err error) {
-	//
-	withBody := false
-	if ctx.Request.ContentLength > 0 {
-		withBody = true
-		err = h.Bind(ctx, r)
-		if err != nil {
-			return
-		}
-	}
-	err = mod(withBody)
-	if err != nil {
-		return
-	}
-	b, _ := json.Marshal(r)
-	bfr := bytes.NewBuffer(b)
-	ctx.Request.Body = io.NopCloser(bfr)
 	return
 }
 

--- a/api/task.go
+++ b/api/task.go
@@ -414,10 +414,12 @@ func (h TaskHandler) Submit(ctx *gin.Context) {
 	}
 	r := &Task{}
 	r.With(&m)
-	err = h.Bind(ctx, r)
-	if err != nil {
-		_ = ctx.Error(err)
-		return
+	if ctx.Request.ContentLength > 0 {
+		err = h.Bind(ctx, r)
+		if err != nil {
+			_ = ctx.Error(err)
+			return
+		}
 	}
 	rtx := WithContext(ctx)
 	task := &tasking.Task{}

--- a/api/taskgroup.go
+++ b/api/taskgroup.go
@@ -206,6 +206,7 @@ func (h TaskGroupHandler) Update(ctx *gin.Context) {
 		"Bucket")
 	m = r.Model()
 	m.ID = id
+	m.UpdateUser = h.CurrentUser(ctx)
 	switch m.State {
 	case "", tasking.Created:
 		err = db.Save(m).Error
@@ -237,6 +238,7 @@ func (h TaskGroupHandler) Update(ctx *gin.Context) {
 		for i := range m.Tasks {
 			task := &tasking.Task{}
 			task.With(&m.Tasks[i])
+			task.CreateUser = h.CurrentUser(ctx)
 			err = rtx.TaskManager.Create(h.DB(ctx), task)
 			if err != nil {
 				_ = ctx.Error(err)

--- a/api/taskgroup.go
+++ b/api/taskgroup.go
@@ -35,6 +35,7 @@ func (h TaskGroupHandler) AddRoutes(e *gin.Engine) {
 	routeGroup.GET(TaskGroupsRoot+"/", h.List)
 	routeGroup.POST(TaskGroupsRoot, h.Create)
 	routeGroup.PUT(TaskGroupRoot, h.Update)
+	routeGroup.PATCH(TaskGroupRoot, Transaction, h.Update)
 	routeGroup.GET(TaskGroupRoot, h.Get)
 	routeGroup.PUT(TaskGroupSubmitRoot, Transaction, h.Submit)
 	routeGroup.DELETE(TaskGroupRoot, h.Delete)

--- a/binding/task.go
+++ b/binding/task.go
@@ -38,8 +38,8 @@ func (h *Task) Update(r *api.Task) (err error) {
 }
 
 // Patch a Task.
-func (h *Task) Patch(r *api.Task) (err error) {
-	path := Path(api.TaskRoot).Inject(Params{api.ID: r.ID})
+func (h *Task) Patch(id uint, r any) (err error) {
+	path := Path(api.TaskRoot).Inject(Params{api.ID: id})
 	err = h.client.Patch(path, r)
 	return
 }

--- a/binding/task.go
+++ b/binding/task.go
@@ -37,6 +37,13 @@ func (h *Task) Update(r *api.Task) (err error) {
 	return
 }
 
+// Patch a Task.
+func (h *Task) Patch(r *api.Task) (err error) {
+	path := Path(api.TaskRoot).Inject(Params{api.ID: r.ID})
+	err = h.client.Patch(path, r)
+	return
+}
+
 // Delete a Task.
 func (h *Task) Delete(id uint) (err error) {
 	err = h.client.Delete(Path(api.TaskRoot).Inject(Params{api.ID: id}))

--- a/task/manager.go
+++ b/task/manager.go
@@ -150,6 +150,7 @@ func (m *Manager) Create(db *gorm.DB, requested *Task) (err error) {
 		task.TTL = requested.TTL
 		task.Data = requested.Data
 		task.ApplicationID = requested.ApplicationID
+		task.BucketID = requested.BucketID
 	default:
 		err = &BadRequest{
 			Reason: "state must be (Created|Ready)",
@@ -193,6 +194,7 @@ func (m *Manager) Update(db *gorm.DB, requested *Task) (err error) {
 			Postponed:
 			task.UpdateUser = requested.UpdateUser
 			task.Name = requested.Name
+			task.Locator = requested.Locator
 			task.Data = requested.Data
 			task.Priority = requested.Priority
 			task.Policy = requested.Policy

--- a/task/manager.go
+++ b/task/manager.go
@@ -197,14 +197,8 @@ func (m *Manager) Update(db *gorm.DB, requested *Task) (err error) {
 			task.Priority = requested.Priority
 			task.Policy = requested.Policy
 			task.TTL = requested.TTL
-		case Running,
-			Succeeded,
-			Failed,
-			Canceled:
-			err = &BadRequest{
-				Reason: "state must not be (Running|Succeeded|Failed|Canceled)",
-			}
-			return
+		default:
+			// discarded.
 		}
 		err = db.Save(task).Error
 		if err != nil {
@@ -247,9 +241,7 @@ func (m *Manager) Cancel(db *gorm.DB, id uint) (err error) {
 			case Succeeded,
 				Failed,
 				Canceled:
-				err = &BadRequest{
-					Reason: "state must not be (Succeeded|Failed|Canceled)",
-				}
+				// discarded.
 				return
 			default:
 			}

--- a/test/api/task/api_test.go
+++ b/test/api/task/api_test.go
@@ -49,7 +49,7 @@ func TestTaskCRUD(t *testing.T) {
 			p := &TaskPatch{}
 			p.Name = "patched " + r.Name
 			p.Policy.PreemptEnabled = true
-			err = Task.Patch(&r)
+			err = Task.Patch(r.ID, p)
 			if err != nil {
 				t.Errorf(err.Error())
 			}
@@ -57,14 +57,14 @@ func TestTaskCRUD(t *testing.T) {
 			if err != nil {
 				t.Errorf(err.Error())
 			}
-			if got.Name != r.Name {
-				t.Errorf("Different response error. Got %s, expected %s", got.Name, r.Name)
+			if got.Name != p.Name {
+				t.Errorf("Different response error. Got %s, expected %s", got.Name, p.Name)
 			}
 			if got.Policy.PreemptEnabled != p.Policy.PreemptEnabled {
 				t.Errorf(
 					"Different response error. Got %v, expected %v",
 					got.Policy.PreemptEnabled,
-					r.Policy.PreemptEnabled)
+					p.Policy.PreemptEnabled)
 			}
 
 			// Delete.

--- a/test/api/task/api_test.go
+++ b/test/api/task/api_test.go
@@ -62,7 +62,7 @@ func TestTaskCRUD(t *testing.T) {
 			}
 			if got.Policy.PreemptEnabled != p.Policy.PreemptEnabled {
 				t.Errorf(
-					"Different response error. Got %s, expected %s",
+					"Different response error. Got %v, expected %v",
 					got.Policy.PreemptEnabled,
 					r.Policy.PreemptEnabled)
 			}

--- a/test/api/task/api_test.go
+++ b/test/api/task/api_test.go
@@ -39,6 +39,34 @@ func TestTaskCRUD(t *testing.T) {
 				t.Errorf("Different response error. Got %s, expected %s", got.Name, r.Name)
 			}
 
+			// patch.
+			type TaskPatch struct {
+				Name   string `json:"name"`
+				Policy struct {
+					PreemptEnabled bool `json:"preemptEnabled"`
+				}
+			}
+			p := &TaskPatch{}
+			p.Name = "patched " + r.Name
+			p.Policy.PreemptEnabled = true
+			err = Task.Patch(&r)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+			got, err = Task.Get(r.ID)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+			if got.Name != r.Name {
+				t.Errorf("Different response error. Got %s, expected %s", got.Name, r.Name)
+			}
+			if got.Policy.PreemptEnabled != p.Policy.PreemptEnabled {
+				t.Errorf(
+					"Different response error. Got %s, expected %s",
+					got.Policy.PreemptEnabled,
+					r.Policy.PreemptEnabled)
+			}
+
 			// Delete.
 			err = Task.Delete(r.ID)
 			if err != nil {


### PR DESCRIPTION
Adds patch endpoints for:
- /tasks
- /taskgroups

The Update() methods on both Task and Taskgroup support both PUT and PATCH depending on the http method. They also support delegation from Submit() which mainly sets the state=Ready.

Updated to return 202 (accepted) on success.
- put /tasks/:id
- patch /tasks/:id
- put /tasks/:id/cancel

BaseHandler.modBody() removed.

Add patch support to binding client.

Adds API test for task patch.

closes: #661 
closes: #662 