### PR TITLE
:sparkles: Add support for default credentials.

### DIFF
--- a/api/identity.go
+++ b/api/identity.go
@@ -282,6 +282,26 @@ func (h IdentityHandler) Update(ctx *gin.Context) {
 		return
 	}
 	m := r.Model()
+	if r.Default {
+		count := int64(0)
+		db := h.DB(ctx)
+		db = db.Model(m)
+		db = db.Where("kind = ?", r.Kind)
+		db = db.Where("default", true)
+		db = db.Where("id != ?", id)
+		err = db.Count(&count).Error
+		if err != nil {
+			_ = ctx.Error(err)
+			return
+		}
+		if count > 0 {
+			err = &BadRequestError{
+				Reason: "Kind already has default.",
+			}
+			_ = ctx.Error(err)
+			return
+		}
+	}
 	err = secret.Encrypt(m)
 	if err != nil {
 		_ = ctx.Error(err)

--- a/binding/application.go
+++ b/binding/application.go
@@ -63,43 +63,20 @@ func (h *Application) Bucket(id uint) (b *BucketContent) {
 
 // FindIdentity by kind.
 func (h *Application) FindIdentity(id uint, kind string) (r *api.Identity, found bool, err error) {
-	direct := []api.Identity{}
-	filter := Filter{}
-	filter.And("application.id").Eq(int(id))
-	filter.And("kind").Eq(kind)
-	p1 := filter.Param()
-	p2 := Param{
+	list := []api.Identity{}
+	p := Param{
 		Key:   api.Decrypted,
 		Value: "1",
 	}
-	path := Path(api.IdentitiesRoot).Inject(Params{api.ID: id})
-	err = h.client.Get(path, &direct, p1, p2)
+	path := Path(api.AppIdentitiesRoot).Inject(Params{api.ID: id, api.Kind: kind})
+	err = h.client.Get(path, &list, p)
 	if err != nil {
 		return
 	}
-	for i := range direct {
-		r = &direct[i]
+	for i := range list {
+		r = &list[i]
 		found = true
 		return
-	}
-	inherited := []api.Identity{}
-	filter = Filter{}
-	filter.And("kind").Eq(kind)
-	filter.And("default").Eq(true)
-	p1 = filter.Param()
-	p2 = Param{
-		Key:   api.Decrypted,
-		Value: "1",
-	}
-	path = Path(api.IdentitiesRoot).Inject(Params{api.ID: id})
-	err = h.client.Get(path, &inherited, p1, p2)
-	if err != nil {
-		return
-	}
-	for i := range inherited {
-		r = &inherited[i]
-		found = true
-		break
 	}
 	return
 }

--- a/binding/identity.go
+++ b/binding/identity.go
@@ -38,6 +38,17 @@ func (h *Identity) List() (list []api.Identity, err error) {
 	return
 }
 
+// Find decrypted Identities.
+func (h *Identity) Find(filter Filter) (list []api.Identity, err error) {
+	list = []api.Identity{}
+	p := Param{
+		Key:   api.Decrypted,
+		Value: "1",
+	}
+	err = h.client.Get(api.IdentitiesRoot, &list, p, filter.Param())
+	return
+}
+
 // Update a Identity.
 func (h *Identity) Update(r *api.Identity) (err error) {
 	path := Path(api.IdentityRoot).Inject(Params{api.ID: r.ID})

--- a/migration/v18/model/core.go
+++ b/migration/v18/model/core.go
@@ -192,9 +192,9 @@ type Proxy struct {
 // Identity represents and identity with a set of credentials.
 type Identity struct {
 	Model
-	Kind         string `gorm:"uniqueIndex:identityA,not null"`
-	Default      bool   `gorm:"uniqueIndex:identityA,default:false,not null"`
+	Kind         string `gorm:"not null"`
 	Name         string `gorm:"index;unique;not null"`
+	Default      bool
 	Description  string
 	User         string
 	Password     string        `secret:""`

--- a/migration/v18/model/core.go
+++ b/migration/v18/model/core.go
@@ -192,7 +192,7 @@ type Proxy struct {
 // Identity represents and identity with a set of credentials.
 type Identity struct {
 	Model
-	Kind         string `gorm:"not null"`
+	Kind         string `gorm:"index,not null"`
 	Name         string `gorm:"index;unique;not null"`
 	Default      bool
 	Description  string

--- a/migration/v18/model/core.go
+++ b/migration/v18/model/core.go
@@ -192,7 +192,8 @@ type Proxy struct {
 // Identity represents and identity with a set of credentials.
 type Identity struct {
 	Model
-	Kind         string `gorm:"not null"`
+	Kind         string `gorm:"uniqueIndex:identityA,not null"`
+	Default      bool   `gorm:"uniqueIndex:identityA,default:false,not null"`
 	Name         string `gorm:"index;unique;not null"`
 	Description  string
 	User         string

--- a/model/query.go
+++ b/model/query.go
@@ -23,3 +23,21 @@ func Intersect(q ...*gorm.DB) (intersect *gorm.DB) {
 	intersect = q[0].Raw(strings.Join(part, " "))
 	return
 }
+
+// Union returns an SQL union of the queries.
+func Union(q ...*gorm.DB) (union *gorm.DB) {
+	var part []string
+	for n, q := range q {
+		if n > 0 {
+			part = append(part, "UNION")
+		}
+		part = append(
+			part,
+			q.ToSQL(func(tx *gorm.DB) *gorm.DB {
+				q = q.Session(&gorm.Session{DryRun: true})
+				return q.Find(nil)
+			}))
+	}
+	union = q[0].Raw(strings.Join(part, " "))
+	return
+}

--- a/test/api/application/identity_test.go
+++ b/test/api/application/identity_test.go
@@ -27,44 +27,46 @@ func TestFindIdentity(t *testing.T) {
 	defer func() {
 		_ = RichClient.Identity.Delete(direct2.ID)
 	}()
-	inherited := &api.Identity{
+	indirect := &api.Identity{
 		Kind:    "Other",
-		Name:    "inherited",
+		Name:    "indirect",
 		Default: true,
 	}
-	err = RichClient.Identity.Create(inherited)
+	err = RichClient.Identity.Create(indirect)
 	assert.Must(t, err)
 	defer func() {
-		_ = RichClient.Identity.Delete(inherited.ID)
+		_ = RichClient.Identity.Delete(indirect.ID)
 	}()
 	application := &api.Application{
 		Name:       t.Name(),
 		Identities: []api.Ref{{ID: direct.ID}},
 	}
-	err = RichClient.Application.Create(application)
+	err = Application.Create(application)
 	assert.Must(t, err)
 	defer func() {
-		_ = RichClient.Application.Delete(application.ID)
+		_ = Application.Delete(application.ID)
 	}()
 	// Find direct.
 	identity, found, err := Application.FindIdentity(application.ID, direct.Kind)
 	assert.Must(t, err)
-	if !found {
-		t.Errorf("not found")
+	if found {
+		if identity.ID != direct.ID {
+			t.Errorf("find direct expected: id=%d", direct.ID)
+		}
+	} else {
+		t.Errorf("direct not found")
 	}
-	if identity.ID != direct.ID {
-		t.Errorf("find direct expected: id=%d", direct.ID)
-	}
-	// Find inherited.
-	identity, found, err = Application.FindIdentity(application.ID, inherited.Kind)
+	// Find indirect.
+	identity, found, err = Application.FindIdentity(application.ID, indirect.Kind)
 	assert.Must(t, err)
-	if !found {
-		t.Errorf("not found")
+	if found {
+		if identity.ID != indirect.ID {
+			t.Errorf("find indirect expected: id=%d", indirect.ID)
+		}
+	} else {
+		t.Errorf("indirect not found")
 	}
-	if identity.ID != inherited.ID {
-		t.Errorf("find inherited expected: id=%d", inherited.ID)
-	}
-	// Not find inherited.
+	// Not find indirect.
 	_, found, err = Application.FindIdentity(application.ID, "None")
 	assert.Must(t, err)
 	if found {

--- a/test/api/application/identity_test.go
+++ b/test/api/application/identity_test.go
@@ -1,0 +1,73 @@
+package application
+
+import (
+	"testing"
+
+	"github.com/konveyor/tackle2-hub/api"
+	"github.com/konveyor/tackle2-hub/test/assert"
+)
+
+func TestFindIdentity(t *testing.T) {
+	// Setup.
+	direct := &api.Identity{
+		Name: "direct",
+		Kind: "Test",
+	}
+	err := RichClient.Identity.Create(direct)
+	assert.Must(t, err)
+	defer func() {
+		_ = RichClient.Identity.Delete(direct.ID)
+	}()
+	direct2 := &api.Identity{
+		Name: "direct2",
+		Kind: "Other",
+	}
+	err = RichClient.Identity.Create(direct2)
+	assert.Must(t, err)
+	defer func() {
+		_ = RichClient.Identity.Delete(direct2.ID)
+	}()
+	inherited := &api.Identity{
+		Kind:    "Other",
+		Name:    "inherited",
+		Default: true,
+	}
+	err = RichClient.Identity.Create(inherited)
+	assert.Must(t, err)
+	defer func() {
+		_ = RichClient.Identity.Delete(inherited.ID)
+	}()
+	application := &api.Application{
+		Name:       t.Name(),
+		Identities: []api.Ref{{ID: direct.ID}},
+	}
+	err = RichClient.Application.Create(application)
+	assert.Must(t, err)
+	defer func() {
+		_ = RichClient.Application.Delete(application.ID)
+	}()
+	// Find direct.
+	identity, found, err := Application.FindIdentity(application.ID, direct.Kind)
+	assert.Must(t, err)
+	if !found {
+		t.Errorf("not found")
+	}
+	if identity.ID != direct.ID {
+		t.Errorf("find direct expected: id=%d", direct.ID)
+	}
+	// Find inherited.
+	identity, found, err = Application.FindIdentity(application.ID, inherited.Kind)
+	assert.Must(t, err)
+	if !found {
+		t.Errorf("not found")
+	}
+	if identity.ID != inherited.ID {
+		t.Errorf("find inherited expected: id=%d", inherited.ID)
+	}
+	// Not find inherited.
+	_, found, err = Application.FindIdentity(application.ID, "None")
+	assert.Must(t, err)
+	if found {
+		t.Errorf("not found expected")
+	}
+}

--- a/test/api/identity/api_test.go
+++ b/test/api/identity/api_test.go
@@ -105,3 +105,24 @@ func TestIdentityNotCreateDuplicates(t *testing.T) {
 	// Clean.
 	assert.Must(t, Identity.Delete(r.ID))
 }
+
+func TestIdentityNotCreateDupDefault(t *testing.T) {
+	identity := &api.Identity{
+		Name:    "Test",
+		Kind:    "Test",
+		Default: true,
+	}
+	err := Identity.Create(identity)
+	assert.Must(t, err)
+	defer func() {
+		_ = Identity.Delete(identity.ID)
+	}()
+	identity.Name = "Test2"
+	err = Identity.Create(identity)
+	if err == nil {
+		t.Errorf("Created duplicate (default) identity: %v", identity)
+		defer func() {
+			_ = Identity.Delete(identity.ID)
+		}()
+	}
+}

--- a/test/api/identity/identity_test.go
+++ b/test/api/identity/identity_test.go
@@ -1,0 +1,54 @@
+package identity
+
+import (
+	"testing"
+
+	"github.com/konveyor/tackle2-hub/api"
+	"github.com/konveyor/tackle2-hub/binding"
+	"github.com/konveyor/tackle2-hub/test/assert"
+)
+
+func TestFindIdentity(t *testing.T) {
+	// Setup.
+	direct := &api.Identity{
+		Name: "direct",
+		Kind: "Test",
+	}
+	err := Identity.Create(direct)
+	assert.Must(t, err)
+	defer func() {
+		_ = RichClient.Identity.Delete(direct.ID)
+	}()
+	direct2 := &api.Identity{
+		Name: "direct2",
+		Kind: "Other",
+	}
+	err = Identity.Create(direct2)
+	assert.Must(t, err)
+	defer func() {
+		_ = RichClient.Identity.Delete(direct2.ID)
+	}()
+	application := &api.Application{
+		Name:       t.Name(),
+		Identities: []api.Ref{{ID: direct.ID}},
+	}
+	err = RichClient.Application.Create(application)
+	assert.Must(t, err)
+	defer func() {
+		_ = RichClient.Application.Delete(application.ID)
+	}()
+	// Find direct.
+	filter := binding.Filter{}
+	filter.And("application.id").Eq(int(application.ID))
+	filter.And("kind").Eq(direct.Kind)
+	found, err := Identity.Find(filter)
+	assert.Must(t, err)
+	if len(found) > 0 {
+		identity := found[0]
+		if identity.ID != direct.ID {
+			t.Errorf("find direct expected: id=%d", direct.ID)
+		}
+	} else {
+		t.Errorf("direct not found")
+	}
+}


### PR DESCRIPTION
Add support for default credentials.
Each kind may have a default.  Adds filter function to /identities/ (list) endpoint.
Adds new /applications/:id/identities/:kind endpoint which will include defaults.

- [x] model updated.
- [x] api updated
- [x] binding updated. 
- [x] Tests

The tackle2-addon go.mod needs to be updated to use the new binding.

ref: https://github.com/konveyor/enhancements/pull/223