### PR TITLE
:sparkles: Trigger discovery when default cred is updated.

### DIFF
--- a/api/identity.go
+++ b/api/identity.go
@@ -75,7 +75,6 @@ func (h IdentityHandler) Get(ctx *gin.Context) {
 // @description filters:
 // @description - kind
 // @description - name
-// @description - isDefault
 // @description - application.id
 // @tags dependencies
 // @tags identities
@@ -95,7 +94,6 @@ func (h IdentityHandler) List(ctx *gin.Context) {
 		_ = ctx.Error(err)
 		return
 	}
-	filter = filter.Renamed("default", "`default`")
 	// Find
 	var list []model.Identity
 	db := h.DB(ctx)

--- a/api/identity.go
+++ b/api/identity.go
@@ -231,6 +231,20 @@ func (h IdentityHandler) Create(ctx *gin.Context) {
 	}
 	r.With(m)
 
+	rtx := RichContext(ctx)
+	tr := trigger.Identity{
+		Trigger: trigger.Trigger{
+			TaskManager: rtx.TaskManager,
+			Client:      rtx.Client,
+			DB:          h.DB(ctx),
+		},
+	}
+	err = tr.Created(m)
+	if err != nil {
+		_ = ctx.Error(err)
+		return
+	}
+
 	h.Respond(ctx, http.StatusCreated, r)
 }
 

--- a/hack/add/identity.sh
+++ b/hack/add/identity.sh
@@ -4,6 +4,8 @@ host="${HOST:-localhost:8080}"
 
 id="${1:-0}" # 0=system-assigned.
 name="${2:-Test}"
+kind="${3:-source}"
+def="${4:-0}"
 
 # create identity.
 curl -X POST ${host}/identities \
@@ -13,7 +15,8 @@ curl -X POST ${host}/identities \
 "
 id: ${id}
 name: ${name}
-kind: source
+kind: ${kind}
+default: ${def}
 description: ${name} Description
 user: userA
 password: passwordA

--- a/hack/update/identity.sh
+++ b/hack/update/identity.sh
@@ -7,7 +7,7 @@ name="${2:-Test}"
 kind="${3:-source}"
 def="${4:-0}"
 
-# create identity.
+# update an identity.
 curl -X PUT ${host}/identities/${id} \
   -H 'Content-Type:application/x-yaml' \
   -H 'Accept:application/x-yaml' \

--- a/hack/update/identity.sh
+++ b/hack/update/identity.sh
@@ -2,14 +2,24 @@
 
 host="${HOST:-localhost:8080}"
 
-curl -X PUT ${host}/identities/1 -d \
-'{
-    "kind": "git",
-    "name":"test-git",
-    "description": "Forklift",
-    "user": "userB",
-    "password": "passwordB",
-    "key": "keyA",
-    "settings": "settingsB"
-}' | jq -M .
+id="${1:-0}" # 0=system-assigned.
+name="${2:-Test}"
+kind="${3:-source}"
+def="${4:-0}"
 
+# create identity.
+curl -X PUT ${host}/identities/${id} \
+  -H 'Content-Type:application/x-yaml' \
+  -H 'Accept:application/x-yaml' \
+ -d \
+"
+id: ${id}
+name: ${name}
+kind: ${kind}
+default: ${def}
+description: ${name} Description
+user: userA
+password: passwordA
+key: keyA
+settings: settingsA
+"

--- a/test/api/identity/api_test.go
+++ b/test/api/identity/api_test.go
@@ -126,3 +126,33 @@ func TestIdentityNotCreateDupDefault(t *testing.T) {
 		}()
 	}
 }
+
+func TestIdentityNotUpdateDupDefault(t *testing.T) {
+	def := &api.Identity{
+		Name:    "Test",
+		Kind:    "Test",
+		Default: true,
+	}
+	err := Identity.Create(def)
+	assert.Must(t, err)
+	defer func() {
+		_ = Identity.Delete(def.ID)
+	}()
+	other := &api.Identity{
+		Name: "Test2",
+		Kind: "Test",
+	}
+	err = Identity.Create(other)
+	assert.Must(t, err)
+	defer func() {
+		_ = Identity.Delete(other.ID)
+	}()
+	other.Default = true
+	err = Identity.Update(other)
+	if err == nil {
+		t.Errorf("Created duplicate (default) identity: %v", other)
+		defer func() {
+			_ = Identity.Delete(other.ID)
+		}()
+	}
+}

--- a/trigger/identity.go
+++ b/trigger/identity.go
@@ -9,7 +9,13 @@ type Identity struct {
 	Trigger
 }
 
