### PR TITLE
:bug: Unique rule needs to match on kind. 

### DIFF
--- a/task/rule.go
+++ b/task/rule.go
@@ -23,8 +23,10 @@ type RuleUnique struct {
 // - addon
 // - subject
 func (r *RuleUnique) Match(ready, other *Task) (matched bool, reason string) {
-	if (ready.Kind != "" && other.Kind != "") &&
-		(ready.Kind != other.Kind || ready.Addon != other.Addon) {
+	if ready.Addon != other.Addon {
+		return
+	}
+	if ready.Kind != "" && other.Kind != "" && ready.Kind != other.Kind {
 		return
 	}
 	if !ready.MatchSubject(other) {


### PR DESCRIPTION
The unique rule prevents 2 of the same kinds of task from operating on the same subject concurrently.  For example, 2 analysis performed on the same application concurrently.  The 2nd is postponed.

New in 0.8, addons may be shared by multiple tasks of tasks so the _kind-of_ task needs to be part of the match.

### Intended Logic

| Addon      | Kind status                  | Result    |
|------------|------------------------------|-----------|
| same       | both unset                   | postponed |
| same       | both set & same              | postponed |
| same       | both set & different         | allowed   |
| same       | one set, one unset           | allowed   |
| different  | (any kind combination)       | allowed   |


closes #906 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unique-task matching accuracy. When both tasks specify a kind and addon, mismatches are correctly rejected; when either is unspecified, subject-based matching proceeds as expected.
  * Reduces both false matches and missed matches in edge cases.
  * Produces clearer match reasoning in logs for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->