### PR TITLE
:ghost: Sort discovery tasks by priority then label.

### DIFF
--- a/api/task.go
+++ b/api/task.go
@@ -805,7 +805,7 @@ func (r *Task) With(m *model.Task) {
 	r.Extensions = m.Extensions
 	r.State = m.State
 	r.Locator = m.Locator
-	r.Priority = m.Priority
+	r.Priority = r.userPriority(m.Priority)
 	r.Policy = TaskPolicy(m.Policy)
 	r.TTL = TTL(m.TTL)
 	r.Data = m.Data.Any
@@ -862,6 +862,16 @@ func (r *Task) Model() (m *model.Task) {
 	}
 	m.ID = r.ID
 	m.Data.Any = r.Data
+	return
+}
+
+// userPriority adjust (ensures) priority is greater than 10.
+// Priority: 0-9 reserved for system tasks.
+func (r *Task) userPriority(in int) (out int) {
+	out = in
+	if out < 10 {
+		out += 10
+	}
 	return
 }
 

--- a/task/README.md
+++ b/task/README.md
@@ -25,8 +25,10 @@ priority. As a result, task pods are created in the order of priority. However, 
 the pod scheduling order is at the discretion of the k8s node-scheduler. To maximize the influence of task
 priority ordering, it is highly recommended for administrators to create a k8s _Resource Quota_ in the
 namespace to restrict the number of pods created.
-Priority: 0-9 are reserved for system tasks. User defined tasks with a priority < 10 are adjusted
-to be priority+10.
+Priority: 0-9 are reserved for system tasks. User defined tasks created with a priority < 10 are
+adjusted to be the priority+10.  This preserves the intended priority ordering within the user range.
+For example: A task created without the priority specified (default:0) will be adjusted to have
+a priority=10.  A task created with priority=4 will be adjusted to priority=14.
 
 ### Resource Quota ###
 

--- a/task/README.md
+++ b/task/README.md
@@ -25,6 +25,8 @@ priority. As a result, task pods are created in the order of priority. However, 
 the pod scheduling order is at the discretion of the k8s node-scheduler. To maximize the influence of task
 priority ordering, it is highly recommended for administrators to create a k8s _Resource Quota_ in the
 namespace to restrict the number of pods created.
+Priority: 0-9 are reserved for system tasks. User defined tasks with a priority < 10 are adjusted
+to be priority+10.
 
 ### Resource Quota ###
 

--- a/trigger/application.go
+++ b/trigger/application.go
@@ -27,8 +27,7 @@ func (r *Application) Updated(m *model.Application) (err error) {
 	if m.Repository == (model.Repository{}) {
 		return
 	}
-	label := Settings.Discovery.Label
-	kinds, err := r.FindTasks(label)
+	kinds, err := r.FindTasks(Settings.Discovery.Label)
 	if err != nil {
 		return
 	}
@@ -37,9 +36,14 @@ func (r *Application) Updated(m *model.Application) (err error) {
 		func(i, j int) bool {
 			ik := kinds[i]
 			jk := kinds[j]
-			iL := ik.Labels[label]
-			jL := jk.Labels[label]
-			return iL < jL
+			iP := ik.Spec.Priority
+			jP := jk.Spec.Priority
+			iN := ik.Name
+			jN := jk.Name
+			if iP != jP {
+				return iP < jP
+			}
+			return iN < jN
 		})
 	taskGroup := &tasking.TaskGroup{
 		TaskGroup: &model.TaskGroup{

--- a/trigger/application.go
+++ b/trigger/application.go
@@ -27,7 +27,8 @@ func (r *Application) Updated(m *model.Application) (err error) {
 	if m.Repository == (model.Repository{}) {
 		return
 	}
-	kinds, err := r.FindTasks(Settings.Discovery.Label)
+	label := Settings.Discovery.Label
+	kinds, err := r.FindTasks(label)
 	if err != nil {
 		return
 	}
@@ -38,12 +39,12 @@ func (r *Application) Updated(m *model.Application) (err error) {
 			jk := kinds[j]
 			iP := ik.Spec.Priority
 			jP := jk.Spec.Priority
-			iN := ik.Name
-			jN := jk.Name
+			iL := ik.Labels[label]
+			jL := jk.Labels[label]
 			if iP != jP {
 				return iP < jP
 			}
-			return iN < jN
+			return iL < jL
 		})
 	taskGroup := &tasking.TaskGroup{
 		TaskGroup: &model.TaskGroup{


### PR DESCRIPTION
 Sort discovery tasks by priority then by label (value).

We'll eventually want to update the `Task` CR in the operator to specify the priority of:
| Name           | Priority |
|--------------------|-------|
| language-discovery | 0     |
| tech-discovery     | 1     |


This will be more robust.

This is what the resources currently look like.
```
[jortel@f35a tackle2-hub][HOST/MAIN]$ oc get tasks -o custom-columns=NAME:.metadata.name,PRIORITY:.spec.priority
NAME                 PRIORITY
language-discovery   <none>     map[konveyor.io/discovery:language]
tech-discovery       <none>     map[konveyor.io/discovery:technology]
```

---

This PR also codifies system priority: 0-9 and user priorities 10+.  Tasks created though the API will be adjusted to ensure they are > 10.  For example: a task created with priority=0 (not specified) will be created with priority=10.  A task created with priority=4 will be created with priority=14.  This preserves the intended priority order within the user range.

---
Related to: https://github.com/konveyor/operator/pull/438
