### PR TITLE
:ghost: Fix circular unique match.

### DIFF
--- a/task/rule.go
+++ b/task/rule.go
@@ -35,9 +35,9 @@ func (r *RuleUnique) Match(ready *Task, d *Domain) (matched bool, reason string)
 		return
 	}
 	if _, found := r.matched[other.ID]; found {
+		matched = false
 		return
 	}
-	matched = true
 	r.matched[ready.ID] = other.ID
 	reason = fmt.Sprintf(
 		"Rule:Unique matched:%d, other:%d",

--- a/task/task_test.go
+++ b/task/task_test.go
@@ -324,11 +324,12 @@ func TestRuleUnique(t *testing.T) {
 
 	domain := NewDomain(tasks)
 
-	// 0 and 1 match on kind
+	// 0 matches 1 on kind
 	matched, _ := rule.Match(tasks[0], domain)
 	g.Expect(matched).To(gomega.BeTrue())
+	g.Expect(rule.matched[tasks[0].ID]).To(gomega.Equal(tasks[1].ID))
 	matched, _ = rule.Match(tasks[1], domain)
-	g.Expect(matched).To(gomega.BeTrue())
+	g.Expect(matched).To(gomega.BeFalse())
 
 	// 2 not matched.  different kind.
 	matched, _ = rule.Match(tasks[2], domain)
@@ -344,8 +345,9 @@ func TestRuleUnique(t *testing.T) {
 	// 3 and 4 match on kind
 	matched, _ = rule.Match(tasks[3], domain)
 	g.Expect(matched).To(gomega.BeTrue())
+	g.Expect(rule.matched[tasks[3].ID]).To(gomega.Equal(tasks[4].ID))
 	matched, _ = rule.Match(tasks[4], domain)
-	g.Expect(matched).To(gomega.BeTrue())
+	g.Expect(matched).To(gomega.BeFalse())
 
 	// 4 not matched.  different kind.
 	matched, _ = rule.Match(tasks[5], domain)


### PR DESCRIPTION
Fix circular unique rule match.
A task cannot be postponed because of an already postponed task.  Neither task will ever get released.

Regression introduced by #897 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the unique rule matching algorithm to properly identify and track duplicate items during rule evaluation. The function now correctly signals match results when comparing items and maintains accurate state tracking of item associations. This ensures the unique rule check works as intended across multiple rule comparisons.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->