### PR TITLE
:bug: Back-port 0.3: Task.List() no longer include associations; Fix rich context leak.

### DIFF
--- a/api/analysis.go
+++ b/api/analysis.go
@@ -4,6 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"io"
+	"net/http"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
 	qf "github.com/konveyor/tackle2-hub/api/filter"
@@ -13,12 +20,6 @@ import (
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 	"gorm.io/gorm/logger"
-	"io"
-	"net/http"
-	"os"
-	"sort"
-	"strconv"
-	"strings"
 )
 
 //
@@ -2143,7 +2144,7 @@ type AnalysisWriter struct {
 //
 // db returns a db client.
 func (r *AnalysisWriter) db() (db *gorm.DB) {
-	rtx := WithContext(r.ctx)
+	rtx := RichContext(r.ctx)
 	db = rtx.DB.Debug()
 	return
 }
@@ -2288,7 +2289,7 @@ type ReportWriter struct {
 //
 // db returns a db client.
 func (r *ReportWriter) db() (db *gorm.DB) {
-	rtx := WithContext(r.ctx)
+	rtx := RichContext(r.ctx)
 	db = rtx.DB.Debug()
 	return
 }

--- a/api/auth.go
+++ b/api/auth.go
@@ -1,9 +1,10 @@
 package api
 
 import (
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	"github.com/konveyor/tackle2-hub/auth"
-	"net/http"
 )
 
 //
@@ -102,7 +103,7 @@ type Login struct {
 // been granted the necessary scope to access a resource.
 func Required(scope string) func(*gin.Context) {
 	return func(ctx *gin.Context) {
-		rtx := WithContext(ctx)
+		rtx := RichContext(ctx)
 		token := ctx.GetHeader(Authorization)
 		request := &auth.Request{
 			Token:  token,

--- a/api/base.go
+++ b/api/base.go
@@ -6,6 +6,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"time"
+
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/binding"
 	liberr "github.com/jortel/go-utils/error"
@@ -16,11 +21,7 @@ import (
 	"github.com/konveyor/tackle2-hub/model"
 	"gopkg.in/yaml.v2"
 	"gorm.io/gorm"
-	"io"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strconv"
-	"strings"
-	"time"
 )
 
 var Log = logr.WithName("api")
@@ -37,7 +38,7 @@ type BaseHandler struct{}
 //
 // DB return db client associated with the context.
 func (h *BaseHandler) DB(ctx *gin.Context) (db *gorm.DB) {
-	rtx := WithContext(ctx)
+	rtx := RichContext(ctx)
 	db = rtx.DB.Debug()
 	return
 }
@@ -45,7 +46,7 @@ func (h *BaseHandler) DB(ctx *gin.Context) (db *gorm.DB) {
 //
 // Client returns k8s client from the context.
 func (h *BaseHandler) Client(ctx *gin.Context) (client client.Client) {
-	rtx := WithContext(ctx)
+	rtx := RichContext(ctx)
 	client = rtx.Client
 	return
 }
@@ -136,7 +137,7 @@ func (h *BaseHandler) modBody(
 //
 // CurrentUser gets username from Keycloak auth token.
 func (h *BaseHandler) CurrentUser(ctx *gin.Context) (user string) {
-	rtx := WithContext(ctx)
+	rtx := RichContext(ctx)
 	user = rtx.User
 	if user == "" {
 		Log.Info("Failed to get current user.")
@@ -150,7 +151,7 @@ func (h *BaseHandler) CurrentUser(ctx *gin.Context) (user string) {
 func (h *BaseHandler) HasScope(ctx *gin.Context, scope string) (b bool) {
 	in := auth.BaseScope{}
 	in.With(scope)
-	rtx := WithContext(ctx)
+	rtx := RichContext(ctx)
 	for _, s := range rtx.Scopes {
 		b = s.Match(in.Resource, in.Method)
 		if b {
@@ -258,14 +259,14 @@ func (h *BaseHandler) Decoder(ctx *gin.Context, encoding string, r io.Reader) (d
 //
 // Status sets the status code.
 func (h *BaseHandler) Status(ctx *gin.Context, code int) {
-	rtx := WithContext(ctx)
+	rtx := RichContext(ctx)
 	rtx.Status(code)
 }
 
 //
 // Respond sets the response.
 func (h *BaseHandler) Respond(ctx *gin.Context, code int, r interface{}) {
-	rtx := WithContext(ctx)
+	rtx := RichContext(ctx)
 	rtx.Respond(code, r)
 }
 

--- a/api/batch.go
+++ b/api/batch.go
@@ -3,9 +3,10 @@ package api
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/gin-gonic/gin"
 	"io"
 	"net/http"
+
+	"github.com/gin-gonic/gin"
 )
 
 //
@@ -64,7 +65,7 @@ func (h BatchHandler) create(ctx *gin.Context, create gin.HandlerFunc) {
 		return
 	}
 
-	rtx := WithContext(ctx)
+	rtx := RichContext(ctx)
 	bErr := BatchError{Message: "Create failed."}
 	for i := range resources {
 		b, _ := json.Marshal(resources[i])

--- a/api/context.go
+++ b/api/context.go
@@ -1,12 +1,20 @@
 package api
 
 import (
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	"github.com/konveyor/tackle2-hub/auth"
 	"gorm.io/gorm"
-	"net/http"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+//
+// Response values.
+type Response struct {
+	Status int
+	Body   interface{}
+}
 
 //
 // Context custom settings.
@@ -24,11 +32,15 @@ type Context struct {
 	Response Response
 }
 
-//
-// Response values.
-type Response struct {
-	Status int
-	Body   interface{}
+// Attach to gin context.
+func (r *Context) Attach(ctx *gin.Context) {
+	r.Context = ctx
+	ctx.Set("RichContext", r)
+}
+
+// Detach from gin context
+func (r *Context) Detach() {
+	delete(r.Context.Keys, "RichContext")
 }
 
 //
@@ -56,7 +68,7 @@ func WithContext(ctx *gin.Context) (n *Context) {
 	object, found := ctx.Get(key)
 	if !found {
 		n = &Context{}
-		ctx.Set(key, n)
+		n.Attach(ctx)
 	} else {
 		n = object.(*Context)
 	}

--- a/api/context.go
+++ b/api/context.go
@@ -62,17 +62,17 @@ func (r *Context) Respond(status int, body interface{}) {
 }
 
 //
-// WithContext is a rich context.
-func WithContext(ctx *gin.Context) (n *Context) {
+// RichContext returns a rich context attached to the gin context.
+func RichContext(ctx *gin.Context) (rtx *Context) {
 	key := "RichContext"
 	object, found := ctx.Get(key)
 	if !found {
-		n = &Context{}
-		n.Attach(ctx)
+		rtx = &Context{}
+		rtx.Attach(ctx)
 	} else {
-		n = object.(*Context)
+		rtx = object.(*Context)
 	}
-	n.Context = ctx
+	rtx.Context = ctx
 	return
 }
 
@@ -84,7 +84,7 @@ func Transaction(ctx *gin.Context) {
 		http.MethodPut,
 		http.MethodPatch,
 		http.MethodDelete:
-		rtx := WithContext(ctx)
+		rtx := RichContext(ctx)
 		err := rtx.DB.Transaction(func(tx *gorm.DB) (err error) {
 			db := rtx.DB
 			rtx.DB = tx
@@ -108,7 +108,7 @@ func Transaction(ctx *gin.Context) {
 func Render() gin.HandlerFunc {
 	return func(ctx *gin.Context) {
 		ctx.Next()
-		rtx := WithContext(ctx)
+		rtx := RichContext(ctx)
 		if rtx.Response.Body != nil {
 			ctx.Negotiate(
 				rtx.Response.Status,

--- a/api/error.go
+++ b/api/error.go
@@ -2,6 +2,9 @@ package api
 
 import (
 	"errors"
+	"net/http"
+	"os"
+
 	"github.com/gin-gonic/gin"
 	"github.com/go-playground/validator/v10"
 	"github.com/konveyor/tackle2-hub/api/filter"
@@ -9,8 +12,6 @@ import (
 	"github.com/konveyor/tackle2-hub/model"
 	"github.com/mattn/go-sqlite3"
 	"gorm.io/gorm"
-	"net/http"
-	"os"
 )
 
 //
@@ -92,7 +93,7 @@ func ErrorHandler() gin.HandlerFunc {
 
 		err := ctx.Errors[0]
 
-		rtx := WithContext(ctx)
+		rtx := RichContext(ctx)
 		if errors.Is(err, &BadRequestError{}) ||
 			errors.Is(err, &filter.Error{}) ||
 			errors.Is(err, &sort.SortError{}) ||

--- a/api/task.go
+++ b/api/task.go
@@ -2,19 +2,20 @@ package api
 
 import (
 	"encoding/json"
-	"github.com/gin-gonic/gin"
-	"github.com/konveyor/tackle2-hub/model"
-	tasking "github.com/konveyor/tackle2-hub/task"
-	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
 	"io/ioutil"
-	k8serr "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/utils/strings/slices"
 	"net/http"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/konveyor/tackle2-hub/model"
+	tasking "github.com/konveyor/tackle2-hub/task"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/utils/strings/slices"
 )
 
 //
@@ -114,7 +115,6 @@ func (h TaskHandler) List(ctx *gin.Context) {
 	if locator != "" {
 		db = db.Where("locator", locator)
 	}
-	db = db.Preload(clause.Associations)
 	result := db.Find(&list)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"context"
+	"net/http"
+	"syscall"
+
 	"github.com/gin-gonic/gin"
 	liberr "github.com/jortel/go-utils/error"
 	"github.com/jortel/go-utils/logr"
@@ -21,10 +24,8 @@ import (
 	"github.com/konveyor/tackle2-hub/tracker"
 	"gorm.io/gorm"
 	"k8s.io/client-go/kubernetes/scheme"
-	"net/http"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"syscall"
 )
 
 var Settings = &settings.Settings
@@ -195,14 +196,16 @@ func main() {
 	}
 	// Web
 	router := gin.Default()
-	router.Use(api.Render())
-	router.Use(api.ErrorHandler())
 	router.Use(
 		func(ctx *gin.Context) {
 			rtx := api.WithContext(ctx)
 			rtx.DB = db
 			rtx.Client = client
+			ctx.Next()
+			rtx.Detach()
 		})
+	router.Use(api.Render())
+	router.Use(api.ErrorHandler())
 	for _, h := range api.All() {
 		h.AddRoutes(router)
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -198,7 +198,7 @@ func main() {
 	router := gin.Default()
 	router.Use(
 		func(ctx *gin.Context) {
-			rtx := api.WithContext(ctx)
+			rtx := api.RichContext(ctx)
 			rtx.DB = db
 			rtx.Client = client
 			ctx.Next()


### PR DESCRIPTION
The gin HTTP request handler uses a `gin.Context` pool.  The _RichContext_ contains the response body which is passed to the `Render` middle-ware. 
We need to remove the rich context to prevent holding on to memory while the context is in the pool.

Fixed on main: #710 