### PR TITLE
:bug: preempted-postpone even when preemption disabled.

### DIFF
--- a/task/rule.go
+++ b/task/rule.go
@@ -77,9 +77,6 @@ type RulePreempted struct {
 // Postpone based on a duration after the last preempted event.
 func (r *RulePreempted) Match(ready, _ *Task) (matched bool, reason string) {
 	preemption := Settings.Hub.Task.Preemption
-	if !preemption.Enabled {
-		return
-	}
 	mark := time.Now()
 	event, found := ready.LastEvent(Preempted)
 	if found {


### PR DESCRIPTION
When a task is preempted, it needs to be postponed for a short duration to prevent thrashing. Since individual tasks may override the _global_ preempt policy, the postpone must happen regardless.