### PR TITLE
:ghost: Better for remote to not be pointer.

### DIFF
--- a/scm/factory.go
+++ b/scm/factory.go
@@ -15,7 +15,7 @@ import (
 )
 
 // New SCM repository factory.
-func New(db *gorm.DB, destDir string, remote *Remote) (r SCM, err error) {
+func New(db *gorm.DB, destDir string, remote Remote) (r SCM, err error) {
 	switch remote.Kind {
 	case "subversion":
 		m := model.Setting{}
@@ -28,7 +28,7 @@ func New(db *gorm.DB, destDir string, remote *Remote) (r SCM, err error) {
 			return
 		}
 		svn := &Subversion{}
-		svn.Remote = *remote
+		svn.Remote = remote
 		svn.Path = destDir
 		svn.Home = filepath.Join(Home, ".svn", svn.Id())
 		svn.Proxies, err = proxyMap(db)
@@ -47,7 +47,7 @@ func New(db *gorm.DB, destDir string, remote *Remote) (r SCM, err error) {
 			return
 		}
 		git := &Git{}
-		git.Remote = *remote
+		git.Remote = remote
 		git.Path = destDir
 		git.Home = filepath.Join(Home, ".git", git.Id())
 		git.Proxies, err = proxyMap(db)

--- a/scm/mirror.go
+++ b/scm/mirror.go
@@ -94,7 +94,7 @@ func (m *Mirror) update() (err error) {
 	if err != nil {
 		return
 	}
-	remote := &Remote{
+	remote := Remote{
 		URL:      m.Remote.URL,
 		Identity: identity,
 	}


### PR DESCRIPTION
The remote is required and modified by New().  Better (and simpler) for the remote to not be a pointer.  Fine for it to be a _shallow_ copy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal consistency in SCM module initialization logic.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->