### PR TITLE
:bug: Fix recover() in Secret.

### DIFF
--- a/secret/secret.go
+++ b/secret/secret.go
@@ -1,6 +1,8 @@
 package secret
 
 import (
+	"errors"
+	"fmt"
 	"reflect"
 )
 
@@ -50,7 +52,12 @@ func (r Secret) Update(object any, fn func(string) string) (err error) {
 	defer func() {
 		p := recover()
 		if p != nil {
-			err = p.(error)
+			switch p.(type) {
+			case error:
+				err = p.(error)
+			default:
+				err = errors.New(fmt.Sprint(p))
+			}
 		}
 	}()
 	mt := reflect.TypeOf(object)


### PR DESCRIPTION
The recover() here to deal with reflect panics. 
recover() returns _any_ and must be type checked.
Example: Many reflect errors are _string_.