### PR TITLE
:bug: No document returned by: POST /tasks with json encoding.

### DIFF
--- a/migration/json/fields.go
+++ b/migration/json/fields.go
@@ -34,6 +34,7 @@ func (d *Data) Merge(other Data) (merged bool) {
 		return
 	}
 	d.Any = d.merge(a, b)
+	d.Any = jsd.JsonSafe(d.Any)
 	merged = true
 	return
 }


### PR DESCRIPTION
Fixes json encoding error for merged task.Data.
POST /tasks succeeded but caused a json encoding error which resulted in no document returned.  This only happens when the task.Data is merged either from a TaskGroup or the Task (CR).Data. 

Not discovered until now because:
- The returned document is not validated by api-tests.
- The UI does not look at returned created tasks until now.
- Developers mostly use YAML.