### PR TITLE
:seedling: MTA-5006 Update auth setup after Keycloak update

### DIFF
--- a/auth/reconcile.go
+++ b/auth/reconcile.go
@@ -180,6 +180,9 @@ func (r *Reconciler) ensureUsers(realm *Realm) (err error) {
 			u := gocloak.User{
 				Username: &user.Name,
 				Enabled:  &enabled,
+				FirstName: &user.FirstName,
+				LastName: &user.LastName,
+				Email: &user.Email,
 			}
 			if Settings.Keycloak.RequirePasswordUpdate {
 				u.RequiredActions = &[]string{"UPDATE_PASSWORD"}

--- a/auth/role.go
+++ b/auth/role.go
@@ -50,6 +50,12 @@ type Resource struct {
 type User struct {
 	// Username
 	Name string `yaml:"name"`
+	// FirstName
+	FirstName string `yaml:"firstName"`
+	// LastName
+	LastName string `yaml:"lastName"`
+	// Email
+	Email string `yaml:"email"`
 	// Default password
 	Password string `yaml:"password"`
 	// List of roles specified by name

--- a/auth/users.yaml
+++ b/auth/users.yaml
@@ -1,4 +1,7 @@
 - name: admin
+  firstName: Admin Firstname
+  lastName: Admin Lastname
+  email: admin@host.local
   password: Passw0rd!
   roles:
     - tackle-admin


### PR DESCRIPTION
There few more mandatory User fields to be setup when auth is enabled, adding those. Or we might update the realm setup to not require it by default.

Fixes: https://issues.redhat.com/browse/MTA-5006