### PR TITLE
:sparkles: Support extenion compat with addon as regex.

### DIFF
--- a/settings/hub.go
+++ b/settings/hub.go
@@ -368,6 +368,7 @@ func (r *Hub) namespace() (ns string, err error) {
 // build returns the hub build version.
 // This is expected to be the output of `git describe`.
 // Examples:
+//
 //	v0.6.0-ea89gcd
 //	v0.6.0
 func (r *Hub) build() (version string, err error) {

--- a/task/error.go
+++ b/task/error.go
@@ -231,23 +231,21 @@ func (e *SelectorNotValid) Retry() (r bool) {
 	return
 }
 
-// AddonRegexNotValid reports extension.Addon REGEX errors.
-type AddonRegexNotValid struct {
+// ExtAddonNotValid reports extension addon ref error.
+type ExtAddonNotValid struct {
 	Extension string
-	Pattern   string
 	Reason    string
 }
 
-func (e *AddonRegexNotValid) Error() string {
+func (e *ExtAddonNotValid) Error() string {
 	return fmt.Sprintf(
-		"Extension (%s) addon REGEX '%s' not valid: %s",
+		"Extension '%s' addon ref not valid. reason: %s",
 		e.Extension,
-		e.Pattern,
 		e.Reason)
 }
 
-func (e *AddonRegexNotValid) Is(err error) (matched bool) {
-	var inst *AddonRegexNotValid
+func (e *ExtAddonNotValid) Is(err error) (matched bool) {
+	var inst *ExtAddonNotValid
 	matched = errors.As(err, &inst)
 	return
 }

--- a/task/error.go
+++ b/task/error.go
@@ -231,6 +231,27 @@ func (e *SelectorNotValid) Retry() (r bool) {
 	return
 }
 
+// AddonRegexNotValid reports extension.Addon REGEX errors.
+type AddonRegexNotValid struct {
+	Extension string
+	Pattern   string
+	Reason    string
+}
+
+func (e *AddonRegexNotValid) Error() string {
+	return fmt.Sprintf(
+		"Extension (%s) addon REGEX '%s' not valid: %s",
+		e.Extension,
+		e.Pattern,
+		e.Reason)
+}
+
+func (e *AddonRegexNotValid) Is(err error) (matched bool) {
+	var inst *AddonRegexNotValid
+	matched = errors.As(err, &inst)
+	return
+}
+
 // PriorityNotFound report priority class not found.
 type PriorityNotFound struct {
 	Name  string

--- a/task/manager.go
+++ b/task/manager.go
@@ -589,9 +589,8 @@ func (m *Manager) matchAddon(extension *crd.Extension, addon *crd.Addon) (matche
 	if p.MatchString(ref) {
 		p, err = regexp.Compile(ref)
 		if err != nil {
-			err = &AddonRegexNotValid{
+			err = &ExtAddonNotValid{
 				Extension: extension.Name,
-				Pattern:   ref,
 				Reason:    err.Error(),
 			}
 			return

--- a/task/manager.go
+++ b/task/manager.go
@@ -90,7 +90,7 @@ const (
 )
 
 var (
-	AddonIsRegex = regexp.MustCompile("[^0-9A-Za-z_-]")
+	IsRegex = regexp.MustCompile("[^0-9A-Za-z_-]")
 )
 
 var (
@@ -585,7 +585,7 @@ func (m *Manager) selectExtensions(task *Task, addon *crd.Addon) (err error) {
 // characters other than: [0-9A-Za-z_].
 func (m *Manager) matchAddon(extension *crd.Extension, addon *crd.Addon) (matched bool, err error) {
 	ref := strings.TrimSpace(extension.Spec.Addon)
-	p := AddonIsRegex
+	p := IsRegex
 	if p.MatchString(ref) {
 		p, err = regexp.Compile(ref)
 		if err != nil {

--- a/task/manager.go
+++ b/task/manager.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -86,6 +87,10 @@ const (
 	Addon  = "addon"
 	Shared = "shared"
 	Cache  = "cache"
+)
+
+var (
+	AddonIsRegex = regexp.MustCompile("[^0-9A-Za-z_-]")
 )
 
 var (
@@ -555,7 +560,11 @@ func (m *Manager) selectExtensions(task *Task, addon *crd.Addon) (err error) {
 	matched := false
 	selector := NewSelector(m.DB, task)
 	for _, extension := range m.cluster.Extensions() {
-		if extension.Spec.Addon != addon.Name {
+		matched, err = m.matchAddon(extension, addon)
+		if err != nil {
+			return
+		}
+		if !matched {
 			continue
 		}
 		matched, err = selector.Match(extension.Spec.Selector)
@@ -566,6 +575,30 @@ func (m *Manager) selectExtensions(task *Task, addon *crd.Addon) (err error) {
 			task.Extensions = append(task.Extensions, extension.Name)
 			task.Event(ExtSelected, extension.Name)
 		}
+	}
+	return
+}
+
+// matchAddon - returns true when the extension's `addon`
+// (ref) matches the addon name.
+// The `ref` is matched as a REGEX when it contains
+// characters other than: [0-9A-Za-z_].
+func (m *Manager) matchAddon(extension *crd.Extension, addon *crd.Addon) (match bool, err error) {
+	ref := strings.TrimSpace(extension.Spec.Addon)
+	p := AddonIsRegex
+	if p.MatchString(ref) {
+		p, err = regexp.Compile(ref)
+		if err != nil {
+			err = &SelectorNotValid{
+				Selector: ref,
+				Reason:   err.Error(),
+			}
+			return
+		}
+		match = p.MatchString(addon.Name)
+	} else {
+
+		match = addon.Name == ref
 	}
 	return
 }

--- a/task/manager.go
+++ b/task/manager.go
@@ -589,9 +589,10 @@ func (m *Manager) matchAddon(extension *crd.Extension, addon *crd.Addon) (matche
 	if p.MatchString(ref) {
 		p, err = regexp.Compile(ref)
 		if err != nil {
-			err = &SelectorNotValid{
-				Selector: ref,
-				Reason:   err.Error(),
+			err = &AddonRegexNotValid{
+				Extension: extension.Name,
+				Pattern:   ref,
+				Reason:    err.Error(),
 			}
 			return
 		}

--- a/task/manager.go
+++ b/task/manager.go
@@ -583,7 +583,7 @@ func (m *Manager) selectExtensions(task *Task, addon *crd.Addon) (err error) {
 // (ref) matches the addon name.
 // The `ref` is matched as a REGEX when it contains
 // characters other than: [0-9A-Za-z_].
-func (m *Manager) matchAddon(extension *crd.Extension, addon *crd.Addon) (match bool, err error) {
+func (m *Manager) matchAddon(extension *crd.Extension, addon *crd.Addon) (matched bool, err error) {
 	ref := strings.TrimSpace(extension.Spec.Addon)
 	p := AddonIsRegex
 	if p.MatchString(ref) {
@@ -595,10 +595,10 @@ func (m *Manager) matchAddon(extension *crd.Extension, addon *crd.Addon) (match 
 			}
 			return
 		}
-		match = p.MatchString(addon.Name)
+		matched = p.MatchString(addon.Name)
 	} else {
 
-		match = addon.Name == ref
+		matched = addon.Name == ref
 	}
 	return
 }

--- a/task/task_test.go
+++ b/task/task_test.go
@@ -145,6 +145,7 @@ func TestAddonRegex(t *testing.T) {
 	addonB.Name = "B"
 	// direct.
 	ext := &crd.Extension{}
+	ext.Name = "Test"
 	ext.Spec.Addon = "A"
 	matched, err := m.matchAddon(ext, addonA)
 	g.Expect(err).To(gomega.BeNil())
@@ -160,4 +161,8 @@ func TestAddonRegex(t *testing.T) {
 	matched, err = m.matchAddon(ext, addonB)
 	g.Expect(err).To(gomega.BeNil())
 	g.Expect(matched).To(gomega.BeTrue())
+	// regex not valid.
+	ext.Spec.Addon = "(]$"
+	matched, err = m.matchAddon(ext, addonA)
+	g.Expect(err).ToNot(gomega.BeNil())
 }

--- a/task/task_test.go
+++ b/task/task_test.go
@@ -135,3 +135,29 @@ func TestPriorityGraph(t *testing.T) {
 	deps := pE.graph(ready[0], ready)
 	g.Expect(len(deps)).To(gomega.Equal(2))
 }
+
+func TestAddonRegex(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	m := Manager{}
+	addonA := &crd.Addon{}
+	addonA.Name = "A"
+	addonB := &crd.Addon{}
+	addonB.Name = "B"
+	// direct.
+	ext := &crd.Extension{}
+	ext.Spec.Addon = "A"
+	matched, err := m.matchAddon(ext, addonA)
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(matched).To(gomega.BeTrue())
+	matched, err = m.matchAddon(ext, addonB)
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(matched).To(gomega.BeFalse())
+	// regex.
+	ext.Spec.Addon = "^(A|B)$"
+	matched, err = m.matchAddon(ext, addonA)
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(matched).To(gomega.BeTrue())
+	matched, err = m.matchAddon(ext, addonB)
+	g.Expect(err).To(gomega.BeNil())
+	g.Expect(matched).To(gomega.BeTrue())
+}


### PR DESCRIPTION
Both the analyzer and tech-discovery both use the same providers. An extension having compatibility with multiple addons is not a common/mainstream use case. To get around this, we have defined a duplicate set of extensions for each provider. One with compatibility with the `analyzer` addon and the other for the `tech-discovery` addon.

After a recent refactor of the generic extension into multiple extensions (go, python, nodejs), it became obvious that maintain the duplicate set of extensions is painful and likely error prone.

It seems a better approach is to change `Extention.Spec.Addon` to (optionally) define a regex. This approach caters to the mainstream use case that extensions have compatibility with one addon.  It also avoids making the field an _array_ requiring a CRD change.  This is which is MUCH simpler.

The existing extensions will need to be updated to be compatible with both addons.
Example (java extension):
```
addon: ^(analyzer|tech-discovery)$
```

The `discovery-` extensions would be deleted.