### PR TITLE
:sparkles: More efficient tag and category binding.Ensure().

### DIFF
--- a/shared/binding/tag.go
+++ b/shared/binding/tag.go
@@ -69,15 +69,18 @@ func (h Tag) Find(name string, category uint) (r *api.Tag, found bool, err error
 
 // Ensure a tag exists.
 func (h Tag) Ensure(wanted *api.Tag) (err error) {
-	r, found, err := h.Find(wanted.Name, wanted.Category.ID)
-	if found && err == nil {
-		*wanted = *r
-		return
-	}
-	err = h.Create(wanted)
-	if err != nil {
-		if errors.Is(err, &client.Conflict{}) {
-			err = nil
+	var r *api.Tag
+	found := false
+	for i := 0; i < 3; i++ {
+		r, found, err = h.Find(wanted.Name, wanted.Category.ID)
+		if found && err == nil {
+			*wanted = *r
+			return
+		}
+		err = h.Create(wanted)
+		if err == nil ||
+			!errors.Is(err, &client.Conflict{}) {
+			return
 		}
 	}
 	return

--- a/shared/binding/tagcategory/pkg.go
+++ b/shared/binding/tagcategory/pkg.go
@@ -73,15 +73,18 @@ func (h TagCategory) Find(name string) (r *api.TagCategory, found bool, err erro
 
 // Ensure a tag-type exists.
 func (h TagCategory) Ensure(wanted *api.TagCategory) (err error) {
-	r, found, err := h.Find(wanted.Name)
-	if found && err == nil {
-		*wanted = *r
-		return
-	}
-	err = h.Create(wanted)
-	if err != nil {
-		if errors.Is(err, &client.Conflict{}) {
-			err = nil
+	var r *api.TagCategory
+	found := false
+	for i := 0; i < 3; i++ {
+		r, found, err = h.Find(wanted.Name)
+		if found && err == nil {
+			*wanted = *r
+			return
+		}
+		err = h.Create(wanted)
+		if err == nil ||
+			!errors.Is(err, &client.Conflict{}) {
+			return
 		}
 	}
 	return


### PR DESCRIPTION
closes #1011

The original design for the Ensure() was intended to be resilient against race conditions whereby multiple clients attempted to create the same tag/category. This is a simpler, quieter, more efficient version.  There is no need to try to create the resource more than once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined tag and tag-category management to simplify control flow, reduce repeated retries, and improve reliability and predictability of create/find operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->