### PR TITLE
:seedling: Omit associations during Create operations

### DIFF
--- a/api/application.go
+++ b/api/application.go
@@ -1160,6 +1160,7 @@ func (r *Application) With(m *model.Application, tags []model.ApplicationTag) {
 			r.Identities,
 			ref)
 	}
+	r.Tags = []TagRef{}
 	for i := range tags {
 		ref := TagRef{}
 		ref.With(tags[i].TagID, tags[i].Tag.Name, tags[i].Source, false)

--- a/api/archetype.go
+++ b/api/archetype.go
@@ -136,9 +136,30 @@ func (h ArchetypeHandler) Create(ctx *gin.Context) {
 	}
 	m := r.Model()
 	m.CreateUser = h.CurrentUser(ctx)
-	result := h.DB(ctx).Create(m)
+	result := h.DB(ctx).Omit(clause.Associations).Create(m)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)
+		return
+	}
+
+	err = h.DB(ctx).Model(m).Association("Stakeholders").Replace("Stakeholders", m.Stakeholders)
+	if err != nil {
+		_ = ctx.Error(err)
+		return
+	}
+	err = h.DB(ctx).Model(m).Association("StakeholderGroups").Replace("StakeholderGroups", m.StakeholderGroups)
+	if err != nil {
+		_ = ctx.Error(err)
+		return
+	}
+	err = h.DB(ctx).Model(m).Association("CriteriaTags").Replace("CriteriaTags", m.CriteriaTags)
+	if err != nil {
+		_ = ctx.Error(err)
+		return
+	}
+	err = h.DB(ctx).Model(m).Association("Tags").Replace("Tags", m.Tags)
+	if err != nil {
+		_ = ctx.Error(err)
 		return
 	}
 
@@ -319,9 +340,19 @@ func (h ArchetypeHandler) AssessmentCreate(ctx *gin.Context) {
 		assessment.PrepareForArchetype(resolver, archetype, m)
 		newAssessment = true
 	}
-	result = h.DB(ctx).Create(m)
+	result = h.DB(ctx).Omit(clause.Associations).Create(m)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)
+		return
+	}
+	err = h.DB(ctx).Model(m).Association("Stakeholders").Replace("Stakeholders", m.Stakeholders)
+	if err != nil {
+		_ = ctx.Error(err)
+		return
+	}
+	err = h.DB(ctx).Model(m).Association("StakeholderGroups").Replace("StakeholderGroups", m.StakeholderGroups)
+	if err != nil {
+		_ = ctx.Error(err)
 		return
 	}
 	if newAssessment {

--- a/api/group.go
+++ b/api/group.go
@@ -97,9 +97,19 @@ func (h StakeholderGroupHandler) Create(ctx *gin.Context) {
 	}
 	m := r.Model()
 	m.CreateUser = h.BaseHandler.CurrentUser(ctx)
-	result := h.DB(ctx).Create(m)
+	result := h.DB(ctx).Omit(clause.Associations).Create(m)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)
+		return
+	}
+	err = h.DB(ctx).Model(m).Association("Stakeholders").Replace(m.Stakeholders)
+	if err != nil {
+		_ = ctx.Error(err)
+		return
+	}
+	err = h.DB(ctx).Model(m).Association("MigrationWaves").Replace(m.MigrationWaves)
+	if err != nil {
+		_ = ctx.Error(err)
 		return
 	}
 	r.With(m)

--- a/api/identity.go
+++ b/api/identity.go
@@ -34,7 +34,7 @@ func (h IdentityHandler) AddRoutes(e *gin.Engine) {
 	routeGroup.GET(IdentitiesRoot+"/", h.setDecrypted, h.List)
 	routeGroup.POST(IdentitiesRoot, h.Create)
 	routeGroup.GET(IdentityRoot, h.setDecrypted, h.Get)
-	routeGroup.PUT(IdentityRoot, h.Update, Transaction)
+	routeGroup.PUT(IdentityRoot, Transaction, h.Update)
 	routeGroup.DELETE(IdentityRoot, h.Delete)
 }
 

--- a/api/migrationwave.go
+++ b/api/migrationwave.go
@@ -98,9 +98,24 @@ func (h MigrationWaveHandler) Create(ctx *gin.Context) {
 	}
 	m := r.Model()
 	m.CreateUser = h.CurrentUser(ctx)
-	result := h.DB(ctx).Create(m)
+	result := h.DB(ctx).Omit(clause.Associations).Create(m)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)
+		return
+	}
+	err = h.DB(ctx).Model(m).Association("Applications").Replace("Applications", m.Applications)
+	if err != nil {
+		_ = ctx.Error(err)
+		return
+	}
+	err = h.DB(ctx).Model(m).Association("Stakeholders").Replace("Stakeholders", m.Stakeholders)
+	if err != nil {
+		_ = ctx.Error(err)
+		return
+	}
+	err = h.DB(ctx).Model(m).Association("StakeholderGroups").Replace("StakeholderGroups", m.StakeholderGroups)
+	if err != nil {
+		_ = ctx.Error(err)
 		return
 	}
 	r.With(m)

--- a/api/stakeholder.go
+++ b/api/stakeholder.go
@@ -97,9 +97,29 @@ func (h StakeholderHandler) Create(ctx *gin.Context) {
 	}
 	m := r.Model()
 	m.CreateUser = h.BaseHandler.CurrentUser(ctx)
-	result := h.DB(ctx).Create(m)
+	result := h.DB(ctx).Omit(clause.Associations).Create(m)
 	if result.Error != nil {
 		_ = ctx.Error(result.Error)
+		return
+	}
+	err = h.DB(ctx).Model(m).Association("Groups").Replace(m.Groups)
+	if err != nil {
+		_ = ctx.Error(err)
+		return
+	}
+	err = h.DB(ctx).Model(m).Association("Owns").Replace(m.Owns)
+	if err != nil {
+		_ = ctx.Error(err)
+		return
+	}
+	err = h.DB(ctx).Model(m).Association("Contributes").Replace(m.Contributes)
+	if err != nil {
+		_ = ctx.Error(err)
+		return
+	}
+	err = h.DB(ctx).Model(m).Association("MigrationWaves").Replace(m.MigrationWaves)
+	if err != nil {
+		_ = ctx.Error(err)
 		return
 	}
 	r.With(m)


### PR DESCRIPTION
When inserting a new record, GORM will also attempt to insert records into tables refered to by many-to-many relationships on the inserted record. This commit attempts to ensure that associations are omitted when inserting records, and then the associations are added to the join tables separately.

Also fixes some spots where the Transaction handler was in the wrong spot in the chain or missing entirely.

Fixes https://github.com/konveyor/tackle2-hub/issues/727