### PR TITLE
:bug: Updates PK catalog when resources has explicitly assigned ID.

### DIFF
--- a/database/db_test.go
+++ b/database/db_test.go
@@ -181,7 +181,7 @@ func TestKeyGen(t *testing.T) {
 		return
 	}
 	// EXPLICIT id=10 created.
-	m := &model.Setting{Key: fmt.Sprintf("key-%d", 10), Value: 10}
+	m := &model.Setting{Key: "key-10", Value: 10}
 	m.ID = 10
 	err = db.Create(m).Error
 	if err != nil {
@@ -206,8 +206,8 @@ func TestKeyGen(t *testing.T) {
 	}
 	// id =12,13 by list.
 	list := []*model.Setting{
-		{Key: fmt.Sprintf("key-%d", 12), Value: 12},
-		{Key: fmt.Sprintf("key-%d", 13), Value: 13},
+		{Key: "key-12", Value: 12},
+		{Key: "key-13", Value: 13},
 	}
 	err = db.Create(&list).Error
 	if err != nil {
@@ -221,8 +221,8 @@ func TestKeyGen(t *testing.T) {
 	}
 	// EXPLICIT id=20,21 by list.
 	list = []*model.Setting{
-		{Model: model.Model{ID: 20}, Key: fmt.Sprintf("key-%d", 20), Value: 20},
-		{Model: model.Model{ID: 21}, Key: fmt.Sprintf("key-%d", 21), Value: 21},
+		{Model: model.Model{ID: 20}, Key: "key-20", Value: 20},
+		{Model: model.Model{ID: 21}, Key: "key-21", Value: 21},
 	}
 	err = db.Create(&list).Error
 	if err != nil {
@@ -234,8 +234,15 @@ func TestKeyGen(t *testing.T) {
 			return
 		}
 	}
+	// EXPLICIT id=14 should not update the PK catalog.
+	m = &model.Setting{Key: "key-14", Value: 14}
+	m.ID = 14
+	err = db.Save(m).Error
+	if err != nil {
+		panic(err)
+	}
 	// id=22 last one.
-	m = &model.Setting{Key: "Done", Value: 22}
+	m = &model.Setting{Key: "key-22", Value: 22}
 	err = db.Save(m).Error
 	if err != nil {
 		panic(err)

--- a/database/db_test.go
+++ b/database/db_test.go
@@ -180,7 +180,7 @@ func TestKeyGen(t *testing.T) {
 		t.Errorf("DELETED ids: 2,4,7 found.")
 		return
 	}
-	// id=10 created
+	// EXPLICIT id=10 created.
 	m := &model.Setting{Key: fmt.Sprintf("key-%d", 10), Value: 10}
 	m.ID = 10
 	err = db.Create(m).Error
@@ -219,7 +219,7 @@ func TestKeyGen(t *testing.T) {
 			return
 		}
 	}
-	// id =20,21 by list hard coded.
+	// EXPLICIT id=20,21 by list.
 	list = []*model.Setting{
 		{Model: model.Model{ID: 20}, Key: fmt.Sprintf("key-%d", 20), Value: 20},
 		{Model: model.Model{ID: 21}, Key: fmt.Sprintf("key-%d", 21), Value: 21},

--- a/database/db_test.go
+++ b/database/db_test.go
@@ -171,7 +171,6 @@ func TestKeyGen(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-
 	var count int64
 	err = db.Model(&model.Setting{}).Where([]uint{2, 4, 7}).Count(&count).Error
 	if err != nil {
@@ -181,16 +180,67 @@ func TestKeyGen(t *testing.T) {
 		t.Errorf("DELETED ids: 2,4,7 found.")
 		return
 	}
-	// id=8 (next) created.
-	next := N
-	m := &model.Setting{Key: fmt.Sprintf("key-%d", next), Value: next}
+	// id=10 created
+	m := &model.Setting{Key: fmt.Sprintf("key-%d", 10), Value: 10}
+	m.ID = 10
+	err = db.Create(m).Error
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("CREATED: %d\n", m.ID)
+	if uint(10) != m.ID {
+		t.Errorf("id:%d but expected: %d", m.ID, 10)
+		return
+	}
+	// id=11 (next) created.
+	next := uint(11)
+	m = &model.Setting{Key: fmt.Sprintf("key-%d", next), Value: next}
 	err = db.Create(m).Error
 	if err != nil {
 		panic(err)
 	}
 	fmt.Printf("CREATED: %d/%d (next)\n", m.ID, next)
-	if uint(N) != m.ID {
+	if next != m.ID {
 		t.Errorf("id:%d but expected: %d", m.ID, next)
 		return
+	}
+	// id =12,13 by list.
+	list := []*model.Setting{
+		{Key: fmt.Sprintf("key-%d", 12), Value: 12},
+		{Key: fmt.Sprintf("key-%d", 13), Value: 13},
+	}
+	err = db.Create(&list).Error
+	if err != nil {
+		panic(err)
+	}
+	for id := range []uint{12, 13} {
+		if next != m.ID {
+			t.Errorf("id:%d but expected: %d", m.ID, id)
+			return
+		}
+	}
+	// id =20,21 by list hard coded.
+	list = []*model.Setting{
+		{Model: model.Model{ID: 20}, Key: fmt.Sprintf("key-%d", 20), Value: 20},
+		{Model: model.Model{ID: 21}, Key: fmt.Sprintf("key-%d", 21), Value: 21},
+	}
+	err = db.Create(&list).Error
+	if err != nil {
+		panic(err)
+	}
+	for id := range []uint{20, 21} {
+		if next != m.ID {
+			t.Errorf("id:%d but expected: %d", m.ID, id)
+			return
+		}
+	}
+	// id=22 last one.
+	m = &model.Setting{Key: "Done", Value: 22}
+	err = db.Save(m).Error
+	if err != nil {
+		panic(err)
+	}
+	if m.ID != 22 {
+		t.Errorf("id:%d but expected: %d", m.ID, 22)
 	}
 }

--- a/database/pk.go
+++ b/database/pk.go
@@ -52,6 +52,7 @@ func (r *PkSequence) Load(db *gorm.DB, models []any) (err error) {
 }
 
 // Next returns the next primary key.
+// Updates the LastID.
 func (r *PkSequence) Next(db *gorm.DB) (id uint) {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
@@ -71,7 +72,7 @@ func (r *PkSequence) Next(db *gorm.DB) (id uint) {
 	return
 }
 
-// Assigned updates last PK.
+// Assigned updates LastID (as needed) when explicitly assigned.
 func (r *PkSequence) Assigned(db *gorm.DB, id uint) {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()


### PR DESCRIPTION
Updates PK catalog when resources has explicitly assigned ID.
For example when populated for demos using scripts.
Example:

TagCategory:
```
id: 14
name: "Test
```
Tag:
```
id:65
categoryID: 14
```

Unit test updated.