### PR TITLE
:ghost: using any instead of interface{} introduced in 1.18.

### DIFF
--- a/addon/task.go
+++ b/addon/task.go
@@ -88,7 +88,7 @@ func (h *Task) Data() (d any) {
 }
 
 // DataWith populates the addon data object.
-func (h *Task) DataWith(object interface{}) (err error) {
+func (h *Task) DataWith(object any) (err error) {
 	b, _ := json.Marshal(h.task.Data)
 	err = json.Unmarshal(b, object)
 	return
@@ -114,7 +114,7 @@ func (h *Task) Succeeded() {
 
 // Failed report addon failed.
 // The reason can be a printf style format.
-func (h *Task) Failed(reason string, v ...interface{}) {
+func (h *Task) Failed(reason string, v ...any) {
 	reason = fmt.Sprintf(reason, v...)
 	h.Error(api.TaskError{
 		Severity:    "Error",
@@ -128,7 +128,7 @@ func (h *Task) Failed(reason string, v ...interface{}) {
 }
 
 // Errorf report addon error.
-func (h *Task) Errorf(severity, description string, v ...interface{}) {
+func (h *Task) Errorf(severity, description string, v ...any) {
 	h.Error(api.TaskError{
 		Severity:    severity,
 		Description: fmt.Sprintf(description, v...),
@@ -153,7 +153,7 @@ func (h *Task) Error(error ...api.TaskError) {
 
 // Activity report addon activity.
 // The description can be a printf style format.
-func (h *Task) Activity(entry string, v ...interface{}) {
+func (h *Task) Activity(entry string, v ...any) {
 	entry = fmt.Sprintf(entry, v...)
 	lines := strings.Split(entry, "\n")
 	for i := range lines {

--- a/api/analysis.go
+++ b/api/analysis.go
@@ -2368,7 +2368,7 @@ type DepAppReport struct {
 }
 
 // FactMap map.
-type FactMap map[string]interface{}
+type FactMap map[string]any
 
 // IssueWriter used to create a file containing issues.
 type IssueWriter struct {

--- a/api/application.go
+++ b/api/application.go
@@ -683,7 +683,7 @@ func (h ApplicationHandler) FactList(ctx *gin.Context, key FactKey) {
 	facts := FactMap{}
 	for i := range list {
 		fact := &list[i]
-		var v interface{}
+		var v any
 		_ = json.Unmarshal(fact.Value, &v)
 		facts[fact.Key] = v
 	}
@@ -730,7 +730,7 @@ func (h ApplicationHandler) FactGet(ctx *gin.Context) {
 		return
 	}
 
-	var v interface{}
+	var v any
 	_ = json.Unmarshal(list[0].Value, &v)
 	h.Respond(ctx, http.StatusOK, v)
 }
@@ -929,7 +929,7 @@ func (h ApplicationHandler) StakeholdersUpdate(ctx *gin.Context) {
 	}
 
 	db = h.DB(ctx).Model(m).Omit(clause.Associations, "BucketID")
-	result = db.Updates(map[string]interface{}{"OwnerID": r.ownerID()})
+	result = db.Updates(map[string]any{"OwnerID": r.ownerID()})
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)
 		return
@@ -1246,9 +1246,9 @@ type Repository struct {
 
 // Fact REST nested resource.
 type Fact struct {
-	Key    string      `json:"key"`
-	Value  interface{} `json:"value"`
-	Source string      `json:"source"`
+	Key    string `json:"key"`
+	Value  any    `json:"value"`
+	Source string `json:"source"`
 }
 
 func (r *Fact) With(m *model.Fact) {

--- a/api/base.go
+++ b/api/base.go
@@ -85,7 +85,7 @@ func (h *BaseHandler) preLoad(db *gorm.DB, fields ...string) (tx *gorm.DB) {
 }
 
 // fields builds a map of fields.
-func (h *BaseHandler) fields(m interface{}) (mp map[string]interface{}) {
+func (h *BaseHandler) fields(m any) (mp map[string]any) {
 	mp = reflect.Fields(m)
 	return
 }
@@ -125,7 +125,7 @@ func (h *BaseHandler) HasScope(ctx *gin.Context, scope string) (b bool) {
 
 // Bind based on Content-Type header.
 // Opinionated towards json.
-func (h *BaseHandler) Bind(ctx *gin.Context, r interface{}) (err error) {
+func (h *BaseHandler) Bind(ctx *gin.Context, r any) (err error) {
 	switch ctx.ContentType() {
 	case "",
 		binding.MIMEPOSTForm,
@@ -144,7 +144,7 @@ func (h *BaseHandler) Bind(ctx *gin.Context, r interface{}) (err error) {
 
 // BindJSON attempts to bind a request body to a struct, assuming that the body is JSON.
 // Binding is strict: unknown fields in the input will cause binding to fail.
-func (h *BaseHandler) BindJSON(ctx *gin.Context, r interface{}) (err error) {
+func (h *BaseHandler) BindJSON(ctx *gin.Context, r any) (err error) {
 	if ctx.Request == nil || ctx.Request.Body == nil {
 		err = errors.New("invalid request")
 		return
@@ -162,7 +162,7 @@ func (h *BaseHandler) BindJSON(ctx *gin.Context, r interface{}) (err error) {
 
 // BindYAML attempts to bind a request body to a struct, assuming that the body is YAML.
 // Binding is strict: unknown fields in the input will cause binding to fail.
-func (h *BaseHandler) BindYAML(ctx *gin.Context, r interface{}) (err error) {
+func (h *BaseHandler) BindYAML(ctx *gin.Context, r any) (err error) {
 	if ctx.Request == nil || ctx.Request.Body == nil {
 		err = errors.New("invalid request")
 		return
@@ -179,7 +179,7 @@ func (h *BaseHandler) BindYAML(ctx *gin.Context, r interface{}) (err error) {
 }
 
 // Validate that the struct field values obey the binding field tags.
-func (h *BaseHandler) Validate(r interface{}) (err error) {
+func (h *BaseHandler) Validate(r any) (err error) {
 	if binding.Validator == nil {
 		return
 	}
@@ -220,7 +220,7 @@ func (h *BaseHandler) Status(ctx *gin.Context, code int) {
 }
 
 // Respond sets the response.
-func (h *BaseHandler) Respond(ctx *gin.Context, code int, r interface{}) {
+func (h *BaseHandler) Respond(ctx *gin.Context, code int, r any) {
 	rtx := WithContext(ctx)
 	rtx.Respond(code, r)
 }
@@ -308,14 +308,14 @@ func (r *Resource) With(m *model.Model) {
 }
 
 // ref with id and named model.
-func (r *Resource) ref(id uint, m interface{}) (ref Ref) {
+func (r *Resource) ref(id uint, m any) (ref Ref) {
 	ref.ID = id
 	ref.Name = r.nameOf(m)
 	return
 }
 
 // refPtr with id and named model.
-func (r *Resource) refPtr(id *uint, m interface{}) (ref *Ref) {
+func (r *Resource) refPtr(id *uint, m any) (ref *Ref) {
 	if id == nil {
 		return
 	}
@@ -334,7 +334,7 @@ func (r *Resource) idPtr(ref *Ref) (id *uint) {
 }
 
 // nameOf model.
-func (r *Resource) nameOf(m interface{}) (name string) {
+func (r *Resource) nameOf(m any) (name string) {
 	name = reflect.NameOf(m)
 	return
 }
@@ -406,7 +406,7 @@ type Sort = sort.Sort
 
 // Decoder binding decoder.
 type Decoder interface {
-	Decode(r interface{}) (err error)
+	Decode(r any) (err error)
 }
 
 // Cursor Paginated rows iterator.
@@ -419,7 +419,7 @@ type Cursor struct {
 }
 
 // Next returns true when has next row.
-func (r *Cursor) Next(m interface{}) (next bool) {
+func (r *Cursor) Next(m any) (next bool) {
 	if r.Error != nil {
 		next = true
 		return

--- a/api/batch.go
+++ b/api/batch.go
@@ -55,7 +55,7 @@ func (h BatchHandler) TagsCreate(ctx *gin.Context) {
 }
 
 func (h BatchHandler) create(ctx *gin.Context, create gin.HandlerFunc) {
-	var resources []interface{}
+	var resources []any
 	err := h.Bind(ctx, &resources)
 	if err != nil {
 		_ = ctx.Error(err)

--- a/api/context.go
+++ b/api/context.go
@@ -30,7 +30,7 @@ type Context struct {
 // Response values.
 type Response struct {
 	Status int
-	Body   interface{}
+	Body   any
 }
 
 // Status sets the values to respond to the request with.
@@ -42,7 +42,7 @@ func (r *Context) Status(status int) {
 }
 
 // Respond sets the values to respond to the request with.
-func (r *Context) Respond(status int, body interface{}) {
+func (r *Context) Respond(status int, body any) {
 	r.Response = Response{
 		Status: status,
 		Body:   body,

--- a/api/error.go
+++ b/api/error.go
@@ -37,7 +37,7 @@ type BatchError struct {
 
 type BatchErrorItem struct {
 	Error    error
-	Resource interface{}
+	Resource any
 }
 
 func (r BatchError) Error() string {

--- a/api/filter/error.go
+++ b/api/filter/error.go
@@ -17,7 +17,7 @@ func (r *Error) Is(err error) (matched bool) {
 }
 
 // Errorf build error.
-func Errorf(s string, v ...interface{}) (err error) {
+func Errorf(s string, v ...any) (err error) {
 	err = &Error{fmt.Sprintf(s, v...)}
 	return
 }

--- a/api/filter/filter.go
+++ b/api/filter/filter.go
@@ -252,7 +252,7 @@ func (f *Field) Where(in *gorm.DB) (out *gorm.DB) {
 
 // SQL builds SQL.
 // Returns statement and values (for ?).
-func (f *Field) SQL() (s string, vList []interface{}) {
+func (f *Field) SQL() (s string, vList []any) {
 	name := f.Name()
 	switch len(f.Value) {
 	case 0:
@@ -296,7 +296,7 @@ func (f *Field) SQL() (s string, vList []interface{}) {
 			s += ")"
 		default:
 			values := f.Value.ByKind(LITERAL, STRING)
-			var collection []interface{}
+			var collection []any
 			for i := range values {
 				v := AsValue(values[i])
 				collection = append(collection, v)
@@ -395,7 +395,7 @@ func (r *Assert) assert(p *Predicate) (err error) {
 }
 
 // AsValue returns the real value.
-func AsValue(t Token) (object interface{}) {
+func AsValue(t Token) (object any) {
 	v := t.Value
 	object = v
 	switch t.Kind {

--- a/api/filter/filter_test.go
+++ b/api/filter/filter_test.go
@@ -230,7 +230,7 @@ func TestFilter(t *testing.T) {
 	}))
 	sql, values := f.SQL()
 	g.Expect(sql).To(gomega.Equal("category IN ?"))
-	g.Expect(values[0]).To(gomega.Equal([]interface{}{"a", "b", "c"}))
+	g.Expect(values[0]).To(gomega.Equal([]any{"a", "b", "c"}))
 
 	f, found = filter.Field("name.first")
 	g.Expect(found).To(gomega.BeTrue())
@@ -265,7 +265,7 @@ func TestFilter(t *testing.T) {
 	g.Expect(found).To(gomega.BeTrue())
 	sql, values = f.SQL()
 	g.Expect(sql).To(gomega.Equal("(category LIKE ? OR category LIKE ?)"))
-	g.Expect(values).To(gomega.Equal([]interface{}{"a", "b"}))
+	g.Expect(values).To(gomega.Equal([]any{"a", "b"}))
 }
 
 func TestValidation(t *testing.T) {

--- a/api/import.go
+++ b/api/import.go
@@ -409,7 +409,7 @@ func (h ImportHandler) applicationFromRow(fileName string, row []string) (app mo
 }
 
 // Import REST resource.
-type Import map[string]interface{}
+type Import map[string]any
 
 // ImportSummary REST resource.
 type ImportSummary struct {

--- a/api/questionnaire.go
+++ b/api/questionnaire.go
@@ -167,9 +167,9 @@ func (h QuestionnaireHandler) Update(ctx *gin.Context) {
 	updated := r.Model()
 	updated.ID = id
 	updated.UpdateUser = h.CurrentUser(ctx)
-	var fields map[string]interface{}
+	var fields map[string]any
 	if m.Builtin() {
-		fields = map[string]interface{}{
+		fields = map[string]any{
 			"updateUser": updated.UpdateUser,
 			"required":   updated.Required,
 		}

--- a/api/reflect/fields.go
+++ b/api/reflect/fields.go
@@ -6,9 +6,9 @@ import (
 )
 
 // Fields returns a map of fields.
-func Fields(m interface{}) (mp map[string]interface{}) {
-	var inspect func(r interface{})
-	inspect = func(r interface{}) {
+func Fields(m any) (mp map[string]any) {
+	var inspect func(r any)
+	inspect = func(r any) {
 		mt := reflect.TypeOf(r)
 		mv := reflect.ValueOf(r)
 		if mt.Kind() == reflect.Ptr {
@@ -55,13 +55,13 @@ func Fields(m interface{}) (mp map[string]interface{}) {
 			}
 		}
 	}
-	mp = map[string]interface{}{}
+	mp = map[string]any{}
 	inspect(m)
 	return
 }
 
 // NameOf returns the name of a model.
-func NameOf(m interface{}) (name string) {
+func NameOf(m any) (name string) {
 	mt := reflect.TypeOf(m)
 	mv := reflect.ValueOf(m)
 	if mv.IsNil() {

--- a/api/setting.go
+++ b/api/setting.go
@@ -229,8 +229,8 @@ func (h SettingHandler) Delete(ctx *gin.Context) {
 
 // Setting REST Resource
 type Setting struct {
-	Key   string      `json:"key"`
-	Value interface{} `json:"value"`
+	Key   string `json:"key"`
+	Value any    `json:"value"`
 }
 
 func (r *Setting) With(m *model.Setting) {

--- a/api/ticket.go
+++ b/api/ticket.go
@@ -194,4 +194,4 @@ func (r *Ticket) Model() (m *model.Ticket) {
 	return
 }
 
-type Fields map[string]interface{}
+type Fields map[string]any

--- a/auth/builtin.go
+++ b/auth/builtin.go
@@ -86,7 +86,7 @@ func (r *Builtin) Authenticate(request *Request) (jwToken *jwt.Token, err error)
 	}
 	jwToken, err = jwt.Parse(
 		token,
-		func(jwToken *jwt.Token) (secret interface{}, err error) {
+		func(jwToken *jwt.Token) (secret any, err error) {
 			_, cast := jwToken.Method.(*jwt.SigningMethodHMAC)
 			if !cast {
 				err = liberr.Wrap(&NotAuthenticated{Token: token})

--- a/binding/application.go
+++ b/binding/application.go
@@ -239,7 +239,7 @@ func (h *AppFacts) List() (facts api.FactMap, err error) {
 }
 
 // Get a fact.
-func (h *AppFacts) Get(name string, value interface{}) (err error) {
+func (h *AppFacts) Get(name string, value any) (err error) {
 	key := api.FactKey(name)
 	key.Qualify(h.source)
 	path := Path(api.ApplicationFactRoot).Inject(
@@ -252,7 +252,7 @@ func (h *AppFacts) Get(name string, value interface{}) (err error) {
 }
 
 // Set a fact (created as needed).
-func (h *AppFacts) Set(name string, value interface{}) (err error) {
+func (h *AppFacts) Set(name string, value any) (err error) {
 	key := api.FactKey(name)
 	key.Qualify(h.source)
 	path := Path(api.ApplicationFactRoot).Inject(

--- a/binding/client.go
+++ b/binding/client.go
@@ -47,7 +47,7 @@ func (r *Filter) Param() (p Param) {
 }
 
 // Params mapping.
-type Params map[string]interface{}
+type Params map[string]any
 
 // Path API path.
 type Path string
@@ -103,7 +103,7 @@ func (r *Client) Reset() {
 }
 
 // Get a resource.
-func (r *Client) Get(path string, object interface{}, params ...Param) (err error) {
+func (r *Client) Get(path string, object any, params ...Param) (err error) {
 	request := func() (request *http.Request, err error) {
 		request = &http.Request{
 			Header: http.Header{},
@@ -149,7 +149,7 @@ func (r *Client) Get(path string, object interface{}, params ...Param) (err erro
 }
 
 // Post a resource.
-func (r *Client) Post(path string, object interface{}) (err error) {
+func (r *Client) Post(path string, object any) (err error) {
 	request := func() (request *http.Request, err error) {
 		bfr, err := json.Marshal(object)
 		if err != nil {
@@ -194,7 +194,7 @@ func (r *Client) Post(path string, object interface{}) (err error) {
 }
 
 // Put a resource.
-func (r *Client) Put(path string, object interface{}, params ...Param) (err error) {
+func (r *Client) Put(path string, object any, params ...Param) (err error) {
 	request := func() (request *http.Request, err error) {
 		bfr, err := json.Marshal(object)
 		if err != nil {
@@ -247,7 +247,7 @@ func (r *Client) Put(path string, object interface{}, params ...Param) (err erro
 }
 
 // Patch a resource.
-func (r *Client) Patch(path string, object interface{}, params ...Param) (err error) {
+func (r *Client) Patch(path string, object any, params ...Param) (err error) {
 	request := func() (request *http.Request, err error) {
 		bfr, err := json.Marshal(object)
 		if err != nil {
@@ -462,7 +462,7 @@ func (r *Client) FileGet(path, destination string) (err error) {
 
 // FilePost uploads a file.
 // Returns the created File resource.
-func (r *Client) FilePost(path, source string, object interface{}) (err error) {
+func (r *Client) FilePost(path, source string, object any) (err error) {
 	if source == "" {
 		fields := []Field{
 			{
@@ -494,7 +494,7 @@ func (r *Client) FilePost(path, source string, object interface{}) (err error) {
 
 // FilePut uploads a file.
 // Returns the created File resource.
-func (r *Client) FilePut(path, source string, object interface{}) (err error) {
+func (r *Client) FilePut(path, source string, object any) (err error) {
 	if source == "" {
 		fields := []Field{
 			{
@@ -538,7 +538,7 @@ func (r *Client) FilePatch(path string, buffer []byte) (err error) {
 }
 
 // FileSend sends file upload from.
-func (r *Client) FileSend(path, method string, fields []Field, object interface{}) (err error) {
+func (r *Client) FileSend(path, method string, fields []Field, object any) (err error) {
 	request := func() (request *http.Request, err error) {
 		pr, pw := io.Pipe()
 		request = &http.Request{

--- a/binding/filter/builder.go
+++ b/binding/filter/builder.go
@@ -30,10 +30,10 @@ const (
 )
 
 // Any match any.
-type Any []interface{}
+type Any []any
 
 // All match all.
-type All []interface{}
+type All []any
 
 // Filter builder.
 type Filter struct {
@@ -75,55 +75,55 @@ func (p *Predicate) String() (s string) {
 }
 
 // Eq returns a (=) predicate.
-func (p *Predicate) Eq(object interface{}) *Predicate {
+func (p *Predicate) Eq(object any) *Predicate {
 	p.operator = EQ
 	p.value = p.valueOf(object)
 	return p
 }
 
 // NotEq returns a (!=) predicate.
-func (p *Predicate) NotEq(object interface{}) *Predicate {
+func (p *Predicate) NotEq(object any) *Predicate {
 	p.operator = NOT + EQ
 	p.value = p.valueOf(object)
 	return p
 }
 
 // Like returns a (~) predicate.
-func (p *Predicate) Like(object interface{}) *Predicate {
+func (p *Predicate) Like(object any) *Predicate {
 	p.operator = LIKE
 	p.value = p.valueOf(object)
 	return p
 }
 
 // Gt returns a (>) predicate.
-func (p *Predicate) Gt(object interface{}) *Predicate {
+func (p *Predicate) Gt(object any) *Predicate {
 	p.operator = GT
 	p.value = p.valueOf(object)
 	return p
 }
 
 // GtEq returns a (>=) predicate.
-func (p *Predicate) GtEq(object interface{}) *Predicate {
+func (p *Predicate) GtEq(object any) *Predicate {
 	p.operator = GT + EQ
 	p.value = p.valueOf(object)
 	return p
 }
 
 // Lt returns a (<) predicate.
-func (p *Predicate) Lt(object interface{}) *Predicate {
+func (p *Predicate) Lt(object any) *Predicate {
 	p.operator = LT
 	p.value = p.valueOf(object)
 	return p
 }
 
 // LtEq returns a (<) predicate.
-func (p *Predicate) LtEq(object interface{}) *Predicate {
+func (p *Predicate) LtEq(object any) *Predicate {
 	p.operator = LT + EQ
 	p.value = p.valueOf(object)
 	return p
 }
 
-func (p *Predicate) valueOf(object interface{}) (result string) {
+func (p *Predicate) valueOf(object any) (result string) {
 	kind := reflect.TypeOf(object).Kind()
 	value := reflect.ValueOf(object)
 	switch kind {

--- a/binding/setting.go
+++ b/binding/setting.go
@@ -10,7 +10,7 @@ type Setting struct {
 }
 
 // Get a setting by key.
-func (h *Setting) Get(key string, v interface{}) (err error) {
+func (h *Setting) Get(key string, v any) (err error) {
 	path := Path(api.SettingRoot).Inject(Params{api.Key: key})
 	err = h.client.Get(path, v)
 	return

--- a/migration/migrate.go
+++ b/migration/migrate.go
@@ -124,7 +124,7 @@ func setVersion(db *gorm.DB, version int) (err error) {
 }
 
 // AutoMigrate the database.
-func autoMigrate(db *gorm.DB, models []interface{}) (err error) {
+func autoMigrate(db *gorm.DB, models []any) (err error) {
 	db, err = database.Open(false)
 	if err != nil {
 		err = liberr.Wrap(err)

--- a/migration/migrate_test.go
+++ b/migration/migrate_test.go
@@ -110,7 +110,7 @@ func (r *TestMigration) Apply(db *gorm.DB) (err error) {
 	return
 }
 
-func (r *TestMigration) Models() (models []interface{}) {
+func (r *TestMigration) Models() (models []any) {
 	return
 }
 

--- a/migration/pkg.go
+++ b/migration/pkg.go
@@ -37,7 +37,7 @@ type Version struct {
 // Migration encapsulates the functionality necessary to perform a migration.
 type Migration interface {
 	Apply(*gorm.DB) error
-	Models() []interface{}
+	Models() []any
 }
 
 // All migrations in order.

--- a/migration/v10/migrate.go
+++ b/migration/v10/migrate.go
@@ -15,6 +15,6 @@ func (r Migration) Apply(db *gorm.DB) (err error) {
 	return
 }
 
-func (r Migration) Models() []interface{} {
+func (r Migration) Models() []any {
 	return model.All()
 }

--- a/migration/v10/model/application.go
+++ b/migration/v10/model/application.go
@@ -255,8 +255,8 @@ type Import struct {
 	RepositoryPath      string
 }
 
-func (r *Import) AsMap() (m map[string]interface{}) {
-	m = make(map[string]interface{})
+func (r *Import) AsMap() (m map[string]any) {
+	m = make(map[string]any)
 	m["filename"] = r.Filename
 	m["applicationName"] = r.ApplicationName
 	// "Application Name" is necessary in order for

--- a/migration/v10/model/core.go
+++ b/migration/v10/model/core.go
@@ -29,7 +29,7 @@ type Setting struct {
 
 // With updates the value of the Setting with the json representation
 // of the `value` parameter.
-func (r *Setting) With(value interface{}) (err error) {
+func (r *Setting) With(value any) (err error) {
 	r.Value, err = json.Marshal(value)
 	if err != nil {
 		err = liberr.Wrap(err)
@@ -38,7 +38,7 @@ func (r *Setting) With(value interface{}) (err error) {
 }
 
 // As unmarshalls the value of the Setting into the `ptr` parameter.
-func (r *Setting) As(ptr interface{}) (err error) {
+func (r *Setting) As(ptr any) (err error) {
 	err = json.Unmarshal(r.Value, ptr)
 	if err != nil {
 		err = liberr.Wrap(err)
@@ -155,7 +155,7 @@ func (m *Task) BeforeCreate(db *gorm.DB) (err error) {
 }
 
 // Error appends an error.
-func (m *Task) Error(severity, description string, x ...interface{}) {
+func (m *Task) Error(severity, description string, x ...any) {
 	var list []TaskError
 	description = fmt.Sprintf(description, x...)
 	te := TaskError{Severity: severity, Description: description}
@@ -165,7 +165,7 @@ func (m *Task) Error(severity, description string, x ...interface{}) {
 }
 
 // Map alias.
-type Map = map[string]interface{}
+type Map = map[string]any
 
 // TTL time-to-live.
 type TTL struct {

--- a/migration/v10/model/pkg.go
+++ b/migration/v10/model/pkg.go
@@ -12,8 +12,8 @@ type JSON = []byte
 // All builds all models.
 // Models are enumerated such that each are listed after
 // all the other models on which they may depend.
-func All() []interface{} {
-	return []interface{}{
+func All() []any {
+	return []any{
 		Application{},
 		TechDependency{},
 		Incident{},

--- a/migration/v11/migrate.go
+++ b/migration/v11/migrate.go
@@ -15,6 +15,6 @@ func (r Migration) Apply(db *gorm.DB) (err error) {
 	return
 }
 
-func (r Migration) Models() []interface{} {
+func (r Migration) Models() []any {
 	return model.All()
 }

--- a/migration/v11/model/application.go
+++ b/migration/v11/model/application.go
@@ -257,8 +257,8 @@ type Import struct {
 	Contributors        string
 }
 
-func (r *Import) AsMap() (m map[string]interface{}) {
-	m = make(map[string]interface{})
+func (r *Import) AsMap() (m map[string]any) {
+	m = make(map[string]any)
 	m["filename"] = r.Filename
 	m["applicationName"] = r.ApplicationName
 	// "Application Name" is necessary in order for

--- a/migration/v11/model/core.go
+++ b/migration/v11/model/core.go
@@ -29,7 +29,7 @@ type Setting struct {
 
 // With updates the value of the Setting with the json representation
 // of the `value` parameter.
-func (r *Setting) With(value interface{}) (err error) {
+func (r *Setting) With(value any) (err error) {
 	r.Value, err = json.Marshal(value)
 	if err != nil {
 		err = liberr.Wrap(err)
@@ -38,7 +38,7 @@ func (r *Setting) With(value interface{}) (err error) {
 }
 
 // As unmarshalls the value of the Setting into the `ptr` parameter.
-func (r *Setting) As(ptr interface{}) (err error) {
+func (r *Setting) As(ptr any) (err error) {
 	err = json.Unmarshal(r.Value, ptr)
 	if err != nil {
 		err = liberr.Wrap(err)
@@ -155,7 +155,7 @@ func (m *Task) BeforeCreate(db *gorm.DB) (err error) {
 }
 
 // Error appends an error.
-func (m *Task) Error(severity, description string, x ...interface{}) {
+func (m *Task) Error(severity, description string, x ...any) {
 	var list []TaskError
 	description = fmt.Sprintf(description, x...)
 	te := TaskError{Severity: severity, Description: description}
@@ -165,7 +165,7 @@ func (m *Task) Error(severity, description string, x ...interface{}) {
 }
 
 // Map alias.
-type Map = map[string]interface{}
+type Map = map[string]any
 
 // TTL time-to-live.
 type TTL struct {

--- a/migration/v11/model/pkg.go
+++ b/migration/v11/model/pkg.go
@@ -12,8 +12,8 @@ type JSON = []byte
 // All builds all models.
 // Models are enumerated such that each are listed after
 // all the other models on which they may depend.
-func All() []interface{} {
-	return []interface{}{
+func All() []any {
+	return []any{
 		Application{},
 		TechDependency{},
 		Incident{},

--- a/migration/v12/migrate.go
+++ b/migration/v12/migrate.go
@@ -15,6 +15,6 @@ func (r Migration) Apply(db *gorm.DB) (err error) {
 	return
 }
 
-func (r Migration) Models() []interface{} {
+func (r Migration) Models() []any {
 	return model.All()
 }

--- a/migration/v12/model/application.go
+++ b/migration/v12/model/application.go
@@ -257,8 +257,8 @@ type Import struct {
 	Contributors        string
 }
 
-func (r *Import) AsMap() (m map[string]interface{}) {
-	m = make(map[string]interface{})
+func (r *Import) AsMap() (m map[string]any) {
+	m = make(map[string]any)
 	m["filename"] = r.Filename
 	m["applicationName"] = r.ApplicationName
 	// "Application Name" is necessary in order for

--- a/migration/v12/model/core.go
+++ b/migration/v12/model/core.go
@@ -29,7 +29,7 @@ type Setting struct {
 
 // With updates the value of the Setting with the json representation
 // of the `value` parameter.
-func (r *Setting) With(value interface{}) (err error) {
+func (r *Setting) With(value any) (err error) {
 	r.Value, err = json.Marshal(value)
 	if err != nil {
 		err = liberr.Wrap(err)
@@ -38,7 +38,7 @@ func (r *Setting) With(value interface{}) (err error) {
 }
 
 // As unmarshalls the value of the Setting into the `ptr` parameter.
-func (r *Setting) As(ptr interface{}) (err error) {
+func (r *Setting) As(ptr any) (err error) {
 	err = json.Unmarshal(r.Value, ptr)
 	if err != nil {
 		err = liberr.Wrap(err)
@@ -155,7 +155,7 @@ func (m *Task) BeforeCreate(db *gorm.DB) (err error) {
 }
 
 // Error appends an error.
-func (m *Task) Error(severity, description string, x ...interface{}) {
+func (m *Task) Error(severity, description string, x ...any) {
 	var list []TaskError
 	description = fmt.Sprintf(description, x...)
 	te := TaskError{Severity: severity, Description: description}
@@ -165,7 +165,7 @@ func (m *Task) Error(severity, description string, x ...interface{}) {
 }
 
 // Map alias.
-type Map = map[string]interface{}
+type Map = map[string]any
 
 // TTL time-to-live.
 type TTL struct {

--- a/migration/v12/model/pkg.go
+++ b/migration/v12/model/pkg.go
@@ -12,8 +12,8 @@ type JSON = []byte
 // All builds all models.
 // Models are enumerated such that each are listed after
 // all the other models on which they may depend.
-func All() []interface{} {
-	return []interface{}{
+func All() []any {
+	return []any{
 		Application{},
 		TechDependency{},
 		Incident{},

--- a/migration/v13/migrate.go
+++ b/migration/v13/migrate.go
@@ -24,6 +24,6 @@ func (r Migration) Apply(db *gorm.DB) (err error) {
 	return
 }
 
-func (r Migration) Models() []interface{} {
+func (r Migration) Models() []any {
 	return model.All()
 }

--- a/migration/v13/model/application.go
+++ b/migration/v13/model/application.go
@@ -257,8 +257,8 @@ type Import struct {
 	Contributors        string
 }
 
-func (r *Import) AsMap() (m map[string]interface{}) {
-	m = make(map[string]interface{})
+func (r *Import) AsMap() (m map[string]any) {
+	m = make(map[string]any)
 	m["filename"] = r.Filename
 	m["applicationName"] = r.ApplicationName
 	// "Application Name" is necessary in order for

--- a/migration/v13/model/core.go
+++ b/migration/v13/model/core.go
@@ -28,7 +28,7 @@ type Setting struct {
 
 // With updates the value of the Setting with the json representation
 // of the `value` parameter.
-func (r *Setting) With(value interface{}) (err error) {
+func (r *Setting) With(value any) (err error) {
 	r.Value, err = json.Marshal(value)
 	if err != nil {
 		err = liberr.Wrap(err)
@@ -37,7 +37,7 @@ func (r *Setting) With(value interface{}) (err error) {
 }
 
 // As unmarshalls the value of the Setting into the `ptr` parameter.
-func (r *Setting) As(ptr interface{}) (err error) {
+func (r *Setting) As(ptr any) (err error) {
 	err = json.Unmarshal(r.Value, ptr)
 	if err != nil {
 		err = liberr.Wrap(err)

--- a/migration/v13/model/pkg.go
+++ b/migration/v13/model/pkg.go
@@ -14,8 +14,8 @@ type JSON = []byte
 // All builds all models.
 // Models are enumerated such that each are listed after
 // all the other models on which they may depend.
-func All() []interface{} {
-	return []interface{}{
+func All() []any {
+	return []any{
 		Application{},
 		TechDependency{},
 		Incident{},

--- a/migration/v14/migrate.go
+++ b/migration/v14/migrate.go
@@ -15,6 +15,6 @@ func (r Migration) Apply(db *gorm.DB) (err error) {
 	return
 }
 
-func (r Migration) Models() []interface{} {
+func (r Migration) Models() []any {
 	return model.All()
 }

--- a/migration/v14/model/application.go
+++ b/migration/v14/model/application.go
@@ -257,8 +257,8 @@ type Import struct {
 	Contributors        string
 }
 
-func (r *Import) AsMap() (m map[string]interface{}) {
-	m = make(map[string]interface{})
+func (r *Import) AsMap() (m map[string]any) {
+	m = make(map[string]any)
 	m["filename"] = r.Filename
 	m["applicationName"] = r.ApplicationName
 	// "Application Name" is necessary in order for

--- a/migration/v14/model/core.go
+++ b/migration/v14/model/core.go
@@ -28,7 +28,7 @@ type Setting struct {
 
 // With updates the value of the Setting with the json representation
 // of the `value` parameter.
-func (r *Setting) With(value interface{}) (err error) {
+func (r *Setting) With(value any) (err error) {
 	r.Value, err = json.Marshal(value)
 	if err != nil {
 		err = liberr.Wrap(err)
@@ -37,7 +37,7 @@ func (r *Setting) With(value interface{}) (err error) {
 }
 
 // As unmarshalls the value of the Setting into the `ptr` parameter.
-func (r *Setting) As(ptr interface{}) (err error) {
+func (r *Setting) As(ptr any) (err error) {
 	err = json.Unmarshal(r.Value, ptr)
 	if err != nil {
 		err = liberr.Wrap(err)

--- a/migration/v14/model/pkg.go
+++ b/migration/v14/model/pkg.go
@@ -14,8 +14,8 @@ type JSON = []byte
 // All builds all models.
 // Models are enumerated such that each are listed after
 // all the other models on which they may depend.
-func All() []interface{} {
-	return []interface{}{
+func All() []any {
+	return []any{
 		Application{},
 		TechDependency{},
 		Incident{},

--- a/migration/v2/migrate.go
+++ b/migration/v2/migrate.go
@@ -36,6 +36,6 @@ func (r Migration) Apply(db *gorm.DB) (err error) {
 	return
 }
 
-func (r Migration) Models() []interface{} {
+func (r Migration) Models() []any {
 	return model.All()
 }

--- a/migration/v2/model/application.go
+++ b/migration/v2/model/application.go
@@ -147,8 +147,8 @@ type Import struct {
 	RepositoryPath      string
 }
 
-func (r *Import) AsMap() (m map[string]interface{}) {
-	m = make(map[string]interface{})
+func (r *Import) AsMap() (m map[string]any) {
+	m = make(map[string]any)
 	m["filename"] = r.Filename
 	m["applicationName"] = r.ApplicationName
 	// "Application Name" is necessary in order for

--- a/migration/v2/model/core.go
+++ b/migration/v2/model/core.go
@@ -85,7 +85,7 @@ func (m *Task) BeforeCreate(db *gorm.DB) (err error) {
 }
 
 // Map alias.
-type Map = map[string]interface{}
+type Map = map[string]any
 
 // TTL time-to-live.
 type TTL struct {

--- a/migration/v2/model/pkg.go
+++ b/migration/v2/model/pkg.go
@@ -14,8 +14,8 @@ type JSON = []byte
 // All builds all models.
 // Models are enumerated such that each are listed after
 // all the other models on which they may depend.
-func All() []interface{} {
-	return []interface{}{
+func All() []any {
+	return []any{
 		ImportSummary{},
 		Import{},
 		ImportTag{},

--- a/migration/v3/migrate.go
+++ b/migration/v3/migrate.go
@@ -82,7 +82,7 @@ func (r Migration) Apply(db *gorm.DB) (err error) {
 	return
 }
 
-func (r Migration) Models() []interface{} {
+func (r Migration) Models() []any {
 	return model.All()
 }
 
@@ -103,7 +103,7 @@ func (r Migration) factMigration(db *gorm.DB) (err error) {
 		return
 	}
 	for _, m := range list {
-		d := map[string]interface{}{}
+		d := map[string]any{}
 		_ = json.Unmarshal(m.Facts, &d)
 		for k, v := range d {
 			jv, _ := json.Marshal(v)

--- a/migration/v3/model/application.go
+++ b/migration/v3/model/application.go
@@ -228,8 +228,8 @@ type Import struct {
 	RepositoryPath      string
 }
 
-func (r *Import) AsMap() (m map[string]interface{}) {
-	m = make(map[string]interface{})
+func (r *Import) AsMap() (m map[string]any) {
+	m = make(map[string]any)
 	m["filename"] = r.Filename
 	m["applicationName"] = r.ApplicationName
 	// "Application Name" is necessary in order for

--- a/migration/v3/model/core.go
+++ b/migration/v3/model/core.go
@@ -133,7 +133,7 @@ func (m *Task) BeforeCreate(db *gorm.DB) (err error) {
 }
 
 // Map alias.
-type Map = map[string]interface{}
+type Map = map[string]any
 
 // TTL time-to-live.
 type TTL struct {

--- a/migration/v3/model/pkg.go
+++ b/migration/v3/model/pkg.go
@@ -14,8 +14,8 @@ type JSON = []byte
 // All builds all models.
 // Models are enumerated such that each are listed after
 // all the other models on which they may depend.
-func All() []interface{} {
-	return []interface{}{
+func All() []any {
+	return []any{
 		ImportSummary{},
 		Import{},
 		ImportTag{},

--- a/migration/v4/migrate.go
+++ b/migration/v4/migrate.go
@@ -21,6 +21,6 @@ func (r Migration) Apply(db *gorm.DB) (err error) {
 	return
 }
 
-func (r Migration) Models() []interface{} {
+func (r Migration) Models() []any {
 	return model.All()
 }

--- a/migration/v4/model/application.go
+++ b/migration/v4/model/application.go
@@ -247,8 +247,8 @@ type Import struct {
 	RepositoryPath      string
 }
 
-func (r *Import) AsMap() (m map[string]interface{}) {
-	m = make(map[string]interface{})
+func (r *Import) AsMap() (m map[string]any) {
+	m = make(map[string]any)
 	m["filename"] = r.Filename
 	m["applicationName"] = r.ApplicationName
 	// "Application Name" is necessary in order for

--- a/migration/v4/model/core.go
+++ b/migration/v4/model/core.go
@@ -133,7 +133,7 @@ func (m *Task) BeforeCreate(db *gorm.DB) (err error) {
 }
 
 // Map alias.
-type Map = map[string]interface{}
+type Map = map[string]any
 
 // TTL time-to-live.
 type TTL struct {

--- a/migration/v4/model/pkg.go
+++ b/migration/v4/model/pkg.go
@@ -14,8 +14,8 @@ type JSON = []byte
 // All builds all models.
 // Models are enumerated such that each are listed after
 // all the other models on which they may depend.
-func All() []interface{} {
-	return []interface{}{
+func All() []any {
+	return []any{
 		ImportSummary{},
 		Import{},
 		ImportTag{},

--- a/migration/v5/migrate.go
+++ b/migration/v5/migrate.go
@@ -61,7 +61,7 @@ func (r Migration) Apply(db *gorm.DB) (err error) {
 	return
 }
 
-func (r Migration) Models() []interface{} {
+func (r Migration) Models() []any {
 	return model.All()
 }
 

--- a/migration/v5/model/application.go
+++ b/migration/v5/model/application.go
@@ -234,8 +234,8 @@ type Import struct {
 	RepositoryPath      string
 }
 
-func (r *Import) AsMap() (m map[string]interface{}) {
-	m = make(map[string]interface{})
+func (r *Import) AsMap() (m map[string]any) {
+	m = make(map[string]any)
 	m["filename"] = r.Filename
 	m["applicationName"] = r.ApplicationName
 	// "Application Name" is necessary in order for

--- a/migration/v5/model/core.go
+++ b/migration/v5/model/core.go
@@ -134,7 +134,7 @@ func (m *Task) BeforeCreate(db *gorm.DB) (err error) {
 }
 
 // Map alias.
-type Map = map[string]interface{}
+type Map = map[string]any
 
 // TTL time-to-live.
 type TTL struct {

--- a/migration/v5/model/pkg.go
+++ b/migration/v5/model/pkg.go
@@ -14,8 +14,8 @@ type JSON = []byte
 // All builds all models.
 // Models are enumerated such that each are listed after
 // all the other models on which they may depend.
-func All() []interface{} {
-	return []interface{}{
+func All() []any {
+	return []any{
 		TechDependency{},
 		Incident{},
 		Issue{},

--- a/migration/v6/migrate.go
+++ b/migration/v6/migrate.go
@@ -37,7 +37,7 @@ func (r Migration) Apply(db *gorm.DB) (err error) {
 	return
 }
 
-func (r Migration) Models() []interface{} {
+func (r Migration) Models() []any {
 	return model.All()
 }
 

--- a/migration/v6/model/application.go
+++ b/migration/v6/model/application.go
@@ -234,8 +234,8 @@ type Import struct {
 	RepositoryPath      string
 }
 
-func (r *Import) AsMap() (m map[string]interface{}) {
-	m = make(map[string]interface{})
+func (r *Import) AsMap() (m map[string]any) {
+	m = make(map[string]any)
 	m["filename"] = r.Filename
 	m["applicationName"] = r.ApplicationName
 	// "Application Name" is necessary in order for

--- a/migration/v6/model/core.go
+++ b/migration/v6/model/core.go
@@ -135,7 +135,7 @@ func (m *Task) BeforeCreate(db *gorm.DB) (err error) {
 }
 
 // Error appends an error.
-func (m *Task) Error(severity, description string, x ...interface{}) {
+func (m *Task) Error(severity, description string, x ...any) {
 	var list []TaskError
 	description = fmt.Sprintf(description, x...)
 	te := TaskError{Severity: severity, Description: description}
@@ -145,7 +145,7 @@ func (m *Task) Error(severity, description string, x ...interface{}) {
 }
 
 // Map alias.
-type Map = map[string]interface{}
+type Map = map[string]any
 
 // TTL time-to-live.
 type TTL struct {

--- a/migration/v6/model/pkg.go
+++ b/migration/v6/model/pkg.go
@@ -12,8 +12,8 @@ type JSON = []byte
 // All builds all models.
 // Models are enumerated such that each are listed after
 // all the other models on which they may depend.
-func All() []interface{} {
-	return []interface{}{
+func All() []any {
+	return []any{
 		TechDependency{},
 		Incident{},
 		Issue{},

--- a/migration/v7/migrate.go
+++ b/migration/v7/migrate.go
@@ -55,6 +55,6 @@ func (r Migration) Apply(db *gorm.DB) (err error) {
 	return
 }
 
-func (r Migration) Models() []interface{} {
+func (r Migration) Models() []any {
 	return model.All()
 }

--- a/migration/v7/model/application.go
+++ b/migration/v7/model/application.go
@@ -237,8 +237,8 @@ type Import struct {
 	RepositoryPath      string
 }
 
-func (r *Import) AsMap() (m map[string]interface{}) {
-	m = make(map[string]interface{})
+func (r *Import) AsMap() (m map[string]any) {
+	m = make(map[string]any)
 	m["filename"] = r.Filename
 	m["applicationName"] = r.ApplicationName
 	// "Application Name" is necessary in order for

--- a/migration/v7/model/core.go
+++ b/migration/v7/model/core.go
@@ -136,7 +136,7 @@ func (m *Task) BeforeCreate(db *gorm.DB) (err error) {
 }
 
 // Error appends an error.
-func (m *Task) Error(severity, description string, x ...interface{}) {
+func (m *Task) Error(severity, description string, x ...any) {
 	var list []TaskError
 	description = fmt.Sprintf(description, x...)
 	te := TaskError{Severity: severity, Description: description}
@@ -146,7 +146,7 @@ func (m *Task) Error(severity, description string, x ...interface{}) {
 }
 
 // Map alias.
-type Map = map[string]interface{}
+type Map = map[string]any
 
 // TTL time-to-live.
 type TTL struct {

--- a/migration/v7/model/pkg.go
+++ b/migration/v7/model/pkg.go
@@ -12,8 +12,8 @@ var (
 // All builds all models.
 // Models are enumerated such that each are listed after
 // all the other models on which they may depend.
-func All() []interface{} {
-	return []interface{}{
+func All() []any {
+	return []any{
 		Application{},
 		TechDependency{},
 		Incident{},

--- a/migration/v8/migrate.go
+++ b/migration/v8/migrate.go
@@ -87,6 +87,6 @@ func (r Migration) Apply(db *gorm.DB) (err error) {
 	return
 }
 
-func (r Migration) Models() []interface{} {
+func (r Migration) Models() []any {
 	return model.All()
 }

--- a/migration/v8/model/application.go
+++ b/migration/v8/model/application.go
@@ -237,8 +237,8 @@ type Import struct {
 	RepositoryPath      string
 }
 
-func (r *Import) AsMap() (m map[string]interface{}) {
-	m = make(map[string]interface{})
+func (r *Import) AsMap() (m map[string]any) {
+	m = make(map[string]any)
 	m["filename"] = r.Filename
 	m["applicationName"] = r.ApplicationName
 	// "Application Name" is necessary in order for

--- a/migration/v8/model/core.go
+++ b/migration/v8/model/core.go
@@ -136,7 +136,7 @@ func (m *Task) BeforeCreate(db *gorm.DB) (err error) {
 }
 
 // Error appends an error.
-func (m *Task) Error(severity, description string, x ...interface{}) {
+func (m *Task) Error(severity, description string, x ...any) {
 	var list []TaskError
 	description = fmt.Sprintf(description, x...)
 	te := TaskError{Severity: severity, Description: description}
@@ -146,7 +146,7 @@ func (m *Task) Error(severity, description string, x ...interface{}) {
 }
 
 // Map alias.
-type Map = map[string]interface{}
+type Map = map[string]any
 
 // TTL time-to-live.
 type TTL struct {

--- a/migration/v8/model/pkg.go
+++ b/migration/v8/model/pkg.go
@@ -12,8 +12,8 @@ var (
 // All builds all models.
 // Models are enumerated such that each are listed after
 // all the other models on which they may depend.
-func All() []interface{} {
-	return []interface{}{
+func All() []any {
+	return []any{
 		Application{},
 		TechDependency{},
 		Incident{},

--- a/migration/v9/migrate.go
+++ b/migration/v9/migrate.go
@@ -28,6 +28,6 @@ func (r Migration) Apply(db *gorm.DB) (err error) {
 	return
 }
 
-func (r Migration) Models() []interface{} {
+func (r Migration) Models() []any {
 	return model.All()
 }

--- a/migration/v9/model/application.go
+++ b/migration/v9/model/application.go
@@ -255,8 +255,8 @@ type Import struct {
 	RepositoryPath      string
 }
 
-func (r *Import) AsMap() (m map[string]interface{}) {
-	m = make(map[string]interface{})
+func (r *Import) AsMap() (m map[string]any) {
+	m = make(map[string]any)
 	m["filename"] = r.Filename
 	m["applicationName"] = r.ApplicationName
 	// "Application Name" is necessary in order for

--- a/migration/v9/model/core.go
+++ b/migration/v9/model/core.go
@@ -136,7 +136,7 @@ func (m *Task) BeforeCreate(db *gorm.DB) (err error) {
 }
 
 // Error appends an error.
-func (m *Task) Error(severity, description string, x ...interface{}) {
+func (m *Task) Error(severity, description string, x ...any) {
 	var list []TaskError
 	description = fmt.Sprintf(description, x...)
 	te := TaskError{Severity: severity, Description: description}
@@ -146,7 +146,7 @@ func (m *Task) Error(severity, description string, x ...interface{}) {
 }
 
 // Map alias.
-type Map = map[string]interface{}
+type Map = map[string]any
 
 // TTL time-to-live.
 type TTL struct {

--- a/migration/v9/model/pkg.go
+++ b/migration/v9/model/pkg.go
@@ -12,8 +12,8 @@ var (
 // All builds all models.
 // Models are enumerated such that each are listed after
 // all the other models on which they may depend.
-func All() []interface{} {
-	return []interface{}{
+func All() []any {
+	return []any{
 		Application{},
 		TechDependency{},
 		Incident{},

--- a/reaper/bucket.go
+++ b/reaper/bucket.go
@@ -64,7 +64,7 @@ func (r *BucketReaper) busy(bucket *model.Bucket) (busy bool, err error) {
 	nRef := int64(0)
 	var n int64
 	ref := RefCounter{DB: r.DB}
-	for _, m := range []interface{}{
+	for _, m := range []any{
 		&model.Application{},
 		&model.TaskGroup{},
 		&model.Task{},

--- a/reaper/file.go
+++ b/reaper/file.go
@@ -63,7 +63,7 @@ func (r *FileReaper) busy(file *model.File) (busy bool, err error) {
 	nRef := int64(0)
 	var n int64
 	ref := RefCounter{DB: r.DB}
-	for _, m := range []interface{}{
+	for _, m := range []any{
 		&model.Task{},
 		&model.TaskReport{},
 		&model.RuleSet{},

--- a/reaper/ref.go
+++ b/reaper/ref.go
@@ -16,7 +16,7 @@ type RefCounter struct {
 }
 
 // Count find & count references.
-func (r *RefCounter) Count(m interface{}, kind string, pk uint) (nRef int64, err error) {
+func (r *RefCounter) Count(m any, kind string, pk uint) (nRef int64, err error) {
 	db := r.DB.Model(m)
 	fields := 0
 	j := 0
@@ -44,8 +44,8 @@ func (r *RefCounter) Count(m interface{}, kind string, pk uint) (nRef int64, err
 			return
 		}
 	}
-	var find func(interface{})
-	find = func(object interface{}) {
+	var find func(any)
+	find = func(object any) {
 		mt := reflect.TypeOf(object)
 		mv := reflect.ValueOf(object)
 		if mt.Kind() == reflect.Ptr {

--- a/seed/jobfunction.go
+++ b/seed/jobfunction.go
@@ -81,7 +81,7 @@ func (r *JobFunction) Apply(db *gorm.DB) (err error) {
 }
 
 // Convenience method to find a JobFunction.
-func (r *JobFunction) find(db *gorm.DB, conditions ...interface{}) (jf *model.JobFunction, found bool, err error) {
+func (r *JobFunction) find(db *gorm.DB, conditions ...any) (jf *model.JobFunction, found bool, err error) {
 	jf = &model.JobFunction{}
 	result := db.First(jf, conditions...)
 	if result.Error != nil {

--- a/seed/questionnaire.go
+++ b/seed/questionnaire.go
@@ -90,7 +90,7 @@ func (r *Questionnaire) Apply(db *gorm.DB) (err error) {
 }
 
 // Convenience method to find a Questionnaire.
-func (r *Questionnaire) find(db *gorm.DB, conditions ...interface{}) (q *model.Questionnaire, found bool, err error) {
+func (r *Questionnaire) find(db *gorm.DB, conditions ...any) (q *model.Questionnaire, found bool, err error) {
 	q = &model.Questionnaire{}
 	result := db.First(q, conditions...)
 	if result.Error != nil {

--- a/seed/ruleset.go
+++ b/seed/ruleset.go
@@ -179,7 +179,7 @@ func file(db *gorm.DB, filePath string) (file *model.File, err error) {
 }
 
 // Convenience method to find a RuleSet.
-func (r *RuleSet) find(db *gorm.DB, conditions ...interface{}) (rs *model.RuleSet, found bool, err error) {
+func (r *RuleSet) find(db *gorm.DB, conditions ...any) (rs *model.RuleSet, found bool, err error) {
 	rs = &model.RuleSet{}
 	result := db.First(rs, conditions...)
 	if result.Error != nil {

--- a/seed/tag.go
+++ b/seed/tag.go
@@ -118,7 +118,7 @@ func (r *TagCategory) applyTags(db *gorm.DB, category *model.TagCategory, tc lib
 }
 
 // Convenience method to find a TagCategory.
-func (r *TagCategory) find(db *gorm.DB, conditions ...interface{}) (category *model.TagCategory, found bool, err error) {
+func (r *TagCategory) find(db *gorm.DB, conditions ...any) (category *model.TagCategory, found bool, err error) {
 	category = &model.TagCategory{}
 	result := db.First(category, conditions...)
 	if result.Error != nil {

--- a/seed/target.go
+++ b/seed/target.go
@@ -176,7 +176,7 @@ func merge(userOrder []uint, seedOrder []uint, ids []uint) (mergedOrder []uint) 
 }
 
 // Convenience method to find a Target.
-func (r *Target) find(db *gorm.DB, conditions ...interface{}) (t *model.Target, found bool, err error) {
+func (r *Target) find(db *gorm.DB, conditions ...any) (t *model.Target, found bool, err error) {
 	t = &model.Target{}
 	result := db.First(t, conditions...)
 	if result.Error != nil {

--- a/test/api/application/facts_test.go
+++ b/test/api/application/facts_test.go
@@ -43,7 +43,7 @@ func TestApplicationFactCRUD(t *testing.T) {
 			}
 
 			// Get.
-			var v interface{}
+			var v any
 			err = Client.Get(factPath, &v)
 			if err != nil {
 				t.Errorf(err.Error())

--- a/test/assert/equality.go
+++ b/test/assert/equality.go
@@ -5,6 +5,6 @@ import (
 )
 
 // Simple equality check working for flat types (no nested types passed by reference).
-func FlatEqual(got, expected interface{}) bool {
+func FlatEqual(got, expected any) bool {
 	return fmt.Sprintf("%v", got) == fmt.Sprintf("%v", expected)
 }


### PR DESCRIPTION
Replaced `interface{}` with much cleaner `any` introduced in 1.18.