### PR TITLE
:sparkles: Max DB connections setting.

### DIFF
--- a/database/pkg.go
+++ b/database/pkg.go
@@ -51,6 +51,14 @@ func Open(enforceFKs bool) (db *gorm.DB, err error) {
 		err = liberr.Wrap(err)
 		return
 	}
+	if Settings.DB.MaxConnection > 0 {
+		dbx, nErr := db.DB()
+		if nErr != nil {
+			err = liberr.Wrap(nErr)
+			return
+		}
+		dbx.SetMaxOpenConns(Settings.DB.MaxConnection)
+	}
 	err = db.AutoMigrate(model.PK{}, model.Setting{})
 	if err != nil {
 		err = liberr.Wrap(err)

--- a/settings/hub.go
+++ b/settings/hub.go
@@ -9,6 +9,7 @@ import (
 const (
 	EnvNamespace               = "NAMESPACE"
 	EnvDbPath                  = "DB_PATH"
+	EnvDbMaxCon                = "DB_MAX_CONNECTION"
 	EnvDbSeedPath              = "DB_SEED_PATH"
 	EnvBucketPath              = "BUCKET_PATH"
 	EnvRwxSupported            = "RWX_SUPPORTED"
@@ -45,8 +46,9 @@ type Hub struct {
 	Namespace string
 	// DB settings.
 	DB struct {
-		Path     string
-		SeedPath string
+		Path          string
+		MaxConnection int
+		SeedPath      string
 	}
 	// Bucket settings.
 	Bucket struct {
@@ -127,6 +129,13 @@ func (r *Hub) Load() (err error) {
 	if !found {
 		r.DB.Path = "/tmp/tackle.db"
 	}
+	s, found := os.LookupEnv(EnvDbMaxCon)
+	if found {
+		n, _ := strconv.Atoi(s)
+		r.DB.MaxConnection = n
+	} else {
+		r.DB.MaxConnection = 1
+	}
 	r.DB.SeedPath, found = os.LookupEnv(EnvDbSeedPath)
 	if !found {
 		r.DB.SeedPath = "/tmp/seed"
@@ -135,7 +144,7 @@ func (r *Hub) Load() (err error) {
 	if !found {
 		r.Bucket.Path = "/tmp/bucket"
 	}
-	s, found := os.LookupEnv(EnvRwxSupported)
+	s, found = os.LookupEnv(EnvRwxSupported)
 	if found {
 		b, _ := strconv.ParseBool(s)
 		r.Cache.RWX = b


### PR DESCRIPTION
Makes the (max) number of DB connections configurable.  The default=1 which is:
- The safest.
- Most consistent performance (not necessarily the best) on NFS.
- Matches how <=0.5 has always worked.

Increasing max-connections > 1 provides much better throughput on fast filesystems.