### PR TITLE
:bug: Fix duplicate identities in application list.

### DIFF
--- a/api/application.go
+++ b/api/application.go
@@ -188,7 +188,6 @@ func (h ApplicationHandler) List(ctx *gin.Context) {
 
 	filter, err := qf.New(ctx,
 		[]qf.Assert{
-			{Field: "id", Kind: qf.LITERAL},
 			{Field: "platform.id", Kind: qf.LITERAL},
 		})
 	if err != nil {


### PR DESCRIPTION
List applications returned duplicate identities.  This caused subsequent update to fail.
Basically, the fix is to use a _map_ for identities in the List() like the other joined entities.

ref: https://issues.redhat.com/browse/MTA-6192

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * None; no user-facing features added.
* **Bug Fixes**
  * Fixed inconsistencies when displaying identities associated with an application.
* **Performance**
  * Improved load times for application details, especially for apps with many identities.
* **Refactor**
  * Major internal overhaul of identity handling to increase reliability and maintainability without changing user workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->