### PR TITLE
:ghost: using any instead of interface{} introduced in Go 1.18.

### DIFF
--- a/api/context.go
+++ b/api/context.go
@@ -53,7 +53,7 @@ func (r *Context) Status(status int) {
 }
 
 // Respond sets the values to respond to the request with.
-func (r *Context) Respond(status int, body interface{}) {
+func (r *Context) Respond(status int, body any) {
 	r.Response = Response{
 		Status: status,
 		Body:   body,

--- a/database/pk.go
+++ b/database/pk.go
@@ -82,7 +82,7 @@ func (r *PkSequence) session(in *gorm.DB) (out *gorm.DB) {
 		ConnPool: in.Statement.ConnPool,
 		Context:  in.Statement.Context,
 		Clauses:  map[string]clause.Clause{},
-		Vars:     make([]interface{}, 0, 8),
+		Vars:     make([]any, 0, 8),
 	}
 	return
 }

--- a/docs/binding.txt
+++ b/docs/binding.txt
@@ -78,7 +78,7 @@ func (h *AppFacts) List() (list []api.Fact, err error)
 func (h *AppFacts) Replace(facts []api.Fact) (err error)
     Replace facts.
 
-func (h *AppFacts) Set(key string, value interface{}) (err error)
+func (h *AppFacts) Set(key string, value any) (err error)
     Set a fact (created as needed).
 
 func (h *AppFacts) Source(source string)
@@ -178,19 +178,19 @@ func (r *Client) Delete(path string, params ...Param) (err error)
 func (r *Client) FileGet(path, destination string) (err error)
     FileGet downloads a file.
 
-func (r *Client) FilePut(path, source string, object interface{}) (err error)
+func (r *Client) FilePut(path, source string, object any) (err error)
     FilePut uploads a file. Returns the created File resource.
 
-func (r *Client) FileSend(path, method string, fields []Field, object interface{}) (err error)
+func (r *Client) FileSend(path, method string, fields []Field, object any) (err error)
     FileSend sends file upload from.
 
-func (r *Client) Get(path string, object interface{}, params ...Param) (err error)
+func (r *Client) Get(path string, object any, params ...Param) (err error)
     Get a resource.
 
-func (r *Client) Post(path string, object interface{}) (err error)
+func (r *Client) Post(path string, object any) (err error)
     Post a resource.
 
-func (r *Client) Put(path string, object interface{}, params ...Param) (err error)
+func (r *Client) Put(path string, object any, params ...Param) (err error)
     Put a resource.
 
 func (r *Client) Reset()
@@ -262,7 +262,7 @@ type Param struct {
 }
     Param.
 
-type Params map[string]interface{}
+type Params map[string]any
     Params mapping.
 
 type Path string
@@ -313,7 +313,7 @@ type Setting struct {
 func (h *Setting) Bool(key string) (b bool, err error)
     Bool setting value.
 
-func (h *Setting) Get(key string, v interface{}) (err error)
+func (h *Setting) Get(key string, v any) (err error)
     Get a setting by key.
 
 func (h *Setting) Int(key string) (n int, err error)
@@ -384,7 +384,7 @@ type Task struct {
 }
     Task API.
 
-func (h *Task) Activity(entry string, x ...interface{})
+func (h *Task) Activity(entry string, x ...any)
     Activity report addon activity. The description can be a printf style
     format.
 
@@ -397,13 +397,13 @@ func (h *Task) Bucket() (b *Bucket)
 func (h *Task) Completed(n int)
     Completed report addon completed (N) items.
 
-func (h *Task) Data() (d map[string]interface{})
+func (h *Task) Data() (d map[string]any)
     Data returns the addon data.
 
-func (h *Task) DataWith(object interface{}) (err error)
+func (h *Task) DataWith(object any) (err error)
     DataWith populates the addon data object.
 
-func (h *Task) Failed(reason string, x ...interface{})
+func (h *Task) Failed(reason string, x ...any)
     Failed report addon failed. The reason can be a printf style format.
 
 func (h *Task) Increment()
@@ -412,7 +412,7 @@ func (h *Task) Increment()
 func (h *Task) Load()
     Load a task by ID.
 
-func (h *Task) Result(object interface{})
+func (h *Task) Result(object any)
     Result report addon result.
 
 func (h *Task) Started()

--- a/hack/next-migration.sh
+++ b/hack/next-migration.sh
@@ -57,7 +57,7 @@ func (r Migration) Apply(db *gorm.DB) (err error) {
 	return
 }
 
-func (r Migration) Models() []interface{} {
+func (r Migration) Models() []any {
 	return model.All()
 }
 EOF

--- a/migration/v15/migrate.go
+++ b/migration/v15/migrate.go
@@ -15,6 +15,6 @@ func (r Migration) Apply(db *gorm.DB) (err error) {
 	return
 }
 
-func (r Migration) Models() []interface{} {
+func (r Migration) Models() []any {
 	return model.All()
 }


### PR DESCRIPTION
Consistently use _any_ keyword.