### PR TITLE
:bug: Update analyses/report/dependencies labels query

### DIFF
--- a/api/analysis.go
+++ b/api/analysis.go
@@ -1692,10 +1692,9 @@ func (h AnalysisHandler) DepReports(ctx *gin.Context) {
 	q = q.Select(
 		"d.Provider",
 		"d.Name",
-		"json_group_array(distinct j.value) Labels",
+		"d.Labels",
 		"COUNT(distinct d.AnalysisID) Applications")
 	q = q.Table("TechDependency d")
-	q = q.Joins(",json_each(Labels) j")
 	q = q.Where("d.AnalysisID IN (?)", h.analysisIDs(ctx, filter))
 	q = q.Where("d.ID IN (?)", h.depIDs(ctx, filter))
 	q = q.Group("d.Provider, d.Name")


### PR DESCRIPTION
Updating SQL query for getting TechDependencies to include also dependencies with empty labels (that were not returned before).

Related to https://issues.redhat.com/browse/MTA-4169

@jortel This look to work for me, if there were plans for using `json_` methods (or I missed some unwanted side-effect), I open to another solution.

Example query and results with this change:
```
SELECT * FROM (SELECT d.Provider,d.Name,d.Labels,COUNT(distinct d.AnalysisID) Applications FROM TechDependency d WHERE d.AnalysisID IN (SELECT MAX(ID) FROM `Analysis` WHERE ApplicationID IN (SELECT `ID` FROM `Application`) GROUP BY `ApplicationID`) AND d.ID IN (SELECT `ID` FROM `TechDependency`) GROUP BY d.Provider, d.Name) ORDER BY name COLLATE NOCASE;
java|AdministracionEfectivoGrupo.AdministracionEfectivo-ejb|["konveyor.io/dep-source=internal","konveyor.io/language=java"]|1
java|AdministracionEfectivoGrupo.AdministracionEfectivo-jpa|["konveyor.io/dep-source=internal","konveyor.io/language=java"]|1
java|AdministracionEfectivoGrupo.AdministracionEfectivo-seguridad|["konveyor.io/dep-source=internal","konveyor.io/language=java"]|1
java|antlr.antlr|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|4
java|aopalliance.aopalliance|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|2
java|asm.asm|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|bcmail-jdk14-1.38.jar|[]|1
java|bcmail-jdk14-138.jar|[]|1
java|bcprov-jdk14-1.38.jar|[]|1
java|bcprov-jdk14-138.jar|[]|1
java|c3p0.c3p0|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|cglib.cglib|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|ch.qos.logback.logback-classic|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|4
java|ch.qos.logback.logback-core|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|com.fasterxml.classmate|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|com.fasterxml.jackson.core.jackson-annotations|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|4
java|com.fasterxml.jackson.core.jackson-core|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|4
java|com.fasterxml.jackson.core.jackson-databind|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|4
java|com.fasterxml.jackson.datatype.jackson-datatype-jsr310|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|com.fasterxml.jackson.jackson-bom|[]|1
java|com.h2database.h2|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|com.ibm.ws.jsf.jar|[]|1
java|com.oracle.database.jdbc.ojdbc11|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|com.oracle.database.jdbc.ojdbc8|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|com.sun.istack.istack-commons-runtime|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|com.sun.mail.javax.mail|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|2
java|com.sun.xml.fastinfoset.FastInfoset|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|commons-beanutils.commons-beanutils|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|commons-collections.commons-collections|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|commons-digester.commons-digester|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|commons-logging.commons-logging|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|2
java|dom4j-1.6.1.jar|[]|1
java|eclipse.jdtcore|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|io.konveyor.demo.config-utils|["konveyor.io/dep-source=internal","konveyor.io/language=java"]|1
java|io.konveyor.demo.configuration-utils|["konveyor.io/dep-source=internal","konveyor.io/language=java"]|3
java|io.micrometer.micrometer-core|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|itext-2.1.7.js2.jar|[]|1
java|j2ee.jar|[]|1
java|jakarta.annotation.jakarta.annotation-api|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|jakarta.validation.jakarta.validation-api|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|javax.activation.activation|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|2
java|javax.activation.javax.activation-api|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|javax.annotation.javax.annotation-api|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|javax.javaee-api|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|2
java|javax.javaee-web-api|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|javax.persistence.javax.persistence-api|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|javax.validation.validation-api|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|javax.xml.bind.jaxb-api|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|jfree.jcommon|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|jfree.jfreechart|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|log4j.log4j|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|net.bytebuddy.byte-buddy|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|net.sf.jasperreports.jasperreports|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|net.wasdev.wlp.sample.acmeair-common|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|net.wasdev.wlp.sample.acmeair-services|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|net.wasdev.wlp.sample.acmeair-services-jpa|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|net.wasdev.wlp.sample.daytrader-ee7-ejb|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|net.wasdev.wlp.sample.daytrader-ee7-web|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|ojdbc6-11.2.0.3.jar|[]|1
java|org.apache.derby.derby|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|org.apache.logging.log4j.log4j-api|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.apache.logging.log4j.log4j-to-slf4j|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.apache.tomcat.tomcat-jdbc|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|4
java|org.apache.tomcat.tomcat-juli|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.apache.tomcat.tomcat-servlet-api|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.aspectj.aspectjrt|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|4
java|org.aspectj.aspectjweaver|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|org.bouncycastle.bctsp-jdk14|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|org.checkerframework.checker-qual|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.codehaus.castor.castor|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|org.dom4j.dom4j|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.eclipse.persistence.javax.persistence|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|org.flywaydb.flyway-core|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|org.glassfish.jaxb.jaxb-runtime|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.glassfish.jaxb.txw2|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.hdrhistogram.HdrHistogram|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.hibernate.common.hibernate-commons-annotations|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|4
java|org.hibernate.hibernate-core|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|4
java|org.hibernate.hibernate-entitymanager|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|4
java|org.hibernate.hibernate-validator|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|org.hibernate.javax.persistence.hibernate-jpa-2.0-api|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|org.hibernate.validator.hibernate-validator|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|4
java|org.jasypt.jasypt|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|org.javassist.javassist|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|4
java|org.jboss.jandex|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.jboss.logging.jboss-logging|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|4
java|org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|org.jboss.spec.javax.rmi.jboss-rmi-api_1.0_spec|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|org.jboss.spec.javax.transaction.jboss-transaction-api_1.1_spec|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.jvnet.staxex.stax-ex|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.latencyutils.LatencyUtils|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.postgresql.postgresql|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|4
java|org.primefaces.primefaces|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|org.quartz-scheduler.quartz|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|org.quartz-scheduler.quartz-jobs|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|org.slf4j.jul-to-slf4j|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.slf4j.slf4j-api|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|4
java|org.slf4j.slf4j-log4j12|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|org.springframework.boot.spring-boot|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.springframework.boot.spring-boot-actuator|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.springframework.boot.spring-boot-actuator-autoconfigure|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.springframework.boot.spring-boot-autoconfigure|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.springframework.boot.spring-boot-starter|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.springframework.boot.spring-boot-starter-actuator|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|4
java|org.springframework.boot.spring-boot-starter-logging|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.springframework.data.spring-data-bom|[]|1
java|org.springframework.data.spring-data-commons|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.springframework.data.spring-data-jpa|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.springframework.spring-aop|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|5
java|org.springframework.spring-asm|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|2
java|org.springframework.spring-beans|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|5
java|org.springframework.spring-context|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|5
java|org.springframework.spring-core|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|5
java|org.springframework.spring-expression|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|5
java|org.springframework.spring-jcl|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.springframework.spring-jdbc|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|4
java|org.springframework.spring-orm|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.springframework.spring-tx|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|4
java|org.springframework.spring-web|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|5
java|org.springframework.spring-webmvc|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|4
java|org.yaml.snakeyaml|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|taglibs.standard|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|xml-apis.xml-apis|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
```

Example beforePR change (missing "short" lines - without labels -  from example above)
```
SELECT * FROM (SELECT d.Provider,d.Name,json_group_array(distinct j.value) Labels,COUNT(distinct d.AnalysisID) Applications FROM TechDependency d ,json_each(Labels) j WHERE d.AnalysisID IN (SELECT MAX(ID) FROM `Analysis` WHERE ApplicationID IN (SELECT `ID` FROM `Application`) GROUP BY `ApplicationID`) AND d.ID IN (SELECT `ID` FROM `TechDependency`) GROUP BY d.Provider, d.Name) ORDER BY name COLLATE NOCASE;
java|AdministracionEfectivoGrupo.AdministracionEfectivo-ejb|["konveyor.io/dep-source=internal","konveyor.io/language=java"]|1
java|AdministracionEfectivoGrupo.AdministracionEfectivo-jpa|["konveyor.io/dep-source=internal","konveyor.io/language=java"]|1
java|AdministracionEfectivoGrupo.AdministracionEfectivo-seguridad|["konveyor.io/dep-source=internal","konveyor.io/language=java"]|1
java|antlr.antlr|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|4
java|aopalliance.aopalliance|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|2
java|asm.asm|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|c3p0.c3p0|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|cglib.cglib|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|ch.qos.logback.logback-classic|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|ch.qos.logback.logback-core|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|com.fasterxml.classmate|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|com.fasterxml.jackson.core.jackson-annotations|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|4
java|com.fasterxml.jackson.core.jackson-core|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|4
java|com.fasterxml.jackson.core.jackson-databind|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|4
java|com.fasterxml.jackson.datatype.jackson-datatype-jsr310|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|com.h2database.h2|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|2
java|com.oracle.database.jdbc.ojdbc11|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|2
java|com.oracle.database.jdbc.ojdbc8|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|com.sun.istack.istack-commons-runtime|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|com.sun.mail.javax.mail|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|2
java|com.sun.xml.fastinfoset.FastInfoset|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|commons-beanutils.commons-beanutils|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|commons-collections.commons-collections|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|commons-digester.commons-digester|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|commons-logging.commons-logging|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|2
java|eclipse.jdtcore|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|io.konveyor.demo.config-utils|["konveyor.io/dep-source=internal","konveyor.io/language=java"]|1
java|io.konveyor.demo.configuration-utils|["konveyor.io/dep-source=internal","konveyor.io/language=java"]|2
java|io.micrometer.micrometer-core|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|jakarta.annotation.jakarta.annotation-api|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|jakarta.validation.jakarta.validation-api|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|javax.activation.activation|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|2
java|javax.activation.javax.activation-api|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|javax.annotation.javax.annotation-api|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|javax.javaee-api|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|2
java|javax.javaee-web-api|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|javax.persistence.javax.persistence-api|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|javax.validation.validation-api|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|javax.xml.bind.jaxb-api|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|jfree.jcommon|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|jfree.jfreechart|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|log4j.log4j|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|net.bytebuddy.byte-buddy|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|net.sf.jasperreports.jasperreports|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|net.wasdev.wlp.sample.acmeair-common|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|net.wasdev.wlp.sample.acmeair-services|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|net.wasdev.wlp.sample.acmeair-services-jpa|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|net.wasdev.wlp.sample.daytrader-ee7-ejb|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|net.wasdev.wlp.sample.daytrader-ee7-web|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|org.apache.derby.derby|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|org.apache.logging.log4j.log4j-api|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.apache.logging.log4j.log4j-to-slf4j|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.apache.tomcat.tomcat-jdbc|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.apache.tomcat.tomcat-juli|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.apache.tomcat.tomcat-servlet-api|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|2
java|org.aspectj.aspectjrt|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|4
java|org.aspectj.aspectjweaver|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|org.bouncycastle.bctsp-jdk14|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|org.checkerframework.checker-qual|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.codehaus.castor.castor|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|org.dom4j.dom4j|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.eclipse.persistence.javax.persistence|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|org.flywaydb.flyway-core|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|org.glassfish.jaxb.jaxb-runtime|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.glassfish.jaxb.txw2|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.hdrhistogram.HdrHistogram|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.hibernate.common.hibernate-commons-annotations|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|4
java|org.hibernate.hibernate-core|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|4
java|org.hibernate.hibernate-entitymanager|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.hibernate.hibernate-validator|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|org.hibernate.javax.persistence.hibernate-jpa-2.0-api|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|org.hibernate.validator.hibernate-validator|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.jasypt.jasypt|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|org.javassist.javassist|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|4
java|org.jboss.jandex|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.jboss.logging.jboss-logging|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|4
java|org.jboss.spec.javax.jms.jboss-jms-api_2.0_spec|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|org.jboss.spec.javax.rmi.jboss-rmi-api_1.0_spec|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|org.jboss.spec.javax.transaction.jboss-transaction-api_1.1_spec|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|org.jboss.spec.javax.transaction.jboss-transaction-api_1.2_spec|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.jvnet.staxex.stax-ex|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.latencyutils.LatencyUtils|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.postgresql.postgresql|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.primefaces.primefaces|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|org.quartz-scheduler.quartz|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|org.quartz-scheduler.quartz-jobs|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|org.slf4j.jul-to-slf4j|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.slf4j.slf4j-api|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|4
java|org.slf4j.slf4j-log4j12|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|org.springframework.boot.spring-boot|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.springframework.boot.spring-boot-actuator|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.springframework.boot.spring-boot-actuator-autoconfigure|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.springframework.boot.spring-boot-autoconfigure|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.springframework.boot.spring-boot-starter|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.springframework.boot.spring-boot-starter-actuator|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.springframework.boot.spring-boot-starter-logging|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.springframework.data.spring-data-commons|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.springframework.data.spring-data-jpa|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.springframework.spring-aop|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|5
java|org.springframework.spring-asm|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|2
java|org.springframework.spring-beans|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|5
java|org.springframework.spring-context|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|5
java|org.springframework.spring-core|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|5
java|org.springframework.spring-expression|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|5
java|org.springframework.spring-jcl|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.springframework.spring-jdbc|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.springframework.spring-orm|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.springframework.spring-tx|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|4
java|org.springframework.spring-web|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|4
java|org.springframework.spring-webmvc|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|org.yaml.snakeyaml|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|3
java|taglibs.standard|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
java|xml-apis.xml-apis|["konveyor.io/dep-source=open-source","konveyor.io/language=java"]|1
```