-// Updated model created trigger.
+// Created model created trigger.
+func (r *Identity) Created(m *model.Identity) (err error) {
+	err = r.Updated(m)
+	return
+}
+
+// Updated model updated trigger.
 func (r *Identity) Updated(m *model.Identity) (err error) {
 	tr := Application{
 		Trigger: Trigger{

--- a/trigger/identity.go
+++ b/trigger/identity.go
@@ -36,6 +36,12 @@ func (r *Identity) Updated(m *model.Identity) (err error) {
 	return
 }
 
+// affected returns a list of affected application ids.
+// An application is affected when:
+//- the changed identity is directly associated
+//- the changed identity is the default (for the kind) and an
+//  application does not have an identity of the same kind
+//  directly associated.
 func (r *Identity) affected(changed *model.Identity) (appIds []uint, err error) {
 	type M struct {
 		ID      uint

--- a/trigger/identity.go
+++ b/trigger/identity.go
@@ -26,10 +26,65 @@ func (r *Identity) Updated(m *model.Identity) (err error) {
 	if err != nil {
 		return
 	}
+	if m.Default {
+		direct := make(map[uint]byte)
+		for i := range m.Applications {
+			appId := m.Applications[i].ID
+			direct[appId] = 0
+		}
+		type M struct {
+			AppId uint
+			ID    uint
+			Kind  string
+		}
+		db := r.DB.Select(
+			"j.ApplicationID AppId",
+			"i.ID ID",
+			"i.Kind Kind")
+		db = r.DB.Table("Identity i")
+		db = db.Joins("JOIN ApplicationIdentity j ON a.ID = j.IdentityID")
+		err = r.DB.Find(&applications).Error
+		if err != nil {
+			return
+		}
+		for i := range m.Applications {
+			app := &m.Applications[i]
+		}
+	}
 	for i := range m.Applications {
 		err = tr.Updated(&m.Applications[i])
 		if err != nil {
 			return
+		}
+	}
+	return
+}
+
+func (r *Identity) affected(m *model.Identity) (appIds []uint, err error) {
+	type M struct {
+		ID      uint
+		Kind    string
+		Default bool
+		AppId   uint
+	}
+	var identities []M
+	db := r.DB.Select(
+		"i.ID ID",
+		"i.Kind Kind",
+		"i.Default Default",
+		"j.ApplicationID AppId")
+	db = r.DB.Table("Identity i")
+	db = db.Joins("JOIN ApplicationIdentity j ON a.ID = j.IdentityID")
+	db = db.Where("i.Kind", m.Kind)
+	err = r.DB.Find(&identities).Error
+	if err != nil {
+		return
+	}
+	direct := make(map[uint]byte)
+	for i := range identities {
+		m2 := &identities[i]
+		if m2.AppId > 0 {
+			direct[m2.ID] = 0
 		}
 	}
 	return

--- a/trigger/identity.go
+++ b/trigger/identity.go
@@ -30,41 +30,43 @@ func (r *Identity) Updated(m *model.Identity) (err error) {
 	if err != nil {
 		return
 	}
-	var appList []model.Application
-	err = r.DB.Find(&appList, affected).Error
-	if err != nil {
-		return
-	}
-	for i := range appList {
-		err = tr.Updated(&m.Applications[i])
+	for _, batch := range affected {
+		var appList []model.Application
+		err = r.DB.Find(&appList, batch).Error
 		if err != nil {
 			return
+		}
+		for i := range appList {
+			err = tr.Updated(&appList[i])
+			if err != nil {
+				return
+			}
 		}
 	}
 	return
 }
 
-// affected returns a list of affected application ids.
+// affected returns the affected application ids.
 // An application is affected when:
 //- the changed identity is directly associated
 //- the changed identity is the default (for the kind) and an
 //  application does not have an identity of the same kind
 //  directly associated.
-func (r *Identity) affected(changed *model.Identity) (appIds []uint, err error) {
+func (r *Identity) affected(changed *model.Identity) (appIds [][]uint, err error) {
 	type M struct {
-		ID      uint
+		AppId   uint
+		Id      uint
 		Kind    string
 		Default bool
-		AppId   uint
 	}
 	db := r.DB.Select(
-		"i.ID ID",
+		"a.ID AppId",
+		"i.ID Id",
 		"i.Kind Kind",
-		"i.`Default` `Default`",
-		"j.ApplicationID AppId")
-	db = db.Table("Identity i")
-	db = db.Joins("LEFT JOIN ApplicationIdentity j ON i.ID = j.IdentityID")
-	db = db.Where("i.Kind", changed.Kind)
+		"i.`Default` `Default`")
+	db = db.Table("Application a")
+	db = db.Joins("LEFT JOIN ApplicationIdentity j ON j.ApplicationID = a.ID")
+	db = db.Joins("LEFT JOIN Identity i ON i.ID = j.IdentityID AND i.Kind = ?", changed.Kind)
 	cursor, err := db.Rows()
 	if err != nil {
 		return
@@ -83,25 +85,37 @@ func (r *Identity) affected(changed *model.Identity) (appIds []uint, err error) 
 	}
 	direct := make(map[uint]uint)
 	for _, m2 := range records {
-		if m2.AppId > 0 {
-			direct[m2.AppId] = m2.ID
+		if m2.Id > 0 {
+			direct[m2.AppId] = m2.Id
 		}
 	}
 	indirect := make(map[uint]uint)
-	for _, m2 := range records {
-		if m2.Default {
+	if changed.Default {
+		for _, m2 := range records {
 			_, hasDirect := direct[m2.AppId]
-			if hasDirect || m2.AppId == 0 {
-				continue
+			if !hasDirect {
+				indirect[m2.AppId] = m2.Id
 			}
-			indirect[m2.AppId] = m2.ID
 		}
 	}
+	batch := make([]uint, 0, 100)
+	add := func(id uint) {
+		if len(batch) == cap(batch) {
+			appIds = append(appIds, batch)
+			batch = make([]uint, 0, cap(batch))
+		}
+		batch = append(batch, id)
+	}
+	defer func() {
+		if len(batch) > 0 {
+			appIds = append(appIds, batch)
+		}
+	}()
 	for appId, _ := range direct {
-		appIds = append(appIds, appId)
+		add(appId)
 	}
 	for appId, _ := range indirect {
-		appIds = append(appIds, appId)
+		add(appId)
 	}
 	return
 }

--- a/trigger/identity.go
+++ b/trigger/identity.go
@@ -11,7 +11,9 @@ type Identity struct {
 
 // Created model created trigger.
 func (r *Identity) Created(m *model.Identity) (err error) {
-	err = r.Updated(m)
+	if m.Default {
+		err = r.Updated(m)
+	}
 	return
 }
 


### PR DESCRIPTION
Application discover needs to be triggered when:
-  A directly mapped identity has been updated.
- A _default_ identity has been created/updated and the application does not have one of the same _kind_ directly mapped.