### PR TITLE
:bug: Improved application LIST performance.

### DIFF
--- a/api/application.go
+++ b/api/application.go
@@ -1107,8 +1107,8 @@ func (h *ApplicationHandler) tagMap(
 	applications []model.Application) (mp map[uint][]model.ApplicationTag, err error) {
 	ids := []uint{}
 	for i := range applications {
-		app := &applications[i]
-		ids = append(ids, app.ID)
+		m := &applications[i]
+		ids = append(ids, m.ID)
 	}
 	mp = make(map[uint][]model.ApplicationTag)
 	list := []model.ApplicationTag{}
@@ -1117,8 +1117,8 @@ func (h *ApplicationHandler) tagMap(
 	if err != nil {
 		return
 	}
-	for _, tag := range list {
-		mp[tag.ApplicationID] = append(mp[tag.ApplicationID], tag)
+	for _, m := range list {
+		mp[m.ApplicationID] = append(mp[m.ApplicationID], m)
 	}
 	return
 }

--- a/api/application.go
+++ b/api/application.go
@@ -1113,6 +1113,7 @@ func (h *ApplicationHandler) tagMap(
 	mp = make(map[uint][]model.ApplicationTag)
 	list := []model.ApplicationTag{}
 	db := h.DB(ctx)
+	db = h.preLoad(db, "Tag")
 	err = db.Find(&list, "ApplicationID", ids).Error
 	if err != nil {
 		return

--- a/api/application.go
+++ b/api/application.go
@@ -170,10 +170,10 @@ func (h ApplicationHandler) List(ctx *gin.Context) {
 	}
 	resources := []Application{}
 	for i := range list {
-		app := &list[i]
+		m := &list[i]
 		resolver := assessment.NewApplicationResolver(&list[i], tagsResolver, membership, questionnaire)
 		r := Application{}
-		r.With(app, tagMap[app.ID])
+		r.With(m, tagMap[m.ID])
 		err = r.WithResolver(resolver)
 		if err != nil {
 			_ = ctx.Error(err)

--- a/api/application.go
+++ b/api/application.go
@@ -1113,7 +1113,7 @@ func (h *ApplicationHandler) tagMap(
 	mp = make(map[uint][]model.ApplicationTag)
 	list := []model.ApplicationTag{}
 	db := h.DB(ctx)
-	db = h.preLoad(db, "Tag")
+	db = db.Joins("Tag")
 	err = db.Find(&list, "ApplicationID", ids).Error
 	if err != nil {
 		return


### PR DESCRIPTION
Currently, the application List endpoint performs a query for each application to fetch the tags.  This does not scale well.  This PR fetches all of the tags into a map keyed by application ID.  Pretty sure this must be similar behavior to the un-correlated subquery done by GORM when pre-loading.

The ApplicationTag (join) models are small so not worried about memory footprint.

This reduced the performance (on my minikube with SSD) from 1.8s => ~700ms with 5k applications which is a 60% performance increase. I would expect a more significant impact on cluster hdd backed file systems.

Roughly related to: https://issues.redhat.com/browse/MTA-4165