### PR TITLE
:bug: Fix ambiguous field filter/sort problem on task list

### DIFF
--- a/api/task.go
+++ b/api/task.go
@@ -175,11 +175,13 @@ func (h TaskHandler) List(ctx *gin.Context) {
 	filter = filter.Renamed("createUser", "task\\.createUser")
 	filter = filter.Renamed("id", "task\\.id")
 	filter = filter.Renamed("name", "task\\.name")
+	filter = filter.Renamed("kind", "task\\.kind")
 	// sort
 	sort := Sort{}
 	sort.Add("task.id", "id")
 	sort.Add("task.createUser", "createUser")
 	sort.Add("task.name", "name")
+	sort.Add("task.kind", "kind")
 	sort.Add("application__id", "application.id")
 	sort.Add("application__name", "application.name")
 	sort.Add("platform__id", "platform.id")


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/MTA-5739

Hub needed an extra field rename on the Task list function to disambiguate the "kind" field to come from the Task table.