### PR TITLE
:bug: Add on.workflow_call to make workflow reusable

### DIFF
--- a/.github/workflows/march-image-build-push.yml
+++ b/.github/workflows/march-image-build-push.yml
@@ -1,6 +1,7 @@
 name: 'Build and Push Multi-Arch Image'
 
 on:
+  workflow_call:
   workflow_dispatch:
   push:
     branches:


### PR DESCRIPTION
Due to [failure to build hub](https://github.com/konveyor/tackle2-seed/actions/runs/21674700072).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration to allow this workflow to be invoked by other workflows, enabling smoother multi-workflow automation and orchestration.
  * No changes to existing manual or push triggers; runtime behavior for end-users remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->