### PR TITLE
:ghost: Fix git checkout tags.

### DIFF
--- a/scm/git.go
+++ b/scm/git.go
@@ -299,7 +299,7 @@ func (r *Git) defaultBranch() (name string, err error) {
 	return
 }
 
-// isTag returns true when a when the remote references a tag.
+// isTag returns true when a when ref is a tag.
 func (r *Git) isTag(ref string) (matched bool, err error) {
 	if ref == "" {
 		return


### PR DESCRIPTION
Fix git.Update() and git.Fetch() when Remote.Branch is a tag.  When it's a tag:
-  do a simple `git checkout`
- skip the `git pull`.

closes #968 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Git fetch now also retrieves and prunes tags for complete repository sync.
  * Pull operations detect tag targets and skip unnecessary pull steps when a tag is referenced.
  * Checkout now detects tags after fetching and checks out tag references directly, avoiding branch-based checkout flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->