### PR TITLE
:bug: Ensure profile generator (user defined) order.

### DIFF
--- a/hack/update/archetype.sh
+++ b/hack/update/archetype.sh
@@ -5,7 +5,9 @@ host="${HOST:-localhost:8080}"
 id="${1:-1}"
 kind="${2:-Test}"
 name="${3:-Test}-${id}"
-genid="${4:-1}"
+genA="${4:-1}"
+genB="${5:-2}"
+genC="${6:-3}"
 
 # update archetype
 curl -X PUT ${host}/archetypes/${id} \
@@ -16,11 +18,13 @@ curl -X PUT ${host}/archetypes/${id} \
 id: ${id}
 name: ${name}
 profiles:
-  - id: 1
-    name: openshift
+  - name: openshift
     generators:
-      - id: ${genid}
+      - id: ${genA}
+      - id: ${genB}
+      - id: ${genC}
   - name: other
     generators:
-      - id: ${genid}
+      - id: ${genA}
+      - id: ${genB}
 "

--- a/migration/v18/model/application.go
+++ b/migration/v18/model/application.go
@@ -176,6 +176,22 @@ type Archetype struct {
 	Profiles          []TargetProfile    `gorm:"constraint:OnDelete:CASCADE"`
 }
 
+type TargetProfile struct {
+	Model
+	Name        string `gorm:"uniqueIndex:targetProfileA;not null"`
+	ArchetypeID uint   `gorm:"uniqueIndex:targetProfileA;not null"`
+	Archetype   Archetype
+	Generators  []ProfileGenerator `gorm:"order:Index;constraint:OnDelete:CASCADE"`
+}
+
+type ProfileGenerator struct {
+	GeneratorID     uint `gorm:"index"`
+	TargetProfileID uint `gorm:"index;uniqueIndex:profileGeneratorA"`
+	Index           int  `gorm:"index;uniqueIndex:profileGeneratorA"`
+	TargetProfile   TargetProfile
+	Generator       Generator
+}
+
 type Tag struct {
 	Model
 	UUID       *string `gorm:"uniqueIndex"`

--- a/migration/v18/model/pkg.go
+++ b/migration/v18/model/pkg.go
@@ -56,5 +56,6 @@ func All() []any {
 		Questionnaire{},
 		Assessment{},
 		Archetype{},
+		ProfileGenerator{},
 	}
 }

--- a/migration/v18/model/platform.go
+++ b/migration/v18/model/platform.go
@@ -22,13 +22,6 @@ type Platform struct {
 	Applications []Application `gorm:"constraint:OnDelete:SET NULL"`
 	Tasks        []Task        `gorm:"constraint:OnDelete:CASCADE"`
 }
