### PR TITLE
:seedling: Set base_tag release-0.7 for on PR builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,3 +94,4 @@ jobs:
     with:
       tackle_hub: ttl.sh/konveyor-hub-${{ github.sha }}:2h
       api_hub_tests_ref: ${{ github.ref }}
+      base_tag: release-0.7


### PR DESCRIPTION
Related to https://github.com/konveyor/ci/pull/97

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration to include a new input parameter for integration testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->