### PR TITLE
:bug: Task createUser not populated.

### DIFF
--- a/api/application.go
+++ b/api/application.go
@@ -428,6 +428,7 @@ func (h ApplicationHandler) Create(ctx *gin.Context) {
 	rtx := RichContext(ctx)
 	tr := trigger.Application{
 		Trigger: trigger.Trigger{
+			User:        rtx.User,
 			TaskManager: rtx.TaskManager,
 			Client:      rtx.Client,
 			DB:          h.DB(ctx),
@@ -567,6 +568,7 @@ func (h ApplicationHandler) Update(ctx *gin.Context) {
 	rtx := RichContext(ctx)
 	tr := trigger.Application{
 		Trigger: trigger.Trigger{
+			User:        rtx.User,
 			TaskManager: rtx.TaskManager,
 			Client:      rtx.Client,
 			DB:          h.DB(ctx),

--- a/api/identity.go
+++ b/api/identity.go
@@ -248,6 +248,7 @@ func (h IdentityHandler) Create(ctx *gin.Context) {
 	rtx := RichContext(ctx)
 	tr := trigger.Identity{
 		Trigger: trigger.Trigger{
+			User:        rtx.User,
 			TaskManager: rtx.TaskManager,
 			Client:      rtx.Client,
 			DB:          h.DB(ctx),
@@ -335,6 +336,7 @@ func (h IdentityHandler) Update(ctx *gin.Context) {
 	rtx := RichContext(ctx)
 	tr := trigger.Identity{
 		Trigger: trigger.Trigger{
+			User:        rtx.User,
 			TaskManager: rtx.TaskManager,
 			Client:      rtx.Client,
 			DB:          h.DB(ctx),

--- a/api/task.go
+++ b/api/task.go
@@ -662,6 +662,7 @@ func (h TaskHandler) CreateReport(ctx *gin.Context) {
 	err = h.DB(ctx).Create(m).Error
 	if err != nil {
 		_ = ctx.Error(err)
+		return
 	}
 	report.With(m)
 

--- a/api/task.go
+++ b/api/task.go
@@ -393,7 +393,7 @@ func (h TaskHandler) Create(ctx *gin.Context) {
 	}
 	rtx := RichContext(ctx)
 	task := &tasking.Task{}
-	task.With(r.Model())
+	task.With(r.Patch(&model.Task{}))
 	task.CreateUser = h.BaseHandler.CurrentUser(ctx)
 	err = rtx.TaskManager.Create(h.DB(ctx), task)
 	if err != nil {
@@ -455,7 +455,7 @@ func (h TaskHandler) Update(ctx *gin.Context) {
 	if _, found := ctx.Get(Submit); found {
 		r.State = tasking.Ready
 	}
-	m = r.Model()
+	m = r.Patch(m)
 	m.ID = id
 	m.UpdateUser = h.CurrentUser(ctx)
 	rtx := RichContext(ctx)
@@ -863,24 +863,22 @@ func (r *Task) With(m *model.Task) {
 	}
 }
 
-// Model builds a model.
-func (r *Task) Model() (m *model.Task) {
-	m = &model.Task{
-		Name:          r.Name,
-		Kind:          r.Kind,
-		Addon:         r.Addon,
-		Extensions:    r.Extensions,
-		State:         r.State,
-		Locator:       r.Locator,
-		Priority:      r.Priority,
-		Policy:        model.TaskPolicy(r.Policy),
-		TTL:           model.TTL(r.TTL),
-		ApplicationID: r.idPtr(r.Application),
-		PlatformID:    r.idPtr(r.Platform),
-	}
+// Patch the specified model.
+func (r *Task) Patch(m *model.Task) *model.Task {
 	m.ID = r.ID
+	m.Name = r.Name
+	m.Kind = r.Kind
+	m.Addon = r.Addon
+	m.Extensions = r.Extensions
+	m.State = r.State
+	m.Locator = r.Locator
+	m.Priority = r.Priority
+	m.Policy = model.TaskPolicy(r.Policy)
+	m.TTL = model.TTL(r.TTL)
 	m.Data.Any = r.Data
-	return
+	m.ApplicationID = r.idPtr(r.Application)
+	m.PlatformID = r.idPtr(r.Platform)
+	return m
 }
 
 // userPriority adjust (ensures) priority is greater than 10.

--- a/api/task.go
+++ b/api/task.go
@@ -687,6 +687,7 @@ func (h TaskHandler) UpdateReport(ctx *gin.Context) {
 	r := &TaskReport{}
 	err := h.Bind(ctx, r)
 	if err != nil {
+		_ = ctx.Error(err)
 		return
 	}
 	m := &model.TaskReport{}
@@ -698,6 +699,7 @@ func (h TaskHandler) UpdateReport(ctx *gin.Context) {
 	err = db.Save(m).Error
 	if err != nil {
 		_ = ctx.Error(err)
+		return
 	}
 
 	h.Status(ctx, http.StatusNoContent)

--- a/api/task.go
+++ b/api/task.go
@@ -865,6 +865,9 @@ func (r *Task) With(m *model.Task) {
 
 // Patch the specified model.
 func (r *Task) Patch(m *model.Task) *model.Task {
+	if m == nil {
+		m = &model.Task{}
+	}
 	m.ID = r.ID
 	m.Name = r.Name
 	m.Kind = r.Kind
@@ -952,8 +955,8 @@ func (r *TaskReport) With(m *model.TaskReport) {
 	r.TaskID = m.TaskID
 	r.Activity = m.Activity
 	r.Result = m.Result.Any
-	r.Errors = make([]TaskError, 0)
-	r.Attached = make([]Attachment, 0)
+	r.Errors = make([]TaskError, 0, len(m.Errors))
+	r.Attached = make([]Attachment, 0, len(m.Attached))
 	for _, err := range m.Errors {
 		r.Errors = append(r.Errors, TaskError(err))
 	}
@@ -964,8 +967,8 @@ func (r *TaskReport) With(m *model.TaskReport) {
 
 // Patch the specified model.
 func (r *TaskReport) Patch(m *model.TaskReport) *model.TaskReport {
-	if r.Activity == nil {
-		r.Activity = []string{}
+	if m == nil {
+		m = &model.TaskReport{}
 	}
 	m.ID = r.ID
 	m.Status = r.Status
@@ -974,6 +977,8 @@ func (r *TaskReport) Patch(m *model.TaskReport) *model.TaskReport {
 	m.Activity = r.Activity
 	m.TaskID = r.TaskID
 	m.Result.Any = r.Result
+	m.Errors = make([]model.TaskError, 0, len(r.Errors))
+	m.Attached = make([]model.Attachment, 0, len(r.Attached))
 	for _, err := range r.Errors {
 		m.Errors = append(m.Errors, model.TaskError(err))
 	}

--- a/api/taskgroup.go
+++ b/api/taskgroup.go
@@ -474,6 +474,9 @@ func (r *TaskGroup) With(m *model.TaskGroup) {
 
 // Patch the specified model.
 func (r *TaskGroup) Patch(m *model.TaskGroup) *model.TaskGroup {
+	if m == nil {
+		m = &model.TaskGroup{}
+	}
 	m.ID = r.ID
 	m.Name = r.Name
 	m.Kind = r.Kind

--- a/api/taskgroup.go
+++ b/api/taskgroup.go
@@ -489,7 +489,7 @@ func (r *TaskGroup) Model() (m *model.TaskGroup) {
 	m.ID = r.ID
 	m.Data.Any = r.Data
 	for _, task := range r.Tasks {
-		m.List = append(m.List, *task.Model())
+		m.List = append(m.List, *task.Patch(&model.Task{}))
 	}
 	if r.Bucket != nil {
 		m.BucketID = &r.Bucket.ID

--- a/api/taskgroup.go
+++ b/api/taskgroup.go
@@ -196,6 +196,8 @@ func (h TaskGroupHandler) Update(ctx *gin.Context) {
 	m = &tasking.TaskGroup{}
 	m.With(r.Model())
 	m.ID = id
+	m.CreateUser = r.CreateUser
+	m.CreateTime = r.CreateTime
 	m.UpdateUser = h.CurrentUser(ctx)
 	switch m.State {
 	case "", tasking.Created:
@@ -422,38 +424,6 @@ func (h *TaskGroupHandler) findRefs(ctx *gin.Context, r *TaskGroup) (err error) 
 			r.Data = other.Any
 		}
 	}
-	return
-}
-
-// Propagate group data into the task.
-func (h *TaskGroupHandler) Propagate(m *model.TaskGroup) (err error) {
-	for i := range m.Tasks {
-		task := &m.Tasks[i]
-		task.Kind = m.Kind
-		task.Addon = m.Addon
-		task.Extensions = m.Extensions
-		task.Priority = m.Priority
-		task.Policy = m.Policy
-		task.SetBucket(m.BucketID)
-		merged := task.Data.Merge(m.Data)
-		if !merged {
-			task.Data = m.Data
-		}
-	}
-	switch m.Mode {
-	case "", tasking.Batch:
-		for i := range m.Tasks {
-			task := &m.Tasks[i]
-			task.State = m.State
-		}
-	case tasking.Pipeline:
-		for i := range m.Tasks {
-			task := &m.Tasks[i]
-			task.State = m.State
-			break
-		}
-	}
-
 	return
 }
 

--- a/api/taskgroup.go
+++ b/api/taskgroup.go
@@ -122,7 +122,7 @@ func (h TaskGroupHandler) Create(ctx *gin.Context) {
 	db := h.DB(ctx)
 	db = db.Omit(clause.Associations)
 	m := &tasking.TaskGroup{}
-	m.With(r.Model())
+	m.With(r.Patch(&model.TaskGroup{}))
 	m.CreateUser = h.BaseHandler.CurrentUser(ctx)
 	switch r.State {
 	case "":
@@ -194,10 +194,8 @@ func (h TaskGroupHandler) Update(ctx *gin.Context) {
 		"BucketID",
 		"Bucket")
 	m = &tasking.TaskGroup{}
-	m.With(r.Model())
+	m.With(r.Patch(m.TaskGroup))
 	m.ID = id
-	m.CreateUser = r.CreateUser
-	m.CreateTime = r.CreateTime
 	m.UpdateUser = h.CurrentUser(ctx)
 	switch m.State {
 	case "", tasking.Created:
@@ -475,18 +473,16 @@ func (r *TaskGroup) With(m *model.TaskGroup) {
 	}
 }
 
-// Model builds a model.
-func (r *TaskGroup) Model() (m *model.TaskGroup) {
-	m = &model.TaskGroup{
-		Name:       r.Name,
-		Kind:       r.Kind,
-		Addon:      r.Addon,
-		Extensions: r.Extensions,
-		State:      r.State,
-		Priority:   r.Priority,
-		Policy:     model.TaskPolicy(r.Policy),
-	}
+// Patch the specified model.
+func (r *TaskGroup) Patch(m *model.TaskGroup) *model.TaskGroup {
 	m.ID = r.ID
+	m.Name = r.Name
+	m.Kind = r.Kind
+	m.Addon = r.Addon
+	m.Extensions = r.Extensions
+	m.State = r.State
+	m.Priority = r.Priority
+	m.Policy = model.TaskPolicy(r.Policy)
 	m.Data.Any = r.Data
 	for _, task := range r.Tasks {
 		m.List = append(m.List, *task.Patch(&model.Task{}))
@@ -494,5 +490,5 @@ func (r *TaskGroup) Model() (m *model.TaskGroup) {
 	if r.Bucket != nil {
 		m.BucketID = &r.Bucket.ID
 	}
-	return
+	return m
 }

--- a/api/taskgroup.go
+++ b/api/taskgroup.go
@@ -193,7 +193,6 @@ func (h TaskGroupHandler) Update(ctx *gin.Context) {
 		clause.Associations,
 		"BucketID",
 		"Bucket")
-	m = &tasking.TaskGroup{}
 	m.With(r.Patch(m.TaskGroup))
 	m.ID = id
 	m.UpdateUser = h.CurrentUser(ctx)
@@ -484,6 +483,7 @@ func (r *TaskGroup) Patch(m *model.TaskGroup) *model.TaskGroup {
 	m.Priority = r.Priority
 	m.Policy = model.TaskPolicy(r.Policy)
 	m.Data.Any = r.Data
+	m.List = make([]model.Task, 0, len(r.Tasks))
 	for _, task := range r.Tasks {
 		m.List = append(m.List, *task.Patch(&model.Task{}))
 	}

--- a/task/task.go
+++ b/task/task.go
@@ -786,7 +786,7 @@ func (g *TaskGroup) With(m *model.TaskGroup) {
 	g.TaskGroup = m
 }
 
-// Propagate group data into the task.
+// propagate group data into the task.
 func (g *TaskGroup) propagate() (err error) {
 	m := g.TaskGroup
 	m.Tasks = make([]model.Task, 0)
@@ -797,6 +797,9 @@ func (g *TaskGroup) propagate() (err error) {
 	}
 	for i := range m.Tasks {
 		task := &m.Tasks[i]
+		task.CreateUser = m.CreateUser
+		task.CreateTime = m.CreateTime
+		task.UpdateUser = m.UpdateUser
 		switch m.Mode {
 		case "", Batch:
 			task.State = m.State

--- a/task/task.go
+++ b/task/task.go
@@ -798,7 +798,6 @@ func (g *TaskGroup) propagate() (err error) {
 	for i := range m.Tasks {
 		task := &m.Tasks[i]
 		task.CreateUser = m.CreateUser
-		task.CreateTime = m.CreateTime
 		task.UpdateUser = m.UpdateUser
 		switch m.Mode {
 		case "", Batch:

--- a/trigger/application.go
+++ b/trigger/application.go
@@ -47,11 +47,9 @@ func (r *Application) Updated(m *model.Application) (err error) {
 			return iL < jL
 		})
 	taskGroup := &tasking.TaskGroup{
-		TaskGroup: &model.TaskGroup{
-			Mode: tasking.Pipeline,
-		},
+		TaskGroup: &model.TaskGroup{Mode: tasking.Pipeline},
 	}
-	taskGroup.Mode = tasking.Pipeline
+	taskGroup.CreateUser = m.CreateUser
 	for _, kind := range kinds {
 		task := model.Task{}
 		task.Kind = kind.Name

--- a/trigger/application.go
+++ b/trigger/application.go
@@ -49,7 +49,7 @@ func (r *Application) Updated(m *model.Application) (err error) {
 	taskGroup := &tasking.TaskGroup{
 		TaskGroup: &model.TaskGroup{Mode: tasking.Pipeline},
 	}
-	taskGroup.CreateUser = m.CreateUser
+	taskGroup.CreateUser = r.User
 	for _, kind := range kinds {
 		task := model.Task{}
 		task.Kind = kind.Name

--- a/trigger/identity.go
+++ b/trigger/identity.go
@@ -21,6 +21,7 @@ func (r *Identity) Created(m *model.Identity) (err error) {
 func (r *Identity) Updated(m *model.Identity) (err error) {
 	tr := Application{
 		Trigger: Trigger{
+			User:        r.User,
 			TaskManager: r.TaskManager,
 			Client:      r.Client,
 			DB:          r.DB,

--- a/trigger/pkg.go
+++ b/trigger/pkg.go
@@ -19,6 +19,7 @@ var (
 
 // Trigger supports actions triggered by model changes.
 type Trigger struct {
+	User        string
 	TaskManager *tasking.Manager
 	Client      k8sclient.Client
 	DB          *gorm.DB


### PR DESCRIPTION
Fixes createUser not populated on tasks.
- CreateUser and CreateTime missing in `TaskGroup.propagate() `
- CreateUser and CreateTime not propagated in the _triggers_.
- Updated resources _losing_ CreateUser and CreateTime. (This affects all resources).  As a result, when a Task (or TaskGroup) is created, then submitted - the CreateUser and CreateTime get cleared.

Refactored a few methods for consistent pattern with regard to err vs result returned by db methods.
```
err = db.Fetch().Error
```

closes #895 

---

A follow up issue/PR will be needed to address other resources.

Trying out a different pattern here:  
**Instead of** each resource implementing `Model()` returning a new model.
**Each resource will** implement `Patch(m *Model)` which can be passed either an existing (fetched) model (to be updated) or an empty one (to be created).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Actions that create or update applications, identities, tasks, and task groups now record the acting user; task groups record their creator.

* **Changes**
  * Child tasks inherit creator/updater metadata from their parent group.
  * Group-level automatic propagation to tasks has been removed.

* **Refactor**
  * Internal REST-to-database mapping now uses in-place patching for tasks, task reports, and task groups (no user-facing behavior changes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->