### PR TITLE
:bug: Fix archetype update with profiles.

### DIFF
--- a/api/association/pkg.go
+++ b/api/association/pkg.go
@@ -213,8 +213,7 @@ func (a *Association) set(m any, field string, value any) (err error) {
 	defer func() {
 		r := recover()
 		if r != nil {
-			rErr, cast := r.(error)
-			if cast {
+			if rErr, cast := r.(error); cast {
 				err = rErr
 			} else {
 				err = fmt.Errorf("%v", r)


### PR DESCRIPTION
Archetype update fails with populated profiles with foreign key constraint violation.
The problem is, the Association was deleting all of the TargetProfiles and then re-creating them with db.Save() instead of db.Create() with an on-conflict clause. As a result, the TargetProfiles where being updated and not created (because ID > 0).
This could be fixed by changing Save() to Create(). However:

For Associations with a _HasMany_ (owner=True) relationship, the original intent was to preserve IDs.  After further consideration, this is a bad idea. The IDs should be read only since the owned entities belong to the owner.  Should the existing ID be honored (preserved), an owned entity could accidentally be referenced by more than one owner.

closes #883 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Replacing owned “has‑many” associations now creates new related records and correctly links them to the parent, preventing unintended updates.
  - Field assignments during association updates now convert internal failures into returned errors instead of causing crashes.
- Stability
  - Improved safeguards and per-item error checks during association updates reduce runtime failures and improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->