### PR TITLE
:bug: [MTA-2286] Don't count autoanswered questions when determining whether an asessement has been started.

### DIFF
--- a/assessment/assessment.go
+++ b/assessment/assessment.go
@@ -139,7 +139,7 @@ func (r *Section) Complete() bool {
 // Started returns whether any questions in the section have been answered.
 func (r *Section) Started() bool {
 	for _, q := range r.Questions {
-		if q.Answered() {
+		if q.Answered() && !q.AutoAnswered() {
 			return true
 		}
 	}
@@ -188,6 +188,17 @@ func (r *Question) Risk() string {
 func (r *Question) Answered() bool {
 	for _, a := range r.Answers {
 		if a.Selected {
+			return true
+		}
+	}
+	return false
+}
+
+// AutoAnswered returns whether the question has had an
+// answer pre-selected by the system.
+func (r *Question) AutoAnswered() bool {
+	for _, a := range r.Answers {
+		if a.AutoAnswered {
 			return true
 		}
 	}

--- a/assessment/assessment_test.go
+++ b/assessment/assessment_test.go
@@ -91,3 +91,117 @@ func TestPrepareSections(t *testing.T) {
 	g.Expect(questions[2].Answers[0].AutoAnswered).To(gomega.BeTrue())
 	g.Expect(questions[2].Answers[0].Selected).To(gomega.BeTrue())
 }
+
+func TestAssessmentStarted(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	assessment := Assessment{
+		Sections: []Section{
+			{
+				Questions: []Question{
+					{
+						Text: "S1Q1",
+						Answers: []Answer{
+							{
+								Text:     "A1",
+								Selected: true,
+							},
+							{
+								Text: "A2",
+							},
+						},
+					},
+					{
+						Text: "S1Q2",
+						Answers: []Answer{
+							{
+								Text: "A1",
+							},
+							{
+								Text: "A2",
+							},
+						},
+					},
+				},
+			},
+			{
+				Questions: []Question{
+					{
+						Text: "S2Q1",
+						Answers: []Answer{
+							{
+								Text: "A1",
+							},
+							{
+								Text: "A2",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	g.Expect(assessment.Started()).To(gomega.BeTrue())
+	g.Expect(assessment.Status()).To(gomega.Equal(StatusStarted))
+	assessment.Sections[0].Questions[0].Answers[0].AutoAnswered = true
+	g.Expect(assessment.Started()).To(gomega.BeFalse())
+	g.Expect(assessment.Status()).To(gomega.Equal(StatusEmpty))
+}
+
+func TestAssessmentComplete(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	assessment := Assessment{
+		Sections: []Section{
+			{
+				Questions: []Question{
+					{
+						Text: "S1Q1",
+						Answers: []Answer{
+							{
+								Text: "A1",
+							},
+							{
+								Text: "A2",
+							},
+						},
+					},
+					{
+						Text: "S1Q2",
+						Answers: []Answer{
+							{
+								Text:     "A1",
+								Selected: true,
+							},
+							{
+								Text: "A2",
+							},
+						},
+					},
+				},
+			},
+			{
+				Questions: []Question{
+					{
+						Text: "S2Q1",
+						Answers: []Answer{
+							{
+								Text: "A1",
+							},
+							{
+								Text:         "A2",
+								Selected:     true,
+								AutoAnswered: true,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	g.Expect(assessment.Complete()).To(gomega.BeFalse())
+	g.Expect(assessment.Status()).To(gomega.Equal(StatusStarted))
+	assessment.Sections[0].Questions[0].Answers[0].Selected = true
+	g.Expect(assessment.Complete()).To(gomega.BeTrue())
+	g.Expect(assessment.Status()).To(gomega.Equal(StatusComplete))
+}


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/MTA-2286