### PR TITLE
:bug: Fix running as non-root on vanilla kubernetes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ COPY --from=report /usr/local/static-report /tmp/analysis/report
 RUN microdnf -y install \
   sqlite \
  && microdnf -y clean all
+RUN echo "hub:x:1001:0:hub:/:/sbin/nologin" >> /etc/passwd
 ENTRYPOINT ["/usr/local/bin/tackle-hub"]
 
 LABEL name="konveyor/tackle2-hub" \


### PR DESCRIPTION
It looks like running as root is failing on minikube (and probably vanilla kubernetes) because there is no /etc/passwd entry to correspond to the UID. This is the source of the current test failures.

https://github.com/golang/go/issues/38599

In a minikube environment the operator runs as UID 1001 and assigns this to the hub as well.

My thoughts on this were that we could:
- Add a /etc/passwd for uid 1001 to cover the default vanilla kube/minikube scenario
- Check in the operator if the operators uid is 1001 and if so set the hub_uid to 0 instead, which I guess mimics the current status quo.
- Find a different way to get the UID in go... (no luck so far and I'd guess if there were an option it would have been mentioned on the issue linked above).

@jortel  also mentioned we could:
- Have the hub exec and run id -u instead of os.user.Current().
- If the ansible module in the operator has access to the real uid, it can set the "TASK_UID" env var.

I am happy to rework this however we want.