### PR TITLE
:sparkles: pod retention.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -67,6 +67,7 @@ require (
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // indirect
+	github.com/moby/spdystream v0.2.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,7 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/andygrunwald/go-jira v1.16.0 h1:PU7C7Fkk5L96JvPc6vDVIrd99vdPnYudHu4ju2c2ikQ=
 github.com/andygrunwald/go-jira v1.16.0/go.mod h1:UQH4IBVxIYWbgagc0LF/k9FRs9xjIiQ8hIcC6HfLwFU=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bytedance/sonic v1.5.0/go.mod h1:ED5hyg4y6t3/9Ku1R6dU/4KyJ48DZ4jPhfY1O2AihPM=
@@ -29,6 +30,7 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
+github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153 h1:yUdfgN0XgIJw7foRItutHYUIhlcKzcSf5vDpdhQAKTc=
 github.com/emicklei/go-restful/v3 v3.9.0 h1:XwGDlfxEnQZzuopoqxwSEllNcCOM9DhhFyhFIIGKwxE=
 github.com/emicklei/go-restful/v3 v3.9.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -121,6 +123,7 @@ github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 h1:yAJXTCF9TqKcTiHJAE8dj7HMvPfh66eeA2JYW7eFpSE=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
@@ -162,6 +165,8 @@ github.com/mattn/go-sqlite3 v1.14.17 h1:mCRHCLDUBXgpKAqIKsaAaAsrAlbkeomtRFKXh2L6
 github.com/mattn/go-sqlite3 v1.14.17/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
+github.com/moby/spdystream v0.2.0 h1:cjW1zVyyoiM0T7b6UoySUFqzXMoqRckQtXwGPiBhOM8=
+github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/settings/hub.go
+++ b/settings/hub.go
@@ -19,6 +19,8 @@ const (
 	EnvTaskReapCreated         = "TASK_REAP_CREATED"
 	EnvTaskReapSucceeded       = "TASK_REAP_SUCCEEDED"
 	EnvTaskReapFailed          = "TASK_REAP_FAILED"
+	EnvTaskPodRetainSucceeded  = "TASK_POD_RETAIN_SUCCEEDED"
+	EnvTaskPodRetainFailed     = "TASK_POD_RETAIN_FAILED"
 	EnvTaskSA                  = "TASK_SA"
 	EnvTaskRetries             = "TASK_RETRIES"
 	EnvTaskPreemptEnabled      = "TASK_PREEMPT_ENABLED"
@@ -83,6 +85,12 @@ type Hub struct {
 			Delayed   time.Duration
 			Postponed time.Duration
 			Rate      int
+		}
+		Pod struct {
+			Retention struct {
+				Succeeded int
+				Failed    int
+			}
 		}
 	}
 	// Frequency
@@ -168,6 +176,20 @@ func (r *Hub) Load() (err error) {
 		r.Task.Reaper.Failed = n
 	} else {
 		r.Task.Reaper.Failed = 43200 // 720 hours (30 days).
+	}
+	s, found = os.LookupEnv(EnvTaskPodRetainSucceeded)
+	if found {
+		n, _ := strconv.Atoi(s)
+		r.Task.Pod.Retention.Succeeded = n
+	} else {
+		r.Task.Pod.Retention.Succeeded = 1
+	}
+	s, found = os.LookupEnv(EnvTaskPodRetainFailed)
+	if found {
+		n, _ := strconv.Atoi(s)
+		r.Task.Pod.Retention.Failed = n
+	} else {
+		r.Task.Pod.Retention.Failed = 4320 // 72 hours.
 	}
 	r.Task.SA, found = os.LookupEnv(EnvTaskSA)
 	if !found {

--- a/task/error.go
+++ b/task/error.go
@@ -327,3 +327,23 @@ func (e *QuotaExceeded) Retry() (r bool) {
 	r = true
 	return
 }
+
+// NotTerminated report pod/container not terminated.
+type NotTerminated struct {
+	Kind string
+	Name string
+}
+
+func (e *NotTerminated) Error() string {
+	return fmt.Sprintf("%s: '%s' not terminated as expected.", e.Kind, e.Name)
+}
+
+func (e *NotTerminated) Is(err error) (matched bool) {
+	var inst *NotTerminated
+	matched = errors.As(err, &inst)
+	return
+}
+
+func (e *NotTerminated) Retry() (r bool) {
+	return
+}

--- a/task/error.go
+++ b/task/error.go
@@ -327,23 +327,3 @@ func (e *QuotaExceeded) Retry() (r bool) {
 	r = true
 	return
 }
-
-// NotTerminated report pod/container not terminated.
-type NotTerminated struct {
-	Kind string
-	Name string
-}
-
-func (e *NotTerminated) Error() string {
-	return fmt.Sprintf("%s: '%s' not terminated as expected.", e.Kind, e.Name)
-}
-
-func (e *NotTerminated) Is(err error) (matched bool) {
-	var inst *NotTerminated
-	matched = errors.As(err, &inst)
-	return
-}
-
-func (e *NotTerminated) Retry() (r bool) {
-	return
-}

--- a/task/manager.go
+++ b/task/manager.go
@@ -1106,19 +1106,6 @@ func (m *Manager) ensureTerminated(task *Task, pod *core.Pod) (err error) {
 // Should the container continue to run after (1) minute,
 // it is reported as an error.
 func (m *Manager) terminateContainer(task *Task, pod *core.Pod, container string) (err error) {
-	matched := task.FindEvent(ContainerKilled)
-	if len(matched) > 0 {
-		for _, event := range matched {
-			if time.Since(event.Last) > time.Minute {
-				err = &NotTerminated{
-					Kind: "Container",
-					Name: container,
-				}
-				break
-			}
-		}
-		return
-	}
 	Log.V(1).Info("KILL container", "container", container)
 	clientSet, err := k8s2.NewClientSet()
 	if err != nil {

--- a/task/manager.go
+++ b/task/manager.go
@@ -1091,6 +1091,7 @@ func (m *Manager) ensureTerminated(pod *core.Pod) (err error) {
 
 // terminateContainer - Terminate container as needed.
 func (m *Manager) terminateContainer(pod *core.Pod, container string) (err error) {
+	Log.V(1).Info("KILL container", "container", container)
 	clientSet, err := k8s2.NewClientSet()
 	if err != nil {
 		return
@@ -1127,6 +1128,21 @@ func (m *Manager) terminateContainer(pod *core.Pod, container string) (err error
 		Stdout: stdout,
 		Stderr: stderr,
 	})
+	if err != nil {
+		Log.Info(
+			"Container KILL failed.",
+			"name",
+			container,
+			"err",
+			err.Error(),
+			"stderr",
+			stderr.String())
+	} else {
+		Log.Info(
+			"Container KILLED.",
+			"name",
+			container)
+	}
 	return
 }
 

--- a/task/manager.go
+++ b/task/manager.go
@@ -873,8 +873,19 @@ func (m *Manager) updateRunning() {
 					Log.Error(err, "")
 					continue
 				}
-				err = m.ensureTerminated(pod)
-				if err != nil {
+				podRetention := 0
+				if running.State == Succeeded {
+					podRetention = Settings.Hub.Task.Pod.Retention.Succeeded
+				} else {
+					podRetention = Settings.Hub.Task.Pod.Retention.Failed
+				}
+				if podRetention > 0 {
+					err = m.ensureTerminated(pod)
+					if err != nil {
+						podRetention = 0
+					}
+				}
+				if podRetention == 0 {
 					err = running.Delete(m.Client)
 					if err != nil {
 						Log.Error(err, "")

--- a/task/manager.go
+++ b/task/manager.go
@@ -1089,7 +1089,7 @@ func (m *Manager) ensureTerminated(pod *core.Pod) (err error) {
 	return
 }
 
-// terminateContainer -
+// terminateContainer - Terminate container as needed.
 func (m *Manager) terminateContainer(pod *core.Pod, container string) (err error) {
 	clientSet, err := k8s2.NewClientSet()
 	if err != nil {

--- a/task/manager.go
+++ b/task/manager.go
@@ -1206,7 +1206,7 @@ func (m *Manager) terminateContainer(task *Task, pod *core.Pod, container string
 	} else {
 		task.Event(
 			ContainerKilled,
-			"container: '%s' has not terminated.",
+			"container: '%s' had not terminated.",
 			container)
 		Log.Info(
 			"Container KILLED.",


### PR DESCRIPTION
Support pod retention settings.

The current policy is to delete pods as soon as completed (succeed or failed).
Tackle users and support are used to troubleshooting by `oc debug` of the task pods.
To support this, the task manager can terminate containers in pods as needed and defer to the reaper to delete the pods. This would be controlled new settings.  By default succeeded tasks would be retained their pods for 1 minute; failed tasks for 72 hours.
In all cases, failure to terminate running container will fallback to deleting the pod immediately.  The retention is best effort.

Running containers are terminated by `kill -p 1`  This will only work for linux containers.