### PR TITLE
:sparkles: Update Issue Description

### DIFF
--- a/api/analysis.go
+++ b/api/analysis.go
@@ -1109,7 +1109,8 @@ func (h AnalysisHandler) AppIssueReports(ctx *gin.Context) {
 	resources := []*IssueReport{}
 	type M struct {
 		model.Issue
-		Files int
+		Files   int
+		Message string
 	}
 	id := h.pk(ctx)
 	err := h.DB(ctx).First(&model.Application{}, id).Error
@@ -1164,6 +1165,7 @@ func (h AnalysisHandler) AppIssueReports(ctx *gin.Context) {
 		"i.Effort",
 		"i.Labels",
 		"i.Links",
+		"n.Message",
 		"COUNT(distinct n.File) Files")
 	q = q.Table("Issue i,")
 	q = q.Joins("Incident n")
@@ -1201,8 +1203,10 @@ func (h AnalysisHandler) AppIssueReports(ctx *gin.Context) {
 	for i := range list {
 		m := list[i]
 		r := &IssueReport{
-			Files:       m.Files,
-			Description: m.Description,
+			Files: m.Files,
+			// Append Incident Message to Description to provide more information on Issue detail
+			// (workaround until Analyzer output Violation struct gets updated to provide better structured data)
+			Description: fmt.Sprintf("%s\n\n%s", m.Description, m.Message),
 			Category:    m.Category,
 			RuleSet:     m.RuleSet,
 			Rule:        m.Rule,


### PR DESCRIPTION
Issue Description field might be too short to provide enough information about fixing the issue, appending incident Message to it to make it more useful.

This is more a workaround/quickfix, long-term solution is explained in ticket below and at https://github.com/konveyor/analyzer-lsp/discussions/452

Related to: https://issues.redhat.com/browse/MTA-4421 and Hub version of https://github.com/konveyor/kantra/issues/341