### PR TITLE
:sparkles: Broker KAI api through hub.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version: '1.22'
       - run: make fmt
 
   vet:
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version: '1.22'
       - run: make vet
 
   build:
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version: '1.22'
       - run: make cmd
 
   test-unit:
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version: '1.22'
       - run: make test
 
   test-api:
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version: '1.22'
       - run: |
           rm -f $DB_PATH
           make run &

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.22'
+          go-version: '1.21'
       - run: make fmt
 
   vet:
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.22'
+          go-version: '1.21'
       - run: make vet
 
   build:
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.22'
+          go-version: '1.21'
       - run: make cmd
 
   test-unit:
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.22'
+          go-version: '1.21'
       - run: make test
 
   test-api:
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.22'
+          go-version: '1.21'
       - run: |
           rm -f $DB_PATH
           make run &

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.22'
+          go-version: '1.21'
       - run: make test
 
   test-api:
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.22'
+          go-version: '1.21'
       - run: |
           make vet
           DISCONNECTED=1 make run &

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version: '1.22'
       - run: make test
 
   test-api:
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version: '1.22'
       - run: |
           make vet
           DISCONNECTED=1 make run &

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ $(CONTROLLERGEN):
 
 # Ensure goimports installed.
 $(GOIMPORTS):
-	go install golang.org/x/tools/cmd/goimports@latest
+	go install golang.org/x/tools/cmd/goimports@v0.24
 
 # Build SAMPLE ADDON
 addon: fmt vet

--- a/api/error.go
+++ b/api/error.go
@@ -79,7 +79,7 @@ func (r *Forbidden) Is(err error) (matched bool) {
 	return
 }
 
-// NotFound reports auth errors.
+// NotFound reports resource not-found errors.
 type NotFound struct {
 	Resource string
 	Reason   string

--- a/api/pkg.go
+++ b/api/pkg.go
@@ -78,6 +78,7 @@ func All() []Handler {
 		&RuleSetHandler{},
 		&SchemaHandler{},
 		&SettingHandler{},
+		&ServiceHandler{},
 		&StakeholderHandler{},
 		&StakeholderGroupHandler{},
 		&TagHandler{},

--- a/api/service.go
+++ b/api/service.go
@@ -29,7 +29,7 @@ type ServiceHandler struct {
 // AddRoutes adds routes.
 func (h ServiceHandler) AddRoutes(e *gin.Engine) {
 	e.GET(ServicesRoot, h.List)
-	e.Any(ServiceRoot, h.Forward)
+	e.Any(ServiceRoot, h.Required, h.Forward)
 }
 
 // List godoc
@@ -49,14 +49,15 @@ func (h ServiceHandler) List(ctx *gin.Context) {
 	h.Respond(ctx, http.StatusOK, r)
 }
 
+// Required enforces RBAC.
+func (h ServiceHandler) Required(ctx *gin.Context) {
+	Required(ctx.Param(Name))
+}
+
 // Forward provides RBAC and forwards request to the service.
 func (h ServiceHandler) Forward(ctx *gin.Context) {
 	path := ctx.Param(Wildcard)
 	name := ctx.Param(Name)
-	Required(name)
-	if len(ctx.Errors) > 0 {
-		return
-	}
 	route, found := serviceRoutes[name]
 	if !found {
 		err := &NotFound{Resource: name}

--- a/api/service.go
+++ b/api/service.go
@@ -1,0 +1,87 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httputil"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	core "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	k8s "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Routes
+const (
+	ServiceRoot = "/service/:name/*" + Wildcard
+)
+
+// ServiceHandler handles service routes.
+type ServiceHandler struct {
+	BaseHandler
+}
+
+// AddRoutes adds routes.
+func (h ServiceHandler) AddRoutes(e *gin.Engine) {
+	e.Any(ServiceRoot, h.ReverseProxy)
+}
+
+// ReverseProxy provides RBAC and forwards request to the service.
+func (h ServiceHandler) ReverseProxy(ctx *gin.Context) {
+	name := ctx.Param(Name)
+	path := ctx.Param(Wildcard)
+	Required(name)(ctx)
+	if len(ctx.Errors) > 0 {
+		return
+	}
+	service := &core.Service{}
+	err := h.Client(ctx).Get(
+		context.TODO(),
+		k8s.ObjectKey{
+			Namespace: Settings.Hub.Namespace,
+			Name:      name,
+		},
+		service)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			h.Status(ctx, http.StatusNotFound)
+			return
+		} else {
+			_ = ctx.Error(err)
+			return
+		}
+	}
+	host := service.Spec.ClusterIP
+	port := int(service.Spec.Ports[0].Port)
+	host = host + ":" + strconv.Itoa(port)
+	proxy := httputil.ReverseProxy{
+		Director: func(req *http.Request) {
+			req.URL.Scheme = h.scheme(service)
+			req.URL.Host = h.host(service)
+			req.URL.Path = path
+		},
+	}
+
+	proxy.ServeHTTP(ctx.Writer, ctx.Request)
+}
+
+func (h *ServiceHandler) scheme(service *core.Service) (scheme string) {
+	scheme = "http"
+	s, found := service.Annotations["konveyor.io/scheme"]
+	if found {
+		scheme = s
+	}
+	return
+}
+
+func (h *ServiceHandler) host(service *core.Service) (host string) {
+	host = service.Spec.ClusterIP
+	for _, p := range service.Spec.Ports {
+		port := int(p.Port)
+		host += ":"
+		host += strconv.Itoa(port)
+		break
+	}
+	return
+}

--- a/api/service.go
+++ b/api/service.go
@@ -31,7 +31,7 @@ func (h ServiceHandler) AddRoutes(e *gin.Engine) {
 func (h ServiceHandler) Forward(ctx *gin.Context) {
 	name := ctx.Param(Name)
 	path := ctx.Param(Wildcard)
-	Required(name)(ctx)
+	Required("service." + name)(ctx)
 	if len(ctx.Errors) > 0 {
 		return
 	}

--- a/api/service.go
+++ b/api/service.go
@@ -51,7 +51,7 @@ func (h ServiceHandler) List(ctx *gin.Context) {
 
 // Required enforces RBAC.
 func (h ServiceHandler) Required(ctx *gin.Context) {
-	Required(ctx.Param(Name))
+	Required(ctx.Param(Name))(ctx)
 }
 
 // Forward provides RBAC and forwards request to the service.

--- a/api/service.go
+++ b/api/service.go
@@ -24,11 +24,11 @@ type ServiceHandler struct {
 
 // AddRoutes adds routes.
 func (h ServiceHandler) AddRoutes(e *gin.Engine) {
-	e.Any(ServiceRoot, h.ReverseProxy)
+	e.Any(ServiceRoot, h.Forward)
 }
 
-// ReverseProxy provides RBAC and forwards request to the service.
-func (h ServiceHandler) ReverseProxy(ctx *gin.Context) {
+// Forward provides RBAC and forwards request to the service.
+func (h ServiceHandler) Forward(ctx *gin.Context) {
 	name := ctx.Param(Name)
 	path := ctx.Param(Wildcard)
 	Required(name)(ctx)

--- a/auth/roles.yaml
+++ b/auth/roles.yaml
@@ -82,6 +82,9 @@
         - get
         - post
         - put
+    - name: kai
+      verbs:
+        - get
     - name: proxies
       verbs:
         - delete
@@ -286,6 +289,9 @@
         - get
         - post
         - put
+    - name: kai
+      verbs:
+        - get
     - name: proxies
       verbs:
         - get
@@ -443,6 +449,9 @@
     - name: jobfunctions
       verbs:
         - get
+    - name: kai
+      verbs:
+        - get
     - name: proxies
       verbs:
         - get
@@ -558,6 +567,9 @@
       verbs:
         - get
     - name: jobfunctions
+      verbs:
+        - get
+    - name: kai
       verbs:
         - get
     - name: proxies

--- a/auth/roles.yaml
+++ b/auth/roles.yaml
@@ -85,6 +85,7 @@
     - name: kai
       verbs:
         - get
+        - post
     - name: proxies
       verbs:
         - delete
@@ -292,6 +293,7 @@
     - name: kai
       verbs:
         - get
+        - post
     - name: proxies
       verbs:
         - get
@@ -452,6 +454,7 @@
     - name: kai
       verbs:
         - get
+        - post
     - name: proxies
       verbs:
         - get
@@ -572,6 +575,7 @@
     - name: kai
       verbs:
         - get
+        - post
     - name: proxies
       verbs:
         - get


### PR DESCRIPTION
Add `/services/` endpoint.
Add `/services/kai/*` endpoint reverse-proxy to route defined in KAI_URL. 
Add auth scopes.

Related: https://github.com/konveyor/operator/pull/376