### PR TITLE
:ghost: Better migration support for dev.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,6 @@ COPY --from=report /usr/local/static-report /tmp/analysis/report
 
 RUN echo "${VERSION}" > /etc/hub-build
 
-#ENV DEVELOPMENT=1
-
 RUN microdnf -y install \
   sqlite \
  && microdnf -y clean all

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -135,6 +135,9 @@ func main() {
 			log.Error(err, "")
 		}
 	}()
+	if Settings.Hub.Development {
+		log.Info("****** DEVELOPMENT MODE ********")
+	}
 	syscall.Umask(0)
 	printHeap()
 	//

--- a/migration/migrate.go
+++ b/migration/migrate.go
@@ -1,11 +1,9 @@
 package migration
 
 import (
-	"errors"
 	"os"
 	"path"
 	"regexp"
-	"strconv"
 	"strings"
 
 	liberr "github.com/jortel/go-utils/error"
@@ -18,67 +16,56 @@ import (
 // Migrate the hub by applying all necessary Migrations.
 func Migrate(migrations []Migration) (err error) {
 	var db *gorm.DB
-
 	db, err = database.Open(false)
 	if err != nil {
 		return
 	}
-
 	defer func() {
 		if err != nil {
 			_ = database.Close(db)
 		}
 	}()
-
-	setting := &model.Setting{}
-	result := db.FirstOrCreate(setting, model.Setting{Key: VersionKey})
-	if result.Error != nil {
-		err = liberr.Wrap(result.Error)
+	version, isUpgrade, err := getVersion(db)
+	if err != nil {
 		return
 	}
-
+	err = version.Validate(migrations)
+	if err != nil {
+		return
+	}
 	err = database.Close(db)
 	if err != nil {
 		return
 	}
 
-	var v Version
-	err = setting.As(&v)
-	if err != nil {
-		return
+	var beginIndex int
+	if !isUpgrade || Settings.Development {
+		beginIndex = version.Latest(migrations).Index()
+	} else {
+		beginIndex = version.Next().Index()
 	}
-	var start = v.Version
-	if start != 0 && start < MinimumVersion {
-		err = errors.New("unsupported database version")
-		return
-	} else if start >= MinimumVersion {
-		start -= MinimumVersion
-	}
-
-	if Settings.Hub.Development {
-		if start >= len(migrations) {
-			Log.Info("Development mode: forcing last migration.")
-			start = len(migrations) - 1
-		}
-	}
-
-	for i := start; i < len(migrations); i++ {
+	for i := beginIndex; i < len(migrations); i++ {
+		version.With(i)
 		m := migrations[i]
-		ver := i + MinimumVersion + 1
-
+		if _, cast := m.(*NopMigration); cast {
+			err = setVersion(db, version)
+			if err != nil {
+				return
+			}
+			continue
+		}
 		db, err = database.Open(false)
 		if err != nil {
-			err = liberr.Wrap(err, "version")
+			err = liberr.Wrap(err)
 			return
 		}
-
 		f := func(db *gorm.DB) (err error) {
-			Log.Info("Running migration.", "version", ver)
+			Log.Info("Running migration.", "version", version.String())
 			err = m.Apply(db)
 			if err != nil {
 				return
 			}
-			err = setVersion(db, ver)
+			err = setVersion(db, version)
 			if err != nil {
 				return
 			}
@@ -86,17 +73,17 @@ func Migrate(migrations []Migration) (err error) {
 		}
 		err = db.Transaction(f)
 		if err != nil {
-			err = liberr.Wrap(err, "version", ver)
+			err = liberr.Wrap(err)
 			return
 		}
-		err = writeSchema(db, ver)
+		err = writeSchema(db, version)
 		if err != nil {
-			err = liberr.Wrap(err, "version", ver)
+			err = liberr.Wrap(err)
 			return
 		}
 		err = database.Close(db)
 		if err != nil {
-			err = liberr.Wrap(err, "version", ver)
+			err = liberr.Wrap(err)
 			return
 		}
 	}
@@ -104,20 +91,38 @@ func Migrate(migrations []Migration) (err error) {
 	return
 }
 
-// Set the version record.
-func setVersion(db *gorm.DB, version int) (err error) {
-	setting := &model.Setting{Key: VersionKey}
-	setting.Value = Version{Version: version}
-	result := db.Where("key", VersionKey).Updates(setting)
+func getVersion(db *gorm.DB) (v *Version, isUpgrade bool, err error) {
+	setting := &model.Setting{}
+	result := db.FirstOrCreate(setting, model.Setting{Key: VersionKey})
 	if result.Error != nil {
 		err = liberr.Wrap(result.Error)
+		return
+	}
+	v = &Version{}
+	err = setting.As(v)
+	if err != nil {
+		err = liberr.Wrap(result.Error)
+		return
+	}
+	isUpgrade = result.RowsAffected == 0
+	return
+}
+
+// Set the version record.
+func setVersion(db *gorm.DB, v *Version) (err error) {
+	setting := &model.Setting{Key: VersionKey}
+	setting.Value = v
+	db = db.Where("key", VersionKey)
+	err = db.Updates(setting).Error
+	if err != nil {
+		err = liberr.Wrap(err)
 		return
 	}
 	return
 }
 
 // writeSchema - writes the migrated schema to a file.
-func writeSchema(db *gorm.DB, version int) (err error) {
+func writeSchema(db *gorm.DB, version *Version) (err error) {
 	var list []struct {
 		Type     string `gorm:"column:type"`
 		Name     string `gorm:"column:name"`
@@ -135,7 +140,7 @@ func writeSchema(db *gorm.DB, version int) (err error) {
 		path.Dir(Settings.Hub.DB.Path),
 		"migration")
 	err = nas.MkDir(dir, 0755)
-	f, err := os.Create(path.Join(dir, strconv.Itoa(version)))
+	f, err := os.Create(path.Join(dir, version.String()))
 	if err != nil {
 		return
 	}

--- a/migration/pkg.go
+++ b/migration/pkg.go
@@ -1,6 +1,11 @@
 package migration
 
 import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	liberr "github.com/jortel/go-utils/error"
 	"github.com/jortel/go-utils/logr"
 	v10 "github.com/konveyor/tackle2-hub/migration/v10"
 	v11 "github.com/konveyor/tackle2-hub/migration/v11"
@@ -29,13 +34,81 @@ var Settings = &settings.Settings
 // VersionKey is the setting containing the migration version.
 const VersionKey = ".migration.version"
 
-// MinimumVersion is the index of the
-// earliest version that we can migrate from.
-var MinimumVersion = 1
-
 // Version represents the value of the .migration.version setting.
 type Version struct {
 	Version int `json:"version"`
+}
+
+func (v *Version) Validate(migrations []Migration) (err error) {
+	if v.Version <= len(migrations) {
+		return
+	}
+	err = &VersionError{Version: v.Index()}
+	err = liberr.Wrap(err)
+	return
+}
+
+func (v *Version) Index() (index int) {
+	index = v.Version - 1
+	if index < 0 {
+		index = 0
+	}
+	return
+}
+
+func (v *Version) With(index int) {
+	v.Version = index + 1
+}
+
+func (v *Version) String() (s string) {
+	s = strconv.Itoa(v.Version)
+	return
+}
+
+func (v *Version) Latest(migrations []Migration) (latest *Version) {
+	latest = &Version{
+		Version: len(migrations),
+	}
+	return
+}
+
+func (v *Version) Rewind(n int) *Version {
+	v.Version -= n
+	if v.Version < 1 {
+		v.Version = 1
+	}
+	return v
+}
+
+func (v *Version) Next() *Version {
+	v.Version++
+	return v
+}
+
+// NopMigration placeholder.
+type NopMigration struct{}
+
+func (m *NopMigration) Apply(*gorm.DB) (err error) {
+	return
+}
+
+func (m *NopMigration) Models() (none []any) {
+	return
+}
+
+type VersionError struct {
+	Version int
+}
+
+func (v *VersionError) Is(err error) (matched bool) {
+	var inst *VersionError
+	matched = errors.As(err, &inst)
+	return
+}
+
+func (v *VersionError) Error() (s string) {
+	s = fmt.Sprintf("Migration version=%d not-valid.", v.Version)
+	return
 }
 
 // Migration encapsulates the functionality necessary to perform a migration.
@@ -45,8 +118,10 @@ type Migration interface {
 }
 
 // All migrations in order.
+// Note: pruned version MUST not be removed but instead, replaced with NopMigration.
 func All() []Migration {
 	return []Migration{
+		&NopMigration{},
 		v2.Migration{},
 		v3.Migration{},
 		v4.Migration{},

--- a/migration/v18/model/platform.go
+++ b/migration/v18/model/platform.go
@@ -25,7 +25,7 @@ type Platform struct {
 
 type Generator struct {
 	Model
-	UUID        *string `gorm:"uniqueIndex"`
+	UUID        *string `gorm:"index:idx_uuid,unique"`
 	Kind        string
 	Name        string
 	Description string

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	liberr "github.com/jortel/go-utils/error"
-	"github.com/konveyor/tackle2-hub/migration"
 	"github.com/konveyor/tackle2-hub/model"
 	libseed "github.com/konveyor/tackle2-seed/pkg"
 	"gorm.io/gorm"
@@ -102,26 +101,6 @@ func saveChecksum(db *gorm.DB, checksum []byte) (err error) {
 		err = liberr.Wrap(result.Error)
 		return
 	}
-	return
-}
-
-// migrationVersion gets the current migration version.
-func migrationVersion(db *gorm.DB) (version uint, err error) {
-	setting := &model.Setting{}
-	result := db.First(setting, model.Setting{Key: migration.VersionKey})
-	if result.Error != nil {
-		err = liberr.Wrap(result.Error)
-		return
-	}
-
-	var v migration.Version
-	err = setting.As(&v)
-	if err != nil {
-		err = liberr.Wrap(err)
-		return
-	}
-
-	version = uint(v.Version)
 	return
 }
 

--- a/settings/hub.go
+++ b/settings/hub.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/user"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -311,6 +312,8 @@ func (r *Hub) Load() (err error) {
 	if found {
 		b, _ := strconv.ParseBool(s)
 		r.Development = b
+	} else {
+		r.Development = r.Build == "" || strings.HasSuffix(r.Build, "-main")
 	}
 	s, found = os.LookupEnv(EnvBucketTTL)
 	if found {


### PR DESCRIPTION
During development on _main_, we often needs to adjust the data-model.  However, we don't want to be adding a new migration every time as it will explode the number of migrations.  Ideally, we only have 1 migration per release.
The approach is to set Development=1 when the hub version ="" or ends with "-main".  By doing this, the latest migration will always be run for local-runs and images built off _main_.

Further, I wanted to simplify the logic in the migrator.
For new instsalls, only run the latest migration.  This is more efficient and less chance for error.
The migration version is 1-based but the migration list is iterated by index 0-based.  Rather than manipulating the index based on the Min-Version, it seems simpler to require that the list of `migrations` be zero based.  Any migrations that are pruned because they are no longer needed for upgrade, they are replaced by _NopMigration_ rather than removed. 

This will likely not get into 8.0.