### PR TITLE
:sparkles: Support list all application identities.

### DIFF
--- a/addon/task.go
+++ b/addon/task.go
@@ -39,6 +39,22 @@ func (h *Task) Application() (r *api.Application, err error) {
 		return
 	}
 	r, err = h.richClient.Application.Get(appRef.ID)
+	if err != nil {
+		return
+	}
+	r.Identities = []api.Ref{}
+	identities, err := h.richClient.Application.Identity(appRef.ID).List()
+	if err != nil {
+		return
+	}
+	for _, identity := range identities {
+		r.Identities = append(
+			r.Identities,
+			api.Ref{
+				ID:   identity.ID,
+				Name: identity.Name,
+			})
+	}
 	return
 }
 

--- a/api/identity.go
+++ b/api/identity.go
@@ -17,7 +17,8 @@ const (
 	IdentitiesRoot = "/identities"
 	IdentityRoot   = IdentitiesRoot + "/:" + ID
 	//
-	AppIdentitiesRoot = ApplicationRoot + "/identities/:" + Kind
+	AppIdentitiesRoot     = ApplicationRoot + "/identities"
+	AppIdentitiesKindRoot = AppIdentitiesRoot + "/:" + Kind
 )
 
 // Params.
@@ -40,6 +41,7 @@ func (h IdentityHandler) AddRoutes(e *gin.Engine) {
 	routeGroup.DELETE(IdentityRoot, h.Delete)
 	//
 	routeGroup.GET(AppIdentitiesRoot, h.AppList)
+	routeGroup.GET(AppIdentitiesKindRoot, h.AppList)
 }
 
 // Get godoc
@@ -142,7 +144,10 @@ func (h IdentityHandler) AppList(ctx *gin.Context) {
 	db := h.DB(ctx)
 	db = db.Joins("JOIN ApplicationIdentity j ON j.IdentityID = Identity.ID")
 	db = db.Where("j.ApplicationID", id)
-	err := db.Find(&direct, "kind", kind).Error
+	if kind != "" {
+		db = db.Where("kind", kind)
+	}
+	err := db.Find(&direct).Error
 	if err != nil {
 		_ = ctx.Error(err)
 		return
@@ -162,7 +167,10 @@ func (h IdentityHandler) AppList(ctx *gin.Context) {
 	db = h.DB(ctx)
 	var indirect []model.Identity
 	db = db.Where("default", true)
-	err = db.Find(&indirect, "kind", kind).Error
+	if kind != "" {
+		db = db.Where("kind", kind)
+	}
+	err = db.Find(&indirect).Error
 	if err != nil {
 		_ = ctx.Error(err)
 		return

--- a/api/identity.go
+++ b/api/identity.go
@@ -162,7 +162,7 @@ func (h IdentityHandler) AppList(ctx *gin.Context) {
 			return
 		}
 		r.With(m)
-		mp[r.Kind] = r
+		mp[m.Kind] = r
 	}
 	db = h.DB(ctx)
 	var indirect []model.Identity
@@ -177,6 +177,9 @@ func (h IdentityHandler) AppList(ctx *gin.Context) {
 	}
 	for i := range indirect {
 		m := &indirect[i]
+		if _, found := mp[m.Kind]; found {
+			continue
+		}
 		r := Identity{}
 		err := h.Decrypt(ctx, m)
 		if err != nil {

--- a/binding/application.go
+++ b/binding/application.go
@@ -70,7 +70,7 @@ func (h *Application) Tags(id uint) (tg AppTags) {
 	return
 }
 
-// Facts returns the tags API.
+// Facts returns the facts API.
 func (h *Application) Facts(id uint) (f AppFacts) {
 	f = AppFacts{
 		client: h.client,
@@ -88,7 +88,7 @@ func (h *Application) Analysis(id uint) (a Analysis) {
 	return
 }
 
-// Manifest returns the tags API.
+// Manifest returns the manifest API.
 func (h *Application) Manifest(id uint) (f AppManifest) {
 	f = AppManifest{
 		client: h.client,
@@ -97,7 +97,7 @@ func (h *Application) Manifest(id uint) (f AppManifest) {
 	return
 }
 
-// Identity returns the tags API.
+// Identity returns the identity API.
 func (h *Application) Identity(id uint) (f AppIdentity) {
 	f = AppIdentity{
 		client: h.client,
@@ -106,7 +106,7 @@ func (h *Application) Identity(id uint) (f AppIdentity) {
 	return
 }
 
-// Assessment returns the tags API.
+// Assessment returns the assessment API.
 func (h *Application) Assessment(id uint) (f AppAssessment) {
 	f = AppAssessment{
 		client: h.client,

--- a/binding/application.go
+++ b/binding/application.go
@@ -355,8 +355,7 @@ type AppIdentity struct {
 }
 
 // List identities.
-func (h AppIdentity) List() (r *api.Identity, found bool, err error) {
-	list := []api.Identity{}
+func (h AppIdentity) List() (list []api.Identity, err error) {
 	p := Param{
 		Key:   api.Decrypted,
 		Value: "1",
@@ -364,11 +363,6 @@ func (h AppIdentity) List() (r *api.Identity, found bool, err error) {
 	path := Path(api.AppIdentitiesRoot).Inject(Params{api.ID: h.appId})
 	err = h.client.Get(path, &list, p)
 	if err != nil {
-		return
-	}
-	for i := range list {
-		r = &list[i]
-		found = true
 		return
 	}
 	return

--- a/binding/application.go
+++ b/binding/application.go
@@ -61,29 +61,54 @@ func (h *Application) Bucket(id uint) (b *BucketContent) {
 	return
 }
 
-// FindIdentity by kind.
-func (h *Application) FindIdentity(id uint, kind string) (r *api.Identity, found bool, err error) {
-	list := []api.Identity{}
-	p := Param{
-		Key:   api.Decrypted,
-		Value: "1",
-	}
-	path := Path(api.AppIdentitiesRoot).Inject(Params{api.ID: id, api.Kind: kind})
-	err = h.client.Get(path, &list, p)
-	if err != nil {
-		return
-	}
-	for i := range list {
-		r = &list[i]
-		found = true
-		return
+// Tags returns the tags API.
+func (h *Application) Tags(id uint) (tg AppTags) {
+	tg = AppTags{
+		client: h.client,
+		appId:  id,
 	}
 	return
 }
 
-// Tags returns the tags API.
-func (h *Application) Tags(id uint) (tg AppTags) {
-	tg = AppTags{
+// Facts returns the tags API.
+func (h *Application) Facts(id uint) (f AppFacts) {
+	f = AppFacts{
+		client: h.client,
+		appId:  id,
+	}
+	return
+}
+
+// Analysis returns the analysis API.
+func (h *Application) Analysis(id uint) (a Analysis) {
+	a = Analysis{
+		client: h.client,
+		appId:  id,
+	}
+	return
+}
+
+// Manifest returns the tags API.
+func (h *Application) Manifest(id uint) (f AppManifest) {
+	f = AppManifest{
+		client: h.client,
+		appId:  id,
+	}
+	return
+}
+
+// Identity returns the tags API.
+func (h *Application) Identity(id uint) (f AppIdentity) {
+	f = AppIdentity{
+		client: h.client,
+		appId:  id,
+	}
+	return
+}
+
+// Assessment returns the tags API.
+func (h *Application) Assessment(id uint) (f AppAssessment) {
+	f = AppAssessment{
 		client: h.client,
 		appId:  id,
 	}
@@ -193,15 +218,6 @@ func (h *AppTags) unique(ids []uint) (u []uint) {
 	return
 }
 
-// Facts returns the tags API.
-func (h *Application) Facts(id uint) (f AppFacts) {
-	f = AppFacts{
-		client: h.client,
-		appId:  id,
-	}
-	return
-}
-
 // AppFacts sub-resource API.
 // Provides association management of facts.
 type AppFacts struct {
@@ -273,31 +289,7 @@ func (h *AppFacts) Replace(facts api.Map) (err error) {
 	return
 }
 
-// Analysis returns the analysis API.
-func (h *Application) Analysis(id uint) (a Analysis) {
-	a = Analysis{
-		client: h.client,
-		appId:  id,
-	}
-	return
-}
-
-// Create an Application Assessment.
-func (h *Application) CreateAssesment(id uint, r *api.Assessment) (err error) {
-	path := Path(api.AppAssessmentsRoot).Inject(Params{api.ID: id})
-	err = h.client.Post(path, &r)
-	return
-}
-
-// Get Application Assessments.
-func (h *Application) GetAssesments(id uint) (list []api.Assessment, err error) {
-	list = []api.Assessment{}
-	path := Path(api.AppAssessmentsRoot).Inject(Params{api.ID: id})
-	err = h.client.Get(path, &list)
-	return
-}
-
-// Analysis API.
+// Analysis sub-resource API.
 type Analysis struct {
 	client *Client
 	appId  uint
@@ -339,15 +331,7 @@ func (h *Analysis) Create(manifest, encoding string) (r *api.Analysis, err error
 	return
 }
 
-// Manifest returns the tags API.
-func (h *Application) Manifest(id uint) (f AppManifest) {
-	f = AppManifest{
-		client: h.client,
-		appId:  id,
-	}
-	return
-}
-
+// AppManifest sub-resource API.
 type AppManifest struct {
 	client *Client
 	appId  uint
@@ -361,5 +345,72 @@ func (h *AppManifest) Get(param ...Param) (r *api.Manifest, err error) {
 	r = &api.Manifest{}
 	path := Path(api.AppManifestRoot).Inject(Params{api.ID: h.appId})
 	err = h.client.Get(path, r, param...)
+	return
+}
+
+// AppIdentity sub-resource API.
+type AppIdentity struct {
+	client *Client
+	appId  uint
+}
+
+// List identities.
+func (h AppIdentity) List() (r *api.Identity, found bool, err error) {
+	list := []api.Identity{}
+	p := Param{
+		Key:   api.Decrypted,
+		Value: "1",
+	}
+	path := Path(api.AppIdentitiesRoot).Inject(Params{api.ID: h.appId})
+	err = h.client.Get(path, &list, p)
+	if err != nil {
+		return
+	}
+	for i := range list {
+		r = &list[i]
+		found = true
+		return
+	}
+	return
+}
+
+// Find by kind.
+func (h AppIdentity) Find(kind string) (r *api.Identity, found bool, err error) {
+	list := []api.Identity{}
+	p := Param{
+		Key:   api.Decrypted,
+		Value: "1",
+	}
+	path := Path(api.AppIdentitiesKindRoot).Inject(Params{api.ID: h.appId, api.Kind: kind})
+	err = h.client.Get(path, &list, p)
+	if err != nil {
+		return
+	}
+	for i := range list {
+		r = &list[i]
+		found = true
+		return
+	}
+	return
+}
+
+// AppAssessment sub-resource API.
+type AppAssessment struct {
+	client *Client
+	appId  uint
+}
+
+// Create an Assessment.
+func (h AppAssessment) Create(r *api.Assessment) (err error) {
+	path := Path(api.AppAssessmentsRoot).Inject(Params{api.ID: h.appId})
+	err = h.client.Post(path, &r)
+	return
+}
+
+// List Assessments.
+func (h AppAssessment) List() (list []api.Assessment, err error) {
+	list = []api.Assessment{}
+	path := Path(api.AppAssessmentsRoot).Inject(Params{api.ID: h.appId})
+	err = h.client.Get(path, &list)
 	return
 }

--- a/hack/add/identity.sh
+++ b/hack/add/identity.sh
@@ -5,7 +5,7 @@ host="${HOST:-localhost:8080}"
 id="${1:-0}" # 0=system-assigned.
 name="${2:-Test}"
 kind="${3:-source}"
-def="${4:-0}"
+def="${4:-false}"
 
 # create identity.
 curl -X POST ${host}/identities \

--- a/test/api/application/identity_test.go
+++ b/test/api/application/identity_test.go
@@ -72,4 +72,10 @@ func TestFindIdentity(t *testing.T) {
 	if found {
 		t.Errorf("not found expected")
 	}
+	// List
+	list, err := Application.Identity(application.ID).List()
+	assert.Must(t, err)
+	if len(list) != 2 {
+		t.Errorf("list expected: 1, actual: %d", len(list))
+	}
 }

--- a/test/api/application/identity_test.go
+++ b/test/api/application/identity_test.go
@@ -47,7 +47,7 @@ func TestFindIdentity(t *testing.T) {
 		_ = Application.Delete(application.ID)
 	}()
 	// Find direct.
-	identity, found, err := Application.FindIdentity(application.ID, direct.Kind)
+	identity, found, err := Application.Identity(application.ID).Find(direct.Kind)
 	assert.Must(t, err)
 	if found {
 		if identity.ID != direct.ID {
@@ -57,7 +57,7 @@ func TestFindIdentity(t *testing.T) {
 		t.Errorf("direct not found")
 	}
 	// Find indirect.
-	identity, found, err = Application.FindIdentity(application.ID, indirect.Kind)
+	identity, found, err = Application.Identity(application.ID).Find(indirect.Kind)
 	assert.Must(t, err)
 	if found {
 		if identity.ID != indirect.ID {
@@ -67,7 +67,7 @@ func TestFindIdentity(t *testing.T) {
 		t.Errorf("indirect not found")
 	}
 	// Not find indirect.
-	_, found, err = Application.FindIdentity(application.ID, "None")
+	_, found, err = Application.Identity(application.ID).Find("None")
 	assert.Must(t, err)
 	if found {
 		t.Errorf("not found expected")

--- a/test/api/application/identity_test.go
+++ b/test/api/application/identity_test.go
@@ -37,6 +37,16 @@ func TestFindIdentity(t *testing.T) {
 	defer func() {
 		_ = RichClient.Identity.Delete(indirect.ID)
 	}()
+	indirect2 := &api.Identity{
+		Kind:    "Test",
+		Name:    "indirect-shadowed",
+		Default: true,
+	}
+	err = RichClient.Identity.Create(indirect2)
+	assert.Must(t, err)
+	defer func() {
+		_ = RichClient.Identity.Delete(indirect2.ID)
+	}()
 	application := &api.Application{
 		Name:       t.Name(),
 		Identities: []api.Ref{{ID: direct.ID}},

--- a/test/api/assessment/api_test.go
+++ b/test/api/assessment/api_test.go
@@ -22,7 +22,7 @@ func TestAssessmentCRUD(t *testing.T) {
 				app := api.Application{Name: r.Application.Name}
 				assert.Must(t, RichClient.Application.Create(&app))
 				r.Application.ID = app.ID
-				err := RichClient.Application.CreateAssesment(app.ID, &r)
+				err := RichClient.Application.Assessment(app.ID).Create(&r)
 				if err != nil {
 					t.Errorf(err.Error())
 				}
@@ -39,7 +39,7 @@ func TestAssessmentCRUD(t *testing.T) {
 			}
 
 			// Get via parent object Application.
-			gotList, err := RichClient.Application.GetAssesments(r.Application.ID)
+			gotList, err := RichClient.Application.Assessment(r.Application.ID).List()
 			if err != nil {
 				t.Errorf(err.Error())
 			}


### PR DESCRIPTION
Add: /applications/:id/identities to list all identities (including defaults) for all kinds.
Inject default creds in addon adapter Application() method.

Required by: 
- https://github.com/konveyor/tackle2-addon-analyzer/pull/154
- https://github.com/konveyor/tackle2-addon-discovery/pull/19

Incidental: Small refactor/re-org of Application binding for consistency. 