### PR TITLE
:bug: Task manager advances/cancels non-pipeline group members.

### DIFF
--- a/reaper/task.go
+++ b/reaper/task.go
@@ -59,7 +59,7 @@ func (r *TaskReaper) Run() {
 		return
 	}
 	pipelineSet := task.PipelineSet{}
-	err := pipelineSet.With(r.DB)
+	err := pipelineSet.Load(r.DB)
 	if err != nil {
 		Log.Error(err, "")
 		return

--- a/task/manager.go
+++ b/task/manager.go
@@ -1216,7 +1216,7 @@ func (m *Manager) next(task *Task) (err error) {
 		return
 	}
 	pipelineSet := PipelineSet{}
-	err = pipelineSet.With(m.DB)
+	err = pipelineSet.Load(m.DB)
 	if err != nil {
 		return
 	}
@@ -1622,8 +1622,8 @@ type Preempt struct {
 // PipelineSet is a set of TaskGroup ids for ALL groups of mode=Pipeline.
 type PipelineSet map[uint]byte
 
-// With load the set.
-func (m *PipelineSet) With(db *gorm.DB) (err error) {
+// Load the set.
+func (m *PipelineSet) Load(db *gorm.DB) (err error) {
 	var list []*model.TaskGroup
 	db = db.Select("ID", "Mode")
 	err = db.Find(&list).Error


### PR DESCRIPTION
The Manager.next() needs to ONLY advance/cancel members of a mode=pipeline group.

closes #901 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced in-memory pipeline membership checks with database-backed lookups for more reliable, up-to-date task classification.
  * Removed legacy map-based pipeline detection logic to simplify processing and reduce maintenance overhead.
  * Task progression now runs only for tasks in pipeline-mode groups, skipping other modes so processing aligns with configured group behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->