-type TargetProfile struct {
-	Model
-	Name        string      `gorm:"uniqueIndex:targetProfileA;not null"`
-	Generators  []Generator `gorm:"many2many:TargetGenerator;constraint:OnDelete:CASCADE"`
-	ArchetypeID uint        `gorm:"uniqueIndex:targetProfileA;not null"`
-	Archetype   Archetype
-}
 
 type Generator struct {
 	Model

--- a/model/pkg.go
+++ b/model/pkg.go
@@ -35,6 +35,7 @@ type Manifest = model.Manifest
 type MigrationWave = model.MigrationWave
 type PK = model.PK
 type Platform = model.Platform
+type ProfileGenerator = model.ProfileGenerator
 type Proxy = model.Proxy
 type Questionnaire = model.Questionnaire
 type Review = model.Review

--- a/test/api/archetype/api_test.go
+++ b/test/api/archetype/api_test.go
@@ -15,23 +15,28 @@ func TestArchetypeCRUD(t *testing.T) {
 		_ = json.Unmarshal(b, &r)
 		t.Run(r.Name, func(t *testing.T) {
 			// generator
-			generator := &api.Generator{
-				Name: t.Name(),
-				Kind: t.Name(),
+			genA := &api.Generator{Name: "genA", Kind: "helm"}
+			genB := &api.Generator{Name: "genB", Kind: "helm"}
+			genC := &api.Generator{Name: "genC", Kind: "helm"}
+			genD := &api.Generator{Name: "genD", Kind: "helm"}
+			for _, g := range []*api.Generator{genA, genB, genC, genD} {
+				err := RichClient.Generator.Create(g)
+				assert.Must(t, err)
 			}
-			err := RichClient.Generator.Create(generator)
-			assert.Must(t, err)
 			defer func() {
-				_ = RichClient.Generator.Delete(generator.ID)
+				_ = RichClient.Generator.Delete(genA.ID)
+				_ = RichClient.Generator.Delete(genB.ID)
+				_ = RichClient.Generator.Delete(genC.ID)
+				_ = RichClient.Generator.Delete(genD.ID)
 			}()
 			// Create.
 			for i := range r.Profiles {
 				p := &r.Profiles[i]
 				p.Generators = append(
 					p.Generators,
-					api.Ref{ID: generator.ID})
+					api.Ref{ID: genA.ID, Name: genA.Name})
 			}
-			err = Archetype.Create(&r)
+			err := Archetype.Create(&r)
 			if err != nil {
 				t.Errorf(err.Error())
 			}
@@ -41,12 +46,24 @@ func TestArchetypeCRUD(t *testing.T) {
 			if err != nil {
 				t.Errorf(err.Error())
 			}
-			if assert.FlatEqual(got, r) {
-				t.Errorf("Different response error. Got %v, expected %v", got, r)
+			if !assert.Eq(r, got) {
+				t.Errorf("Different response error.\nGot:\n%+v\nExpected:\n%+v", got, &r)
 			}
 
+			nProfiles := len(r.Profiles)
+
 			// Update.
-			r.Name = "Updated " + r.Name
+			// Change the name and add a profile.
+			r.Name += "-Updated"
+			r.Profiles = append(
+				r.Profiles,
+				api.TargetProfile{
+					Name: "Added",
+					Generators: []api.Ref{
+						{
+							ID:   genD.ID,
+							Name: genD.Name,
+						}}})
 			err = Archetype.Update(&r)
 			if err != nil {
 				t.Errorf(err.Error())
@@ -56,8 +73,44 @@ func TestArchetypeCRUD(t *testing.T) {
 			if err != nil {
 				t.Errorf(err.Error())
 			}
-			if got.Name != r.Name {
-				t.Errorf("Different response error. Got %s, expected %s", got.Name, r.Name)
+			if !assert.Eq(r.Name, got.Name) {
+				t.Errorf("Different error.\nGot:\n%+v\nExpected:\n%+v", got, &r)
+			}
+			if !assert.Eq(nProfiles+1, len(got.Profiles)) {
+				t.Errorf("Different error.\nGot:\n%+v\nExpected:\n%+v", got, &r)
+			}
+
+			// add a profile and add generators and ensure ordering preserved.
+			for i := range r.Profiles {
+				p := &r.Profiles[i]
+				p.Generators = append(
+					p.Generators,
+					api.Ref{ID: genC.ID, Name: genC.Name},
+					api.Ref{ID: genB.ID, Name: genB.Name},
+				)
+			}
+			err = Archetype.Update(&r)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+			got, err = Archetype.Get(r.ID)
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+			for i := range got.Profiles {
+				p := &got.Profiles[i]
+				p.CreateTime = r.Profiles[i].CreateTime
+			}
+			// transfer updateUser and profiles Ids.
+			// needs to be ignored in Eq().
+			r.UpdateUser = got.UpdateUser
+			for i := range got.Profiles {
+				if i < len(r.Profiles) {
+					(&r.Profiles[i]).ID = got.Profiles[i].ID
+				}
+			}
+			if !assert.Eq(r, got) {
+				t.Errorf("Different response error.\nGot:\n%+v\nExpected:\n%+v", got, &r)
 			}
 
 			// Delete.

--- a/test/api/archetype/samples.go
+++ b/test/api/archetype/samples.go
@@ -7,13 +7,13 @@ import (
 // Set of valid resources for tests and reuse.
 var (
 	MinimalArchetype = api.Archetype{
-		Name:        "Minimal Archetype",
+		Name:        "Minimal",
 		Description: "Archetype minimal sample 1",
 		Comments:    "Archetype comments",
 	}
 	WithProfiles = api.Archetype{
-		Name:        "Minimal Archetype",
-		Description: "Archetype minimal sample 1",
+		Name:        "WithProfiles",
+		Description: "Archetype with profiles",
 		Comments:    "Archetype comments",
 		Profiles: []api.TargetProfile{
 			{Name: "openshift"},


### PR DESCRIPTION
To support ordered association between a target profile and its generators, a custom join table needs to used.

close #885 

Also, added 2 convenience functions in `assert` for _diffing_ and describing differences in resources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Profiles within an archetype now support ordered generators; order is preserved on create/update and reflected in reads.
- Bug Fixes
  - More reliable loading of profile and generator data ensures complete and consistent results.
- Chores
  - Updated helper script to accept three generator IDs and populate multiple generators per profile.
  - Sample/test archetype names and payloads adjusted for clarity.
- Migrations
  - Introduced schema to support ordered generators per profile without changing the public API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->