### PR TITLE
:bug: Reduce noise produced by the builtin provider.

### DIFF
--- a/auth/auth_test.go
+++ b/auth/auth_test.go
@@ -193,6 +193,26 @@ func TestRequestPermitNotAuthenticated(t *testing.T) {
 	g.Expect(len(result.Scopes)).To(gomega.Equal(0))
 }
 
+func TestRequestPermitNotNotValid(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	Settings.Auth.Token.Key = "TestKey"
+	Hub = &Builtin{}
+	Remote = &_TestProvider{err: &NotValid{}}
+	//
+	// Permit
+	request := Request{
+		Token:  "ABCD",
+		Scope:  "things",
+		Method: "PUT",
+	}
+	result, err := request.Permit()
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(result.Authenticated).To(gomega.BeFalse())
+	g.Expect(result.Authorized).To(gomega.BeFalse())
+	g.Expect(result.User).To(gomega.Equal(""))
+	g.Expect(len(result.Scopes)).To(gomega.Equal(0))
+}
+
 func TestRequestHubPermitNotAuthorized(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	Settings.Auth.Token.Key = "TestKey"

--- a/auth/builtin.go
+++ b/auth/builtin.go
@@ -67,8 +67,8 @@ type Builtin struct {
 func (r *Builtin) Authenticate(request *Request) (jwToken *jwt.Token, err error) {
 	defer func() {
 		if errors.Is(err, &NotValid{}) {
-			Log.V(1).Info(
-				"Token not valid",
+			Log.V(2).Info(
+				"[builtin] Token not valid",
 				"token",
 				request.Token,
 				"reason",

--- a/auth/builtin.go
+++ b/auth/builtin.go
@@ -67,12 +67,7 @@ type Builtin struct {
 func (r *Builtin) Authenticate(request *Request) (jwToken *jwt.Token, err error) {
 	defer func() {
 		if errors.Is(err, &NotValid{}) {
-			Log.V(2).Info(
-				"[builtin] Token not valid",
-				"token",
-				request.Token,
-				"reason",
-				err.Error())
+			Log.V(2).Info("[builtin] " + err.Error())
 		}
 	}()
 	token, err := r.parseToken(request)

--- a/auth/builtin.go
+++ b/auth/builtin.go
@@ -66,7 +66,7 @@ type Builtin struct {
 func (r *Builtin) Authenticate(request *Request) (jwToken *jwt.Token, err error) {
 	defer func() {
 		if err != nil {
-			Log.Info(err.Error())
+			Log.V(2).Info(err.Error())
 		}
 	}()
 	token, err := r.parseToken(request)

--- a/auth/builtin.go
+++ b/auth/builtin.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"errors"
 	"strings"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -65,8 +66,13 @@ type Builtin struct {
 // Authenticate the token
 func (r *Builtin) Authenticate(request *Request) (jwToken *jwt.Token, err error) {
 	defer func() {
-		if err != nil {
-			Log.V(2).Info(err.Error())
+		if errors.Is(err, &NotValid{}) {
+			Log.V(1).Info(
+				"Token not valid",
+				"token",
+				request.Token,
+				"reason",
+				err.Error())
 		}
 	}()
 	token, err := r.parseToken(request)

--- a/auth/request.go
+++ b/auth/request.go
@@ -51,6 +51,11 @@ func (r *Request) Permit() (result Result, err error) {
 				break
 			}
 		}
+	} else {
+		Log.Info(
+			"Token not authenticated.",
+			"token",
+			r.Token)
 	}
 	return
 }


### PR DESCRIPTION
When auth is enabled, the builtin provider is logging all errors (even token not authenticated).  Not authenticating the token is is part of the designed process.  The builtin provider should only log invalid tokens and a higher (level=2) logging level. Tokens not authenticated should only be logged (level=1) when none of the providers can authenticate it.

Spam Example:
```
time=2025-02-06T14:33:58Z level=info msg=[auth] Token
 [eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJHb1ZGZ3ltY2pCT3Z2eDNtLUFy
CB0YXJnZXRzOmdldCB0YXJnZXRzOnBvc3QgdHJhY2tlcnM6cG9zdCBhcHBsaWNhdGlv
ZXJzOmRlbGV0ZSBzdGFrZWhvbGRlcnM6cG9zdCBwcm9maWxlIGJ1Y2tldHM6ZGVsZXR
XGJEv_63_gL3RezVKBOMI4G_pVXzsNgzSB-aK703RVwfVxZrys2I3z7tA4u2LynMVFTuZ] not-authenticated.
```