### PR TITLE
:sparkles: Render applications using joins

### DIFF
--- a/api/base.go
+++ b/api/base.go
@@ -404,6 +404,17 @@ type Cursor struct {
 
 // Next returns true when has next row.
 func (r *Cursor) Next(m any) (next bool) {
+	defer func() {
+		p := recover()
+		if p != nil {
+			switch p.(type) {
+			case error:
+				r.Error = p.(error)
+			default:
+				r.Error = errors.New(fmt.Sprint(p))
+			}
+		}
+	}()
 	if r.Error != nil {
 		next = true
 		return

--- a/assessment/archetype.go
+++ b/assessment/archetype.go
@@ -20,7 +20,11 @@ func (r *Archetype) With(m *model.Archetype) {
 }
 
 // NewArchetypeResolver creates a new ArchetypeResolver.
-func NewArchetypeResolver(m *model.Archetype, tags *TagResolver, membership *MembershipResolver, questionnaire *QuestionnaireResolver) (a *ArchetypeResolver) {
+func NewArchetypeResolver(
+	m *model.Archetype,
+	tags *TagResolver,
+	membership *MembershipResolver,
+	questionnaire *QuestionnaireResolver) (a *ArchetypeResolver) {
 	a = &ArchetypeResolver{
 		tags:          tags,
 		membership:    membership,

--- a/assessment/membership.go
+++ b/assessment/membership.go
@@ -8,16 +8,19 @@ import (
 )
 
 // NewMembershipResolver builds a MembershipResolver.
-func NewMembershipResolver(db *gorm.DB) (m *MembershipResolver) {
-	m = &MembershipResolver{db: db}
+func NewMembershipResolver(db *gorm.DB) (m *MembershipResolver, err error) {
+	m = &MembershipResolver{}
 	m.tagSets = make(map[uint]Set)
 	m.archetypeMembers = make(map[uint][]Application)
+	err = m.cacheArchetypes(db)
+	if err != nil {
+		return
+	}
 	return
 }
 
 // MembershipResolver resolves archetype membership.
 type MembershipResolver struct {
-	db               *gorm.DB
 	archetypes       []Archetype
 	tagSets          map[uint]Set
 	archetypeMembers map[uint][]Application
@@ -27,25 +30,14 @@ type MembershipResolver struct {
 
 // Applications returns the list of applications that are members of the given archetype.
 func (r *MembershipResolver) Applications(m Archetype) (applications []Application, err error) {
-	err = r.cacheArchetypeMembers()
-	if err != nil {
-		return
-	}
-
 	applications = r.archetypeMembers[m.ID]
-
 	return
 }
 
 // Archetypes returns the list of archetypes that the application is a member of.
-func (r *MembershipResolver) Archetypes(app Application) (archetypes []Archetype, err error) {
-	err = r.cacheArchetypes()
-	if err != nil {
-		return
-	}
-
+func (r *MembershipResolver) Archetypes(m Application) (archetypes []Archetype, err error) {
 	appTags := NewSet()
-	for _, t := range app.Tags {
+	for _, t := range m.Tags {
 		appTags.Add(t.ID)
 	}
 
@@ -71,19 +63,19 @@ loop:
 			}
 		}
 		archetypes = append(archetypes, a1)
-		r.archetypeMembers[a1.ID] = append(r.archetypeMembers[a1.ID], app)
+		r.archetypeMembers[a1.ID] = append(r.archetypeMembers[a1.ID], m)
 	}
 
 	return
 }
 
-func (r *MembershipResolver) cacheArchetypes() (err error) {
+func (r *MembershipResolver) cacheArchetypes(db *gorm.DB) (err error) {
 	if r.archetypesCached {
 		return
 	}
 
 	list := []model.Archetype{}
-	db := r.db.Preload(clause.Associations)
+	db = db.Preload(clause.Associations)
 	db = db.Preload("Assessments.Stakeholders")
 	db = db.Preload("Assessments.StakeholderGroups")
 	result := db.Find(&list)
@@ -107,12 +99,12 @@ func (r *MembershipResolver) cacheArchetypes() (err error) {
 	return
 }
 
-func (r *MembershipResolver) cacheArchetypeMembers() (err error) {
+func (r *MembershipResolver) cacheArchetypeMembers(db *gorm.DB) (err error) {
 	if r.membersCached {
 		return
 	}
 	list := []model.Application{}
-	result := r.db.Preload("Tags").Find(&list)
+	result := db.Preload("Tags").Find(&list)
 	if result.Error != nil {
 		err = liberr.Wrap(err)
 		return

--- a/assessment/questionnaire.go
+++ b/assessment/questionnaire.go
@@ -8,25 +8,24 @@ import (
 
 // NewQuestionnaireResolver builds a QuestionnaireResolver.
 func NewQuestionnaireResolver(db *gorm.DB) (a *QuestionnaireResolver, err error) {
-	a = &QuestionnaireResolver{db: db}
+	a = &QuestionnaireResolver{}
 	a.requiredQuestionnaires = NewSet()
-	err = a.cacheQuestionnaires()
+	err = a.cacheQuestionnaires(db)
 	return
 }
 
 // QuestionnaireResolver resolves questionnaire logic.
 type QuestionnaireResolver struct {
-	db                     *gorm.DB
 	requiredQuestionnaires Set
 }
 
-func (r *QuestionnaireResolver) cacheQuestionnaires() (err error) {
+func (r *QuestionnaireResolver) cacheQuestionnaires(db *gorm.DB) (err error) {
 	if r.requiredQuestionnaires.Size() > 0 {
 		return
 	}
 
 	questionnaires := []model.Questionnaire{}
-	result := r.db.Find(&questionnaires, "required = ?", true)
+	result := db.Find(&questionnaires, "required = ?", true)
 	if result.Error != nil {
 		err = liberr.Wrap(err)
 		return

--- a/test/api/importcsv/api_test.go
+++ b/test/api/importcsv/api_test.go
@@ -3,6 +3,7 @@ package importcsv
 import (
 	"io/ioutil"
 	"os"
+	"sort"
 	"testing"
 	"time"
 
@@ -61,6 +62,16 @@ func TestImportCSV(t *testing.T) {
 					if r.ExpectedApplications[i].Binary != gotApp.Binary {
 						t.Errorf("Mismatch in binary of imported Application: Expected %s, Actual %s", r.ExpectedApplications[i].Binary, gotApp.Binary)
 					}
+					sort.Slice(
+						r.ExpectedApplications[i].Tags,
+						func(a, b int) bool {
+							return r.ExpectedApplications[i].Tags[a].ID < r.ExpectedApplications[i].Tags[b].ID
+						})
+					sort.Slice(
+						gotApp.Tags,
+						func(a, b int) bool {
+							return gotApp.Tags[a].ID < gotApp.Tags[b].ID
+						})
 					for j, tag := range r.ExpectedApplications[i].Tags {
 						if tag.Name != gotApp.Tags[j].Name {
 							t.Errorf("Mismatch in tag name of imported Application: Expected %s, Actual %s", tag.Name, gotApp.Tags[j].Name)


### PR DESCRIPTION
Query the application using joins instead of preload() and the response streamed back with in-line encoding.
Much faster.  Reduces query of 5k applications from 10-14 seconds to 3-4 seconds.  Also keeps RSS (memory) to around 100-130 MB instead of ballooning to 6-7GB and staying there.  Tested on minikube with SSD storage.

The assessment package need to be changed so that the resolvers ALL could be built upfront to ensure no other SQL statements were executed while iterating the cursor (which holds the db lock).

Overlaps with #822:
- api/context.go
- api/analysis.go

After #822 is merged, these files will need to be unstaged and the PR rebased.