### PR TITLE
:bug: Fix Tag and TagCategory indexes missing.

### DIFF
--- a/migration/v16/migrate.go
+++ b/migration/v16/migrate.go
@@ -13,12 +13,11 @@ var log = logr.WithName("migration|v15")
 type Migration struct{}
 
 func (r Migration) Apply(db *gorm.DB) (err error) {
-	err = db.AutoMigrate(r.Models()...)
+	err = r.dropColumns(db)
 	if err != nil {
-		err = liberr.Wrap(err)
 		return
 	}
-	err = r.dropColumns(db)
+	err = db.AutoMigrate(r.Models()...)
 	return
 }
 


### PR DESCRIPTION
DropColumn needs to be done BEFORE AutoMigrate() is called.
```
SQLite didn't support ALTER TABLE DROP COLUMN until version 3.35.0 (released in March 2021). 
When you drop a column in SQLite, the database actually:
- Creates a new table without the column, 
- Copies the data over (excluding the dropped column),
- Drops the old table,
- Renames the new one.

During this process, indexes, triggers, constraints, etc., are also reviewed and recreated — but only 
if they are considered to still be valid and relevant.
```