### PR TITLE
:sparkles: Upload files instead of multi-part form.

### DIFF
--- a/binding/application.go
+++ b/binding/application.go
@@ -333,16 +333,19 @@ func (h *Analysis) Create(commit, encoding, issues, deps string) (err error) {
 	}
 	r := api.AnalysisManifest{Commit: commit}
 	file := File{client: h.client}
+	// post issues.
 	f, err := file.Post(issues)
 	if err != nil {
 		return
 	}
 	r.Issues = api.Ref{ID: f.ID}
+	// post deps.
 	f, err = file.Post(deps)
 	if err != nil {
 		return
 	}
 	r.Dependencies = api.Ref{ID: f.ID}
+	// post manifest.
 	path := Path(api.AppAnalysesRoot).Inject(Params{api.ID: h.appId})
 	err = h.client.Encoding(encoding).Post(path, r)
 	return


### PR DESCRIPTION
Upload issues and deps files instead of using multi-part form.
Much simpler and more easily supports the addon staging the issues and deps files on disk rather than streaming.  The more atomic approach will prevent transaction deadlock which can more easily occur when the addon-analyzer builder reported an error (which it should never do).