### PR TITLE
:ghost: Relax seed kind not supported.

### DIFF
--- a/seed/seed.go
+++ b/seed/seed.go
@@ -22,7 +22,8 @@ type Hub struct {
 
 // With collects the resources to be seeded.
 func (r *Hub) With(seed libseed.Seed) (err error) {
-	switch strings.ToLower(seed.Kind) {
+	kind := strings.ToLower(seed.Kind)
+	switch kind {
 	case libseed.KindTagCategory:
 		err = r.TagCategory.With(seed)
 	case libseed.KindJobFunction:
@@ -34,7 +35,7 @@ func (r *Hub) With(seed libseed.Seed) (err error) {
 	case libseed.KindQuestionnaire:
 		err = r.Questionnaire.With(seed)
 	default:
-		err = liberr.New("unknown kind", "kind", seed.Kind, "file", seed.Filename())
+		log.Info("WARNING: " + kind + " not supported.")
 	}
 	return
 }


### PR DESCRIPTION
This way new seeded types will pass CI.
Discussed with @mansam  and there isn't a downside.  The hub should start even when there are seed _kinds_ supported in the seed repository that are not yet supported in the hub.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved seeding resilience: unknown seed types no longer cause the process to fail. The system now logs a warning and continues, reducing interruptions during initialization and supporting smoother runs in mixed or custom setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->