### PR TITLE
:sparkles: Ensure addon adapter logs stack traces. 

### DIFF
--- a/addon/adapter.go
+++ b/addon/adapter.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	logapi "github.com/go-logr/logr"
+	liberr "github.com/jortel/go-utils/error"
 	"github.com/jortel/go-utils/logr"
 	"github.com/konveyor/tackle2-hub/binding"
 	"github.com/konveyor/tackle2-hub/settings"
@@ -17,6 +18,7 @@ import (
 
 var (
 	Settings = &settings.Settings
+	Wrap     = liberr.Wrap
 	Log      = logr.WithName("addon")
 )
 
@@ -128,6 +130,7 @@ func (h *Adapter) Run(addon func() error) {
 		}
 		if err != nil {
 			h.Failed(err.Error())
+			h.Log.Error(err, "Addon failed.")
 			os.Exit(1)
 		}
 	}()

--- a/addon/task.go
+++ b/addon/task.go
@@ -118,6 +118,7 @@ func (h *Task) Data() (d any) {
 func (h *Task) DataWith(object any) (err error) {
 	b, _ := json.Marshal(h.task.Data)
 	err = json.Unmarshal(b, object)
+	err = Wrap(err)
 	return
 }
 


### PR DESCRIPTION
The adapter used to log errors but got removed in some previous patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and logging for addon failures, ensuring errors are now explicitly logged when they occur.
  * Enhanced error messages in task data processing for better clarity and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->