### PR TITLE
:ghost: Store settings as time.Duration.

### DIFF
--- a/internal/heap/pkg.go
+++ b/internal/heap/pkg.go
@@ -42,13 +42,12 @@ func Print() {
 }
 
 func Monitor() {
-	delay := time.Duration(Settings.Frequency.Heap) * time.Second
-	if delay == 0 {
+	if Settings.Frequency.Heap == 0 {
 		return // disabled
 	}
 	go func() {
 		for {
-			time.Sleep(delay)
+			time.Sleep(Settings.Frequency.Heap)
 			Free()
 		}
 	}()

--- a/internal/reaper/bucket.go
+++ b/internal/reaper/bucket.go
@@ -53,7 +53,7 @@ func (r *BucketReaper) Run() {
 		}
 		if bucket.Expiration == nil {
 			Log.Info("Bucket (orphan) found.", "id", bucket.ID, "path", bucket.Path)
-			mark := time.Now().Add(time.Minute * time.Duration(Settings.Bucket.TTL))
+			mark := time.Now().Add(Settings.Bucket.TTL)
 			bucket.Expiration = &mark
 			err = r.DB.Save(&bucket).Error
 			Log.Error(err, "")

--- a/internal/reaper/file.go
+++ b/internal/reaper/file.go
@@ -54,7 +54,7 @@ func (r *FileReaper) Run() {
 		}
 		if file.Expiration == nil {
 			Log.Info("File (orphan) found.", "id", file.ID, "path", file.Path)
-			mark := time.Now().Add(time.Minute * time.Duration(Settings.File.TTL))
+			mark := time.Now().Add(Settings.File.TTL)
 			file.Expiration = &mark
 			err = r.DB.Save(&file).Error
 			Log.Error(err, "")

--- a/internal/reaper/manager.go
+++ b/internal/reaper/manager.go
@@ -12,10 +12,6 @@ import (
 	k8s "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const (
-	Unit = time.Minute
-)
-
 var (
 	Settings = &settings.Settings
 	Log      = logr.New("reaper", Settings.Log.Reaper)
@@ -77,8 +73,7 @@ func (m *Manager) Run(ctx context.Context) {
 
 // Pause.
 func (m *Manager) pause() {
-	d := Unit * time.Duration(Settings.Frequency.Reaper)
-	time.Sleep(d)
+	time.Sleep(Settings.Frequency.Reaper)
 }
 
 // Reaper interface.

--- a/internal/reaper/task.go
+++ b/internal/reaper/task.go
@@ -74,15 +74,14 @@ func (r *TaskReaper) Run() {
 		case task.Created:
 			mark := m.CreateTime
 			if m.TTL.Created > 0 {
-				d := time.Duration(m.TTL.Created) * Unit
+				d := time.Duration(m.TTL.Created) * time.Minute
 				if time.Since(mark) > d {
 					if !pipelineSet.Contains(m) {
 						r.delete(m)
 					}
 				}
 			} else {
-				d := time.Duration(Settings.Hub.Task.Reaper.Created) * Unit
-				if time.Since(mark) > d {
+				if time.Since(mark) > Settings.Hub.Task.Reaper.Created {
 					if !pipelineSet.Contains(m) {
 						r.release(m)
 					}
@@ -93,7 +92,7 @@ func (r *TaskReaper) Run() {
 			task.QuotaBlocked:
 			mark := m.CreateTime
 			if m.TTL.Pending > 0 {
-				d := time.Duration(m.TTL.Pending) * Unit
+				d := time.Duration(m.TTL.Pending) * time.Minute
 				if time.Since(mark) > d {
 					r.delete(m)
 				}
@@ -104,7 +103,7 @@ func (r *TaskReaper) Run() {
 				mark = *m.Started
 			}
 			if m.TTL.Running > 0 {
-				d := time.Duration(m.TTL.Running) * Unit
+				d := time.Duration(m.TTL.Running) * time.Minute
 				if time.Since(mark) > d {
 					r.delete(m)
 				}
@@ -115,13 +114,12 @@ func (r *TaskReaper) Run() {
 				mark = *m.Terminated
 			}
 			if m.TTL.Succeeded > 0 {
-				d := time.Duration(m.TTL.Succeeded) * Unit
+				d := time.Duration(m.TTL.Succeeded) * time.Minute
 				if time.Since(mark) > d {
 					r.delete(m)
 				}
 			} else {
-				d := time.Duration(Settings.Hub.Task.Reaper.Succeeded) * Unit
-				if time.Since(mark) > d {
+				if time.Since(mark) > Settings.Hub.Task.Reaper.Succeeded {
 					r.release(m)
 				}
 			}
@@ -131,13 +129,12 @@ func (r *TaskReaper) Run() {
 				mark = *m.Terminated
 			}
 			if m.TTL.Failed > 0 {
-				d := time.Duration(m.TTL.Failed) * Unit
+				d := time.Duration(m.TTL.Failed) * time.Minute
 				if time.Since(mark) > d {
 					r.delete(m)
 				}
 			} else {
-				d := time.Duration(Settings.Hub.Task.Reaper.Failed) * Unit
-				if time.Since(mark) > d {
+				if time.Since(mark) > Settings.Hub.Task.Reaper.Failed {
 					r.release(m)
 				}
 			}
@@ -231,9 +228,7 @@ func (r *GroupReaper) Run() {
 		switch m.State {
 		case task.Created:
 			mark := m.CreateTime
-			d := time.Duration(
-				Settings.Hub.Task.Reaper.Created) * Unit
-			if time.Since(mark) > d {
+			if time.Since(mark) > Settings.Hub.Task.Reaper.Created {
 				r.delete(m)
 			}
 		case task.Ready:

--- a/internal/task/capacity.go
+++ b/internal/task/capacity.go
@@ -33,7 +33,6 @@ func (m *CapacityMonitor) Reset() {
 
 // Run the monitor.
 func (m *CapacityMonitor) Run(ctx context.Context, cluster *Cluster) {
-	pause := Unit * time.Duration(Settings.Frequency.Task)
 	m.Reset()
 	Log.Info("CapacityMonitor started.")
 	go func() {
@@ -46,7 +45,7 @@ func (m *CapacityMonitor) Run(ctx context.Context, cluster *Cluster) {
 				err := cluster.Refresh()
 				Log.Error(err, "")
 				m.Adjust(cluster)
-				time.Sleep(pause)
+				time.Sleep(Settings.Frequency.Task)
 			}
 		}
 	}()

--- a/internal/task/manager.go
+++ b/internal/task/manager.go
@@ -82,10 +82,6 @@ const (
 )
 
 const (
-	Unit = time.Second
-)
-
-const (
 	Addon  = "addon"
 	Shared = "shared"
 	Cache  = "cache"
@@ -337,8 +333,7 @@ func (m *Manager) Cancel(db *gorm.DB, id uint) (err error) {
 
 // Pause.
 func (m *Manager) pause() {
-	d := Unit * time.Duration(Settings.Frequency.Task)
-	time.Sleep(d)
+	time.Sleep(Settings.Frequency.Task)
 }
 
 // action enqueues an asynchronous action.

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -802,17 +802,16 @@ func (r *Task) podRetentionExpired() (expired bool) {
 	if r.Terminated != nil {
 		mark = *r.Terminated
 	}
-	d := time.Duration(period) * time.Second
-	expired = time.Since(mark) > d
+	expired = time.Since(mark) > period
 	return
 }
 
-// retention returns the retention period (seconds).
-func (r *Task) podRetention() (seconds int) {
+// retention returns the retention period.
+func (r *Task) podRetention() (period time.Duration) {
 	if r.State == Succeeded {
-		seconds = Settings.Hub.Task.Pod.Retention.Succeeded
+		period = Settings.Hub.Task.Pod.Retention.Succeeded
 	} else {
-		seconds = Settings.Hub.Task.Pod.Retention.Failed
+		period = Settings.Hub.Task.Pod.Retention.Failed
 	}
 	return
 }

--- a/shared/settings/hub.go
+++ b/shared/settings/hub.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/user"
 	"strconv"
+	"time"
 )
 
 const (
@@ -63,11 +64,11 @@ type Hub struct {
 	// Bucket settings.
 	Bucket struct {
 		Path string
-		TTL  int
+		TTL  time.Duration
 	}
 	// File settings.
 	File struct {
-		TTL int
+		TTL time.Duration
 	}
 	// Cache settings.
 	Cache struct {
@@ -82,25 +83,25 @@ type Hub struct {
 	Task struct {
 		SA      string
 		Retries int
-		Reaper  struct { // minutes.
-			Created   int
-			Succeeded int
-			Failed    int
+		Reaper  struct {
+			Created   time.Duration
+			Succeeded time.Duration
+			Failed    time.Duration
 		}
 		Pod struct {
 			Quota     int
 			Retention struct {
-				Succeeded int
-				Failed    int
+				Succeeded time.Duration
+				Failed    time.Duration
 			}
 		}
 		UID int64
 	}
 	// Frequency
 	Frequency struct {
-		Task   int
-		Reaper int
-		Heap   int
+		Task   time.Duration
+		Reaper time.Duration
+		Heap   time.Duration
 	}
 	// Development environment
 	Development bool
@@ -177,23 +178,23 @@ func (r *Hub) Load() (err error) {
 	s, found = os.LookupEnv(EnvTaskReapCreated)
 	if found {
 		n, _ := strconv.Atoi(s)
-		r.Task.Reaper.Created = n
+		r.Task.Reaper.Created = time.Duration(n) * time.Minute
 	} else {
-		r.Task.Reaper.Created = 4320 // 72 hours.
+		r.Task.Reaper.Created = 4320 * time.Minute // 72 hours.
 	}
 	s, found = os.LookupEnv(EnvTaskReapSucceeded)
 	if found {
 		n, _ := strconv.Atoi(s)
-		r.Task.Reaper.Succeeded = n
+		r.Task.Reaper.Succeeded = time.Duration(n) * time.Minute
 	} else {
-		r.Task.Reaper.Succeeded = 4320 // 72 hours.
+		r.Task.Reaper.Succeeded = 4320 * time.Minute // 72 hours.
 	}
 	s, found = os.LookupEnv(EnvTaskReapFailed)
 	if found {
 		n, _ := strconv.Atoi(s)
-		r.Task.Reaper.Failed = n
+		r.Task.Reaper.Failed = time.Duration(n) * time.Minute
 	} else {
-		r.Task.Reaper.Failed = 43200 // 720 hours (30 days).
+		r.Task.Reaper.Failed = 43200 * time.Minute // 720 hours (30 days).
 	}
 	s, found = os.LookupEnv(EnvTaskPodQuota)
 	if found {
@@ -205,16 +206,16 @@ func (r *Hub) Load() (err error) {
 	s, found = os.LookupEnv(EnvTaskPodRetainSucceeded)
 	if found {
 		n, _ := strconv.Atoi(s)
-		r.Task.Pod.Retention.Succeeded = n
+		r.Task.Pod.Retention.Succeeded = time.Duration(n) * time.Minute
 	} else {
-		r.Task.Pod.Retention.Succeeded = 1
+		r.Task.Pod.Retention.Succeeded = 1 * time.Minute
 	}
 	s, found = os.LookupEnv(EnvTaskPodRetainFailed)
 	if found {
 		n, _ := strconv.Atoi(s)
-		r.Task.Pod.Retention.Failed = n
+		r.Task.Pod.Retention.Failed = time.Duration(n) * time.Minute
 	} else {
-		r.Task.Pod.Retention.Failed = 4320 // 72 hours.
+		r.Task.Pod.Retention.Failed = 4320 * time.Minute // 72 hours.
 	}
 	r.Task.SA, found = os.LookupEnv(EnvTaskSA)
 	if !found {
@@ -230,23 +231,23 @@ func (r *Hub) Load() (err error) {
 	s, found = os.LookupEnv(EnvFrequencyTask)
 	if found {
 		n, _ := strconv.Atoi(s)
-		r.Frequency.Task = n
+		r.Frequency.Task = time.Duration(n) * time.Second
 	} else {
-		r.Frequency.Task = 1 // 1 second.
+		r.Frequency.Task = 1 * time.Second
 	}
 	s, found = os.LookupEnv(EnvFrequencyReaper)
 	if found {
 		n, _ := strconv.Atoi(s)
-		r.Frequency.Reaper = n
+		r.Frequency.Reaper = time.Duration(n) * time.Minute
 	} else {
-		r.Frequency.Reaper = 1 // 1 minute.
+		r.Frequency.Reaper = 1 * time.Minute
 	}
 	s, found = os.LookupEnv(EnvFrequencyHeap)
 	if found {
 		n, _ := strconv.Atoi(s)
-		r.Frequency.Heap = n // seconds.
+		r.Frequency.Heap = time.Duration(n) * time.Second
 	} else {
-		r.Frequency.Heap = 240 // 4 minutes.
+		r.Frequency.Heap = 240 * time.Second // 4 minutes.
 	}
 	s, found = os.LookupEnv(EnvTaskUid)
 	if found {
@@ -282,16 +283,16 @@ func (r *Hub) Load() (err error) {
 	s, found = os.LookupEnv(EnvBucketTTL)
 	if found {
 		n, _ := strconv.Atoi(s)
-		r.Bucket.TTL = n
+		r.Bucket.TTL = time.Duration(n) * time.Minute
 	} else {
-		r.Bucket.TTL = 1 // minutes.
+		r.Bucket.TTL = 1 * time.Minute
 	}
 	s, found = os.LookupEnv(EnvFileTTL)
 	if found {
 		n, _ := strconv.Atoi(s)
-		r.File.TTL = n
+		r.File.TTL = time.Duration(n) * time.Minute
 	} else {
-		r.File.TTL = 720 // minutes: 12 hours.
+		r.File.TTL = 720 * time.Minute // 12 hours.
 	}
 	s, found = os.LookupEnv(EnvAppName)
 	if found {


### PR DESCRIPTION
Store settings that are durations are time.Duration.  More explicit and less brittle. This protects against mismatch between the environment variables and the units.

This will be useful for tests to run faster and with fine grained timing.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated configuration settings for bucket, file, task, and frequency intervals to use standardized time duration formats, improving consistency in how timing parameters are specified and interpreted across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->