### PR TITLE
:sparkles: Support bulk task cancel using filter criteria.

### DIFF
--- a/api/task.go
+++ b/api/task.go
@@ -25,6 +25,7 @@ const (
 	TasksReportRoot          = TasksRoot + "/report"
 	TasksReportQueueRoot     = TasksReportRoot + "/queue"
 	TasksReportDashboardRoot = TasksReportRoot + "/dashboard"
+	TasksCancelRoot          = TasksRoot + "/cancel"
 	TaskRoot                 = TasksRoot + "/:" + ID
 	TaskReportRoot           = TaskRoot + "/report"
 	TaskAttachedRoot         = TaskRoot + "/attached"
@@ -32,7 +33,6 @@ const (
 	TaskBucketContentRoot    = TaskBucketRoot + "/*" + Wildcard
 	TaskSubmitRoot           = TaskRoot + "/submit"
 	TaskCancelRoot           = TaskRoot + "/cancel"
-	TasksCancelRoot          = TasksRoot + "/cancel"
 )
 const (
 	Submit = "submit"

--- a/binding/task.go
+++ b/binding/task.go
@@ -30,10 +30,10 @@ func (h *Task) List() (list []api.Task, err error) {
 	return
 }
 
-// CancelMultipleTasks - Cancel multiple tasks by their IDs.
-func (h *Task) CancelMultipleTasks(ids []uint) (err error) {
-    err = h.client.Put(api.TaskCancelListRoot, ids)
-    return
+// BulkCancel - Cancel tasks matched by filter.
+func (h *Task) BulkCancel(filter Filter) (err error) {
+	err = h.client.Put(api.TasksCancelRoot, 0, filter.Param())
+	return
 }
 
 // Update a Task.

--- a/test/api/task/api_test.go
+++ b/test/api/task/api_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/konveyor/tackle2-hub/binding"
+	"github.com/konveyor/tackle2-hub/binding/filter"
 	"github.com/konveyor/tackle2-hub/test/assert"
 )
 
@@ -108,5 +110,14 @@ func TestTaskList(t *testing.T) {
 
 	for _, r := range samples {
 		assert.Must(t, Task.Delete(r.ID))
+	}
+}
+
+func TestBulkCancel(t *testing.T) {
+	f := binding.Filter{}
+	f.And("id").Eq(filter.Any{1, 2, 3})
+	err := Task.BulkCancel(f)
+	if err != nil {
+		t.Errorf(err.Error())
 	}
 }


### PR DESCRIPTION
Update the bulk (cancel) action route to be an action against the collection.  Also, instead of passing a list of IDs in the body, use a filter instead.  This is more flexible and RESTful.

Example:
/tasks/cancel?filter=id:(1|2|3)
/tasks/cancel?filter=application.id:44
/tasks/cancel?filter=kind:analysis,state=Pending

The only downside is the url length may be an issue for many thousands of cancels (by id).  However, I don't see that as a mainstream use-case.  I would think that use-case would be better supported by filtering by other than id.  To cancel all running tasks, an empty filter may be passed.