### PR TITLE
:sparkles: Reaper optimization.

### DIFF
--- a/k8s/api/tackle/v1alpha2/zz_generated.deepcopy.go
+++ b/k8s/api/tackle/v1alpha2/zz_generated.deepcopy.go
@@ -22,7 +22,7 @@ limitations under the License.
 package v1alpha2
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/reaper/bucket.go
+++ b/reaper/bucket.go
@@ -29,7 +29,7 @@ func (r *BucketReaper) Run() {
 	if len(list) == 0 {
 		return
 	}
-	ids := make(map[uint]any)
+	ids := make(map[uint]byte)
 	finder := RefFinder{DB: r.DB}
 	for _, m := range []any{
 		&model.Application{},

--- a/reaper/bucket.go
+++ b/reaper/bucket.go
@@ -26,13 +26,24 @@ func (r *BucketReaper) Run() {
 		Log.Error(err, "")
 		return
 	}
-	for _, bucket := range list {
-		busy, err := r.busy(&bucket)
+	if len(list) == 0 {
+		return
+	}
+	ids := make(map[uint]any)
+	finder := RefFinder{DB: r.DB}
+	for _, m := range []any{
+		&model.Application{},
+		&model.TaskGroup{},
+		&model.Task{},
+	} {
+		err := finder.Find(m, "bucket", ids)
 		if err != nil {
 			Log.Error(err, "")
 			continue
 		}
-		if busy {
+	}
+	for _, bucket := range list {
+		if _, found := ids[bucket.ID]; found {
 			if bucket.Expiration != nil {
 				bucket.Expiration = nil
 				err = r.DB.Save(&bucket).Error
@@ -57,27 +68,6 @@ func (r *BucketReaper) Run() {
 			}
 		}
 	}
-}
-
-// busy determines if anything references the bucket.
-func (r *BucketReaper) busy(bucket *model.Bucket) (busy bool, err error) {
-	nRef := int64(0)
-	var n int64
-	ref := RefCounter{DB: r.DB}
-	for _, m := range []any{
-		&model.Application{},
-		&model.TaskGroup{},
-		&model.Task{},
-	} {
-		n, err = ref.Count(m, "bucket", bucket.ID)
-		if err != nil {
-			Log.Error(err, "")
-			continue
-		}
-		nRef += n
-	}
-	busy = nRef > 0
-	return
 }
 
 // Delete bucket.

--- a/reaper/file.go
+++ b/reaper/file.go
@@ -28,7 +28,7 @@ func (r *FileReaper) Run() {
 	if len(list) == 0 {
 		return
 	}
-	ids := make(map[uint]any)
+	ids := make(map[uint]byte)
 	finder := RefFinder{DB: r.DB}
 	for _, m := range []any{
 		&model.Task{},

--- a/reaper/ref.go
+++ b/reaper/ref.go
@@ -8,40 +8,31 @@ import (
 	"gorm.io/gorm"
 )
 
-// RefCounter provides model inspection for files
-// tagged with: ref:<kind>.
-type RefCounter struct {
+// RefFinder provides model inspection for files
+// tagged with:
+//   ref:<kind>
+//   []ref:<kind>
+type RefFinder struct {
 	// DB
 	DB *gorm.DB
 }
 
-// Count find & count references.
-func (r *RefCounter) Count(m any, kind string, pk uint) (nRef int64, err error) {
-	db := r.DB.Model(m)
-	fields := 0
-	j := 0
+// Find returns a map of all references for the model and kind.
+func (r *RefFinder) Find(m any, kind string, ids map[uint]any) (err error) {
+	var nfields []string
+	var jfields []string
 	add := func(ft reflect.StructField) {
 		tag, found := ft.Tag.Lookup("ref")
 		if found && tag == kind {
-			db = db.Or(ft.Name, pk)
-			fields++
+			nfields = append(
+				nfields,
+				ft.Name)
 			return
 		}
 		if found && tag == "[]"+kind {
-			db = db.Joins(
-				fmt.Sprintf(
-					",json_each(%s) j%d",
-					ft.Name,
-					j))
-			db = db.Or(
-				fmt.Sprintf(
-					"json_extract(j%d.value,?)=?",
-					j),
-				"$.id",
-				pk)
-			fields++
-			j++
-			return
+			jfields = append(
+				jfields,
+				ft.Name)
 		}
 	}
 	var find func(any)
@@ -76,20 +67,57 @@ func (r *RefCounter) Count(m any, kind string, pk uint) (nRef int64, err error) 
 				add(ft)
 			case reflect.Slice:
 				add(ft)
+			default:
 			}
 		}
 	}
 	find(m)
-	if fields == 0 {
+	if len(nfields)+len(jfields) == 0 {
 		return
 	}
-	err = db.Count(&nRef).Error
+	db := r.DB.Model(m)
+	if Log.V(1).Enabled() {
+		db = db.Debug()
+	}
+	var fields []string
+	var list []map[string]any
+	for i := range nfields {
+		fields = append(fields, nfields[i])
+	}
+	for i := range jfields {
+		fields = append(
+			fields,
+			fmt.Sprintf(
+				"json_extract(j%d.value,'$.id')",
+				i))
+		db = db.Joins(
+			fmt.Sprintf(
+				",json_each(%s) j%d",
+				jfields[i],
+				i))
+	}
+	db = db.Select(fields)
+	err = db.Find(&list).Error
 	if err != nil {
 		err = liberr.Wrap(
 			err,
 			"object",
 			reflect.TypeOf(m).Name(),
 		)
+	}
+	for _, ref := range list {
+		for _, v := range ref {
+			switch n := v.(type) {
+			case uint:
+				ids[n] = n
+			case *uint:
+				if n != nil {
+					ids[*n] = *n
+				}
+			case int64:
+				ids[uint(n)] = n
+			}
+		}
 	}
 
 	return

--- a/reaper/ref.go
+++ b/reaper/ref.go
@@ -10,15 +10,16 @@ import (
 
 // RefFinder provides model inspection for files
 // tagged with:
-//   ref:<kind>
-//   []ref:<kind>
+//
+//	ref:<kind>
+//	[]ref:<kind>
 type RefFinder struct {
 	// DB
 	DB *gorm.DB
 }
 
 // Find returns a map of all references for the model and kind.
-func (r *RefFinder) Find(m any, kind string, ids map[uint]any) (err error) {
+func (r *RefFinder) Find(m any, kind string, ids map[uint]byte) (err error) {
 	var nfields []string
 	var jfields []string
 	add := func(ft reflect.StructField) {
@@ -109,13 +110,13 @@ func (r *RefFinder) Find(m any, kind string, ids map[uint]any) (err error) {
 		for _, v := range ref {
 			switch n := v.(type) {
 			case uint:
-				ids[n] = n
+				ids[n] = 0
 			case *uint:
 				if n != nil {
-					ids[*n] = *n
+					ids[*n] = 0
 				}
 			case int64:
-				ids[uint(n)] = n
+				ids[uint(n)] = 0
 			}
 		}
 	}


### PR DESCRIPTION
The default reaper frequency is (1) minute.

The reapers are performing 3-4 queries for every _file_ and _bucket_ evaluated for reaping.  With the addition of attaching files to tasks and task-reports, the number of files has increased substantially.  The current algorithm will run 3-4 queries for each resource evaluated.

For example: A deployment with 2000 analyzed applications can have ~25,000 files.  To evaluate 4 resources for references (Task, TaskGroup, Rule, Target) resulted in 100,000 queries each reaper run.

This PR each run (default: 1/ minute) : 
- FileReaper will run exactly **4** queries. 
- BucketReaper will run exactly **3** queries.