### PR TITLE
:sparkles: Run task pod as AnyUser. (#755)

### DIFF
--- a/settings/addon.go
+++ b/settings/addon.go
@@ -7,13 +7,16 @@ import (
 )
 
 const (
-	EnvHubBaseURL = "HUB_BASE_URL"
-	EnvHubToken   = "TOKEN"
-	EnvTask       = "TASK"
+	EnvHubBaseURL   = "HUB_BASE_URL"
+	EnvHubToken     = "TOKEN"
+	EnvTask         = "TASK"
+	EnvAddonHomeDir = "ADDON_HOME"
 )
 
 // Addon settings.
 type Addon struct {
+	// HomeDir working directory.
+	HomeDir string
 	// Hub settings.
 	Hub struct {
 		// URL for the hub API.
@@ -27,6 +30,10 @@ type Addon struct {
 
 func (r *Addon) Load() (err error) {
 	var found bool
+	r.HomeDir, found = os.LookupEnv(EnvAddonHomeDir)
+	if !found {
+		r.HomeDir = "/addon"
+	}
 	r.Hub.URL, found = os.LookupEnv(EnvHubBaseURL)
 	if !found {
 		r.Hub.URL = "http://localhost:8080"

--- a/task/manager.go
+++ b/task/manager.go
@@ -78,6 +78,7 @@ const (
 )
 
 const (
+	Addon  = "addon"
 	Shared = "shared"
 	Cache  = "cache"
 )
@@ -1484,6 +1485,12 @@ func (r *Task) specification(
 	addon *crd.Addon,
 	extensions []crd.Extension,
 	secret *core.Secret) (specification core.PodSpec) {
+	addonDir := core.Volume{
+		Name: Addon,
+		VolumeSource: core.VolumeSource{
+			EmptyDir: &core.EmptyDirVolumeSource{},
+		},
+	}
 	shared := core.Volume{
 		Name: Shared,
 		VolumeSource: core.VolumeSource{
@@ -1511,6 +1518,7 @@ func (r *Task) specification(
 		InitContainers:     init,
 		Containers:         plain,
 		Volumes: []core.Volume{
+			addonDir,
 			shared,
 			cache,
 		},
@@ -1524,7 +1532,6 @@ func (r *Task) containers(
 	addon *crd.Addon,
 	extensions []crd.Extension,
 	secret *core.Secret) (init []core.Container, plain []core.Container) {
-	userid := int64(0)
 	token := &core.EnvVarSource{
 		SecretKeyRef: &core.SecretKeySelector{
 			Key: settings.EnvHubToken,
@@ -1548,11 +1555,12 @@ func (r *Task) containers(
 		container := &plain[i]
 		injector.Inject(container)
 		r.propagateEnv(&plain[0], container)
-		container.SecurityContext = &core.SecurityContext{
-			RunAsUser: &userid,
-		}
 		container.VolumeMounts = append(
 			container.VolumeMounts,
+			core.VolumeMount{
+				Name:      Addon,
+				MountPath: Settings.Addon.HomeDir,
+			},
 			core.VolumeMount{
 				Name:      Shared,
 				MountPath: Settings.Shared.Path,
@@ -1563,6 +1571,10 @@ func (r *Task) containers(
 			})
 		container.Env = append(
 			container.Env,
+			core.EnvVar{
+				Name:  settings.EnvAddonHomeDir,
+				Value: Settings.Addon.HomeDir,
+			},
 			core.EnvVar{
 				Name:  settings.EnvSharedPath,
 				Value: Settings.Shared.Path,


### PR DESCRIPTION
To support running the task pods as _AnyUser_ instead of root:
- The task manager needs to no longer RunAs user root.
- The /addon directory needs to be an _EmptyDir_. This is because the addon-analyzer Dockerfile cannot create the /addon directory as owned by the _AnyUser_.

Signed-off-by: Jeff Ortel <jortel@redhat.com>
(cherry picked from commit 8769075b3668ed48ae7fe4214c1c3c0757e386ca)