### PR TITLE
:ghost: Revised Addon.tasks m2m approach.

### DIFF
--- a/generated/crd/tackle.konveyor.io_addons.yaml
+++ b/generated/crd/tackle.konveyor.io_addons.yaml
@@ -1271,11 +1271,9 @@ spec:
               selector:
                 description: Selector defines criteria to be selected for a task.
                 type: string
-              tasks:
-                description: Tasks declares tasks the addon provides.
-                items:
-                  type: string
-                type: array
+              task:
+                description: Task declares task compatability.
+                type: string
             type: object
           status:
             description: Status defines the observed state of the resource.

--- a/k8s/api/tackle/v1alpha1/addon.go
+++ b/k8s/api/tackle/v1alpha1/addon.go
@@ -34,8 +34,8 @@ type AddonSpec struct {
 	// +kubebuilder:validation:Optional
 	Resources *core.ResourceRequirements `json:"resources,omitempty"`
 	//
-	// Tasks declares tasks the addon provides.
-	Tasks []string `json:"tasks,omitempty"`
+	// Task declares task compatability.
+	Task string `json:"task,omitempty"`
 	// Selector defines criteria to be selected for a task.
 	Selector string `json:"selector,omitempty"`
 	// Container defines the addon container.
@@ -112,17 +112,6 @@ func (r *Addon) Migrate() (updated bool) {
 	if r.Spec.Container.Name == "" {
 		r.Spec.Container.Name = "addon"
 		updated = true
-	}
-	return
-}
-
-// Provides returns true when the addon provides the specified kind-of task.
-func (r *Addon) Provides(task string) (match bool) {
-	for _, kind := range r.Spec.Tasks {
-		match = task == kind
-		if match {
-			break
-		}
 	}
 	return
 }

--- a/k8s/api/tackle/v1alpha1/zz_generated.deepcopy.go
+++ b/k8s/api/tackle/v1alpha1/zz_generated.deepcopy.go
@@ -104,11 +104,6 @@ func (in *AddonSpec) DeepCopyInto(out *AddonSpec) {
 		*out = new(v1.ResourceRequirements)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.Tasks != nil {
-		in, out := &in.Tasks, &out.Tasks
-		*out = make([]string, len(*in))
-		copy(*out, *in)
-	}
 	in.Container.DeepCopyInto(&out.Container)
 	in.Metadata.DeepCopyInto(&out.Metadata)
 }

--- a/task/error.go
+++ b/task/error.go
@@ -250,6 +250,25 @@ func (e *ExtAddonNotValid) Is(err error) (matched bool) {
 	return
 }
 
+// AddonTaskNotValid reports addon task ref error.
+type AddonTaskNotValid struct {
+	Addon  string
+	Reason string
+}
+
+func (e *AddonTaskNotValid) Error() string {
+	return fmt.Sprintf(
+		"Addon '%s' task ref not valid. reason: %s",
+		e.Addon,
+		e.Reason)
+}
+
+func (e *AddonTaskNotValid) Is(err error) (matched bool) {
+	var inst *AddonTaskNotValid
+	matched = errors.As(err, &inst)
+	return
+}
+
 // PriorityNotFound report priority class not found.
 type PriorityNotFound struct {
 	Name  string

--- a/task/manager.go
+++ b/task/manager.go
@@ -540,7 +540,11 @@ func (m *Manager) selectAddon(task *Task) (addon *crd.Addon, err error) {
 	var selected *crd.Addon
 	selector := NewSelector(m.DB, task)
 	for _, addon = range m.cluster.Addons() {
-		if !addon.Provides(kind.Name) {
+		matched, err = task.matchTask(addon, kind)
+		if err != nil {
+			return
+		}
+		if !matched {
 			continue
 		}
 		matched, err = selector.Match(addon.Spec.Selector)

--- a/task/task.go
+++ b/task/task.go
@@ -458,7 +458,7 @@ func (r *Task) matchTask(addon *crd.Addon, task *crd.Task) (matched bool, err er
 		}
 		matched = p.MatchString(task.Name)
 	} else {
-		matched = addon.Name == ref
+		matched = task.Name == ref
 	}
 	return
 }

--- a/task/task.go
+++ b/task/task.go
@@ -440,6 +440,29 @@ func (r *Task) getExtensions(client k8s.Client) (extensions []crd.Extension, err
 	return
 }
 
+// matchTask - returns true when the addon's `task`
+// (ref) matches the task name.
+// The `ref` is matched as a REGEX when it contains
+// characters other than: [0-9A-Za-z_].
+func (r *Task) matchTask(addon *crd.Addon, task *crd.Task) (matched bool, err error) {
+	ref := strings.TrimSpace(addon.Spec.Task)
+	p := IsRegex
+	if p.MatchString(ref) {
+		p, err = regexp.Compile(ref)
+		if err != nil {
+			err = &AddonTaskNotValid{
+				Addon:  addon.Name,
+				Reason: err.Error(),
+			}
+			return
+		}
+		matched = p.MatchString(task.Name)
+	} else {
+		matched = addon.Name == ref
+	}
+	return
+}
+
 // matchAddon - returns true when the extension's `addon`
 // (ref) matches the addon name.
 // The `ref` is matched as a REGEX when it contains


### PR DESCRIPTION
Revised for consistency with Extension.addon ref being a REGEX instead of list.  This also does not require a change in the CRD (which is always good).

Requires: https://github.com/konveyor/operator/pull/457

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new error type for handling invalid addon task references, providing clearer error messages.

* **Bug Fixes**
  * Improved addon task matching logic to support both direct string and regex-based matching, enhancing flexibility and error handling.

* **Refactor**
  * Simplified addon specification by replacing the list of tasks with a single task field.
  * Removed obsolete methods and updated internal logic to align with the new task matching approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->