### PR TITLE
:ghost: corrected generator params field.

### DIFF
--- a/api/generator.go
+++ b/api/generator.go
@@ -170,7 +170,7 @@ type Generator struct {
 	Kind       string      `json:"kind" binding:"required"`
 	Name       string      `json:"name"`
 	Repository *Repository `json:"repository"`
-	Parameters Map         `json:"parameters"`
+	Params     Map         `json:"params"`
 	Values     Map         `json:"values"`
 	Identity   *Ref        `json:"identity,omitempty" yaml:",omitempty"`
 	Profiles   []Ref       `json:"profiles"`
@@ -182,7 +182,7 @@ func (r *Generator) With(m *model.Generator) {
 	r.Kind = m.Kind
 	r.Name = m.Name
 	r.Identity = r.refPtr(m.IdentityID, m.Identity)
-	r.Parameters = m.Parameters
+	r.Params = m.Params
 	r.Values = m.Values
 	if m.Repository != (model.Repository{}) {
 		repository := Repository(m.Repository)
@@ -200,7 +200,7 @@ func (r *Generator) Model() (m *model.Generator) {
 	m.ID = r.ID
 	m.Kind = r.Kind
 	m.Name = r.Name
-	m.Parameters = r.Parameters
+	m.Params = r.Params
 	m.Values = r.Values
 	if r.Repository != nil {
 		m.Repository = model.Repository(*r.Repository)

--- a/migration/v18/model/platform.go
+++ b/migration/v18/model/platform.go
@@ -35,7 +35,7 @@ type Generator struct {
 	Kind       string
 	Name       string
 	Repository Repository `gorm:"type:json;serializer:json"`
-	Parameters json.Map   `gorm:"type:json;serializer:json"`
+	Params     json.Map   `gorm:"type:json;serializer:json"`
 	Values     json.Map   `gorm:"type:json;serializer:json"`
 	IdentityID *uint
 	Identity   *Identity

--- a/test/api/generator/samples.go
+++ b/test/api/generator/samples.go
@@ -12,7 +12,7 @@ var (
 		Repository: &api.Repository{
 			URL: "https://github.com/konveyor/tackle2-hub",
 		},
-		Parameters: api.Map{
+		Params: api.Map{
 			"p1": "v1",
 			"p2": "v2",
 		},


### PR DESCRIPTION
Changed to `Params` for consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Renamed the "parameters" field to "params" in relevant data structures and updated all related references for consistency.

* **Tests**
  * Updated test data to use the new "params" field name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->