### PR TITLE
:bug: Postponed task: extensions (re)selected when released.

### DIFF
--- a/internal/task/manager.go
+++ b/internal/task/manager.go
@@ -649,6 +649,7 @@ func (m *Manager) postpone(list []*Task, inflight []*Task) (err error) {
 		reason, found := postponed[task.ID]
 		if found {
 			task.State = Postponed
+			task.Extensions = nil // TODO: see hub issue-1001.
 			task.Event(Postponed, reason)
 			Log.Info(
 				"Task postponed.",
@@ -659,7 +660,6 @@ func (m *Manager) postpone(list []*Task, inflight []*Task) (err error) {
 		}
 		_, found = released[task.ID]
 		if found {
-			task.Extensions = nil
 			task.State = Ready
 		}
 	}


### PR DESCRIPTION
closes #999 

Extensions need to be re-selected when (after) postponed task is _released_.  Released means back in the Ready state and may be scheduled.
Current:
1. Task (id=3) created and addon and extensions selected.
2. Analysis task (id=3) postponed by discovery task (id=1).  The **java** extension selected because no tags.
3. Discovery task (id=1) completed and application tagged.
4. Analysis task (id=3) released.  Started (but has stale extension selection).

Fixed:
1. Task (id=3) created and addon and extensions selected.
2. Analysis task (id=3) postponed by discovery task (id=1).  The **java** extension selected because no tags.
3. Discovery task (id=1) completed and application tagged.
4. Analysis task (id=3) released.  Extension selection cleared.
5. Analysis task (id-3) extensions (re)selected (next manager pass).

**NOTE**: This knowingly breaks user selected extensions.  Issue #1001 documents this.  This is almost certainly not a feature used in the wild.  This simpler fix is needed for 0.9 late in the development cycle.

Also, found a regression introduced during the performance/scale effort.  The Running tasks no longer fetched in startReady().  They were needed to ensure the inflight tasks were considered by the postpone rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preparation now loads and considers in‑flight (running) tasks when deciding which tasks to process, reducing conflicts.
  * Postponement now accounts for active in‑flight tasks when deferring work, improving scheduling accuracy.
  * Addon selection uses the updated context that includes in‑flight tasks for more consistent choices.
  * Clears residual task state when marking tasks Ready to avoid carrying over extensions.
  * Errors encountered while loading in‑flight tasks are now surfaced to prevent silent failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->