### PR TITLE
:bug: Fix rendered task priority

### DIFF
--- a/internal/api/resource/pkg_test.go
+++ b/internal/api/resource/pkg_test.go
@@ -3286,7 +3286,7 @@ func TestTask_With_and_Patch_and_userPriority(t *testing.T) {
 	g.Expect(r.Name).To(gomega.Equal("t"))
 	g.Expect(r.Kind).To(gomega.Equal("k"))
 	g.Expect(r.Addon).To(gomega.Equal("a"))
-	g.Expect(r.Priority).To(gomega.Equal(15)) // elevated
+	g.Expect(r.Priority).To(gomega.Equal(5))
 
 	// Patch back
 	m2 := &model.Task{}
@@ -3294,7 +3294,7 @@ func TestTask_With_and_Patch_and_userPriority(t *testing.T) {
 	g.Expect(m2.Name).To(gomega.Equal("t"))
 	g.Expect(m2.Kind).To(gomega.Equal("k"))
 	g.Expect(m2.Addon).To(gomega.Equal("a"))
-	g.Expect(m2.Priority).To(gomega.Equal(15))
+	g.Expect(m2.Priority).To(gomega.Equal(5))
 }
 
 // FactKey: Qualify/Source/Name semantics.

--- a/internal/api/resource/task.go
+++ b/internal/api/resource/task.go
@@ -39,7 +39,7 @@ func (r *Task) With(m *model.Task) {
 	r.Extensions = m.Extensions
 	r.State = m.State
 	r.Locator = m.Locator
-	r.Priority = r.userPriority(m.Priority)
+	r.Priority = m.Priority
 	r.Policy = TaskPolicy(m.Policy)
 	r.TTL = TTL(m.TTL)
 	r.Data = m.Data.Any
@@ -130,16 +130,6 @@ func (r *Task) InjectFiles(db *gorm.DB) (err error) {
 		r.Activity = append(
 			append(snipA, content...),
 			snipB...)
-	}
-	return
-}
-
-// userPriority adjust (ensures) priority is greater than 10.
-// Priority: 0-9 reserved for system tasks.
-func (r *Task) userPriority(in int) (out int) {
-	out = in
-	if out < 10 {
-		out += 10
 	}
 	return
 }

--- a/internal/api/task.go
+++ b/internal/api/task.go
@@ -376,7 +376,7 @@ func (h TaskHandler) Create(ctx *gin.Context) {
 		_ = ctx.Error(err)
 		return
 	}
-	r.Priority = min(r.Priority, 10)
+	r.Priority = max(r.Priority, 10)
 	rtx := RichContext(ctx)
 	m := &model.Task{}
 	r.Patch(m)
@@ -441,7 +441,7 @@ func (h TaskHandler) Update(ctx *gin.Context) {
 		_ = ctx.Error(err)
 		return
 	}
-	r.Priority = min(r.Priority, 10)
+	r.Priority = max(r.Priority, 10)
 	if _, found := ctx.Get(Submit); found {
 		r.State = task.Ready
 	}

--- a/internal/api/task.go
+++ b/internal/api/task.go
@@ -419,7 +419,8 @@ func (h TaskHandler) Delete(ctx *gin.Context) {
 // @description to ensure the priority higher than system reserved (0-9).
 // @tags tasks
 // @accept json
-// @success 200
+// @produce json
+// @success 200 {object} api.Task
 // @router /tasks/{id} [put]
 // @param id path int true "Task ID"
 // @param task body Task true "Task data"
@@ -455,10 +456,12 @@ func (h TaskHandler) Update(ctx *gin.Context) {
 		_ = ctx.Error(err)
 		return
 	}
-
-	r.With(m)
-
-	h.Respond(ctx, http.StatusOK, r)
+	if _, found := ctx.Get(Submit); !found {
+		r.With(m)
+		h.Respond(ctx, http.StatusOK, r)
+	} else {
+		h.Status(ctx, http.StatusNoContent)
+	}
 }
 
 // Submit godoc
@@ -466,7 +469,7 @@ func (h TaskHandler) Update(ctx *gin.Context) {
 // @description Patch and submit a task.
 // @tags tasks
 // @accept json
-// @success 200
+// @success 204
 // @router /tasks/{id}/submit [put]
 // @param id path int true "Task ID"
 // @param task body Task false "Task data (optional)"

--- a/internal/api/task.go
+++ b/internal/api/task.go
@@ -361,6 +361,8 @@ func (h TaskHandler) Dashboard(ctx *gin.Context) {
 // Create godoc
 // @summary Create a task.
 // @description Create a task.
+// @description Note: The priority will be adjusted as needed
+// @description to ensure the priority higher than system reserved (0-9).
 // @tags tasks
 // @accept json
 // @produce json
@@ -374,6 +376,7 @@ func (h TaskHandler) Create(ctx *gin.Context) {
 		_ = ctx.Error(err)
 		return
 	}
+	r.Priority = min(r.Priority, 10)
 	rtx := RichContext(ctx)
 	m := &model.Task{}
 	r.Patch(m)
@@ -412,6 +415,8 @@ func (h TaskHandler) Delete(ctx *gin.Context) {
 // Update godoc
 // @summary Update a task.
 // @description Update a task.
+// @description Note: The priority will be adjusted as needed
+// @description to ensure the priority higher than system reserved (0-9).
 // @tags tasks
 // @accept json
 // @success 200
@@ -436,6 +441,7 @@ func (h TaskHandler) Update(ctx *gin.Context) {
 		_ = ctx.Error(err)
 		return
 	}
+	r.Priority = min(r.Priority, 10)
 	if _, found := ctx.Get(Submit); found {
 		r.State = task.Ready
 	}

--- a/internal/api/taskgroup.go
+++ b/internal/api/taskgroup.go
@@ -108,7 +108,7 @@ func (h TaskGroupHandler) Create(ctx *gin.Context) {
 		_ = ctx.Error(err)
 		return
 	}
-	r.Priority = min(r.Priority, 10)
+	r.Priority = max(r.Priority, 10)
 	err = h.findRefs(ctx, r)
 	if err != nil {
 		_ = ctx.Error(err)
@@ -178,7 +178,7 @@ func (h TaskGroupHandler) Update(ctx *gin.Context) {
 	if err != nil {
 		return
 	}
-	r.Priority = min(r.Priority, 10)
+	r.Priority = max(r.Priority, 10)
 	if _, found := ctx.Get(Submit); found {
 		r.State = task.Ready
 	}

--- a/internal/api/taskgroup.go
+++ b/internal/api/taskgroup.go
@@ -108,12 +108,12 @@ func (h TaskGroupHandler) Create(ctx *gin.Context) {
 		_ = ctx.Error(err)
 		return
 	}
-	r.Priority = max(r.Priority, 10)
 	err = h.findRefs(ctx, r)
 	if err != nil {
 		_ = ctx.Error(err)
 		return
 	}
+	r.Priority = max(r.Priority, 10)
 	rtx := RichContext(ctx)
 	m := &model.TaskGroup{}
 	r.Patch(m)
@@ -179,7 +179,6 @@ func (h TaskGroupHandler) Update(ctx *gin.Context) {
 	if err != nil {
 		return
 	}
-	r.Priority = max(r.Priority, 10)
 	if _, found := ctx.Get(Submit); found {
 		r.State = task.Ready
 	}
@@ -188,6 +187,7 @@ func (h TaskGroupHandler) Update(ctx *gin.Context) {
 		_ = ctx.Error(err)
 		return
 	}
+	r.Priority = max(r.Priority, 10)
 	r.Patch(m)
 	m.ID = id
 	m.UpdateUser = h.CurrentUser(ctx)

--- a/internal/api/taskgroup.go
+++ b/internal/api/taskgroup.go
@@ -93,6 +93,8 @@ func (h TaskGroupHandler) List(ctx *gin.Context) {
 // Create godoc
 // @summary Create a task group.
 // @description Create a task group.
+// @description Note: The priority will be adjusted as needed
+// @description to ensure the priority higher than system reserved (0-9).
 // @tags taskgroups
 // @accept json
 // @produce json
@@ -106,6 +108,7 @@ func (h TaskGroupHandler) Create(ctx *gin.Context) {
 		_ = ctx.Error(err)
 		return
 	}
+	r.Priority = min(r.Priority, 10)
 	err = h.findRefs(ctx, r)
 	if err != nil {
 		_ = ctx.Error(err)
@@ -150,6 +153,8 @@ func (h TaskGroupHandler) Create(ctx *gin.Context) {
 // Update godoc
 // @summary Update a task group.
 // @description Update a task group.
+// @description Note: The priority will be adjusted as needed
+// @description to ensure the priority higher than system reserved (0-9).
 // @tags taskgroups
 // @accept json
 // @success 204
@@ -173,6 +178,7 @@ func (h TaskGroupHandler) Update(ctx *gin.Context) {
 	if err != nil {
 		return
 	}
+	r.Priority = min(r.Priority, 10)
 	if _, found := ctx.Get(Submit); found {
 		r.State = task.Ready
 	}

--- a/internal/api/taskgroup.go
+++ b/internal/api/taskgroup.go
@@ -157,9 +157,10 @@ func (h TaskGroupHandler) Create(ctx *gin.Context) {
 // @description to ensure the priority higher than system reserved (0-9).
 // @tags taskgroups
 // @accept json
-// @success 204
+// @produce json
+// @success 200 {object} api.TaskGroup
 // @router /taskgroups/{id} [put]
-// @param id path int true "Task ID"
+// @param id path int true "TaskGroup ID"
 // @param task body TaskGroup true "Task data"
 func (h TaskGroupHandler) Update(ctx *gin.Context) {
 	id := h.pk(ctx)
@@ -217,8 +218,27 @@ func (h TaskGroupHandler) Update(ctx *gin.Context) {
 			})
 		return
 	}
+	if _, found := ctx.Get(Submit); !found {
+		r.With(m)
+		h.Respond(ctx, http.StatusOK, r)
+	} else {
+		h.Status(ctx, http.StatusNoContent)
+	}
+}
 
-	h.Status(ctx, http.StatusNoContent)
+// Submit godoc
+// @summary Submit a task group.
+// @description Patch and submit a task group.
+// @tags taskgroups
+// @accept json
+// @success 204
+// @router /taskgroups/{id}/submit [put]
+// @param id path int true "TaskGroup ID"
+// @param taskgroup body TaskGroup false "TaskGroup data (optional)"
+func (h TaskGroupHandler) Submit(ctx *gin.Context) {
+	ctx.Set(Submit, true)
+	ctx.Request.Method = http.MethodPatch
+	h.Update(ctx)
 }
 
 // Delete godoc
@@ -254,21 +274,6 @@ func (h TaskGroupHandler) Delete(ctx *gin.Context) {
 	}
 
 	h.Status(ctx, http.StatusNoContent)
-}
-
-// Submit godoc
-// @summary Submit a task group.
-// @description Patch and submit a task group.
-// @tags taskgroups
-// @accept json
-// @success 204
-// @router /taskgroups/{id}/submit [put]
-// @param id path int true "TaskGroup ID"
-// @param taskgroup body TaskGroup false "TaskGroup data (optional)"
-func (h TaskGroupHandler) Submit(ctx *gin.Context) {
-	ctx.Set(Submit, true)
-	ctx.Request.Method = http.MethodPatch
-	h.Update(ctx)
 }
 
 // BucketGet godoc

--- a/test/binding/task_test.go
+++ b/test/binding/task_test.go
@@ -77,6 +77,8 @@ func TestTaskWithApplication(t *testing.T) {
 	err = client.Task.Create(task)
 	g.Expect(err).To(BeNil())
 	g.Expect(task.ID).NotTo(BeZero())
+	// Verify priority was adjusted (user priority must be >= 10)
+	g.Expect(task.Priority).To(Equal(10))
 
 	t.Cleanup(func() {
 		ctx, cfn := context.WithTimeout(
@@ -409,6 +411,75 @@ func TestTaskBucket(t *testing.T) {
 	// Verify deletion
 	err = bucket.Get("test-file.txt", tmpDest)
 	g.Expect(errors.Is(err, &api.NotFound{})).To(BeTrue())
+}
+
+// TestTaskPriorityAdjustment tests that task priority is adjusted to be >= 10
+func TestTaskPriorityAdjustment(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	// CREATE: Create a task with priority < 10
+	taskLow := &api.Task{
+		Name:     "Test Task Low Priority",
+		Addon:    "analyzer",
+		State:    tasking.Created,
+		Priority: 3,
+	}
+	err := client.Task.Create(taskLow)
+	g.Expect(err).To(BeNil())
+	g.Expect(taskLow.ID).NotTo(BeZero())
+	// Verify priority was adjusted to 10
+	g.Expect(taskLow.Priority).To(Equal(10))
+
+	t.Cleanup(func() {
+		ctx, cfn := context.WithTimeout(
+			context.Background(),
+			time.Minute)
+		defer cfn()
+		_ = client.Task.Select(taskLow.ID).Blocking.Delete(ctx)
+	})
+
+	// GET: Retrieve and verify adjusted priority persisted
+	retrieved, err := client.Task.Get(taskLow.ID)
+	g.Expect(err).To(BeNil())
+	g.Expect(retrieved.Priority).To(Equal(10))
+
+	// CREATE: Create a task with priority >= 10
+	taskHigh := &api.Task{
+		Name:     "Test Task High Priority",
+		Addon:    "analyzer",
+		State:    tasking.Created,
+		Priority: 15,
+	}
+	err = client.Task.Create(taskHigh)
+	g.Expect(err).To(BeNil())
+	g.Expect(taskHigh.ID).NotTo(BeZero())
+	// Verify priority was NOT adjusted (stays 15)
+	g.Expect(taskHigh.Priority).To(Equal(15))
+
+	t.Cleanup(func() {
+		ctx, cfn := context.WithTimeout(
+			context.Background(),
+			time.Minute)
+		defer cfn()
+		_ = client.Task.Select(taskHigh.ID).Blocking.Delete(ctx)
+	})
+
+	// GET: Retrieve and verify priority stayed at 15
+	retrieved, err = client.Task.Get(taskHigh.ID)
+	g.Expect(err).To(BeNil())
+	g.Expect(retrieved.Priority).To(Equal(15))
+
+	// UPDATE: Update task with priority < 10
+	taskLow.Priority = 5
+	err = client.Task.Update(taskLow)
+	g.Expect(err).To(BeNil())
+	// Verify priority was adjusted to 10
+	g.Expect(taskLow.Priority).To(Equal(10))
+
+	// GET: Retrieve and verify adjusted priority after update
+	updated, err := client.Task.Get(taskLow.ID)
+	g.Expect(err).To(BeNil())
+	g.Expect(updated.Priority).To(Equal(10))
 }
 
 // TestTaskGetAttached tests retrieving a task with attached resources

--- a/test/binding/task_test.go
+++ b/test/binding/task_test.go
@@ -482,6 +482,42 @@ func TestTaskPriorityAdjustment(t *testing.T) {
 	g.Expect(updated.Priority).To(Equal(10))
 }
 
+// TestTaskSubmit tests submitting a task
+func TestTaskSubmit(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	// CREATE: Create a task
+	task := &api.Task{
+		Name:  "Test Task for Submit",
+		Addon: "analyzer",
+		State: tasking.Created,
+		Data: api.Map{
+			"mode": api.Map{
+				"binary": true,
+			},
+		},
+	}
+	err := client.Task.Create(task)
+	g.Expect(err).To(BeNil())
+	g.Expect(task.ID).NotTo(BeZero())
+	t.Cleanup(func() {
+		ctx, cfn := context.WithTimeout(
+			context.Background(),
+			time.Minute)
+		defer cfn()
+		_ = client.Task.Select(task.ID).Blocking.Delete(ctx)
+	})
+
+	// SUBMIT: Submit the task
+	err = client.Task.Submit(task.ID)
+	g.Expect(err).To(BeNil())
+
+	// GET: Retrieve and verify state changed
+	submitted, err := client.Task.Get(task.ID)
+	g.Expect(err).To(BeNil())
+	g.Expect(submitted.State).NotTo(Equal(tasking.Created))
+}
+
 // TestTaskGetAttached tests retrieving a task with attached resources
 func TestTaskGetAttached(t *testing.T) {
 	g := NewGomegaWithT(t)

--- a/test/binding/taskgroup_test.go
+++ b/test/binding/taskgroup_test.go
@@ -24,13 +24,16 @@ func TestTaskGroup(t *testing.T) {
 			},
 			"output": "/output/report",
 		},
-		State: tasking.Created,
+		State:    tasking.Created,
+		Priority: 7,
 	}
 
 	// CREATE: Create the task group
 	err := client.TaskGroup.Create(taskGroup)
 	g.Expect(err).To(BeNil())
 	g.Expect(taskGroup.ID).NotTo(BeZero())
+	// Verify priority was adjusted (user priority must be >= 10)
+	g.Expect(taskGroup.Priority).To(Equal(10))
 
 	t.Cleanup(func() {
 		_ = client.TaskGroup.Delete(taskGroup.ID)
@@ -158,6 +161,75 @@ func TestTaskGroupSubmit(t *testing.T) {
 	submitted, err := client.TaskGroup.Get(taskGroup.ID)
 	g.Expect(err).To(BeNil())
 	g.Expect(submitted.State).NotTo(Equal(tasking.Created))
+}
+
+// TestTaskGroupPriorityAdjustment tests that task group priority is adjusted to be >= 10
+func TestTaskGroupPriorityAdjustment(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	// CREATE: Create a task group with priority < 10
+	taskGroupLow := &api.TaskGroup{
+		Name:     "Test Task Group Low Priority",
+		State:    tasking.Created,
+		Priority: 2,
+		Data: api.Map{
+			"mode": api.Map{
+				"binary": true,
+			},
+		},
+	}
+	err := client.TaskGroup.Create(taskGroupLow)
+	g.Expect(err).To(BeNil())
+	g.Expect(taskGroupLow.ID).NotTo(BeZero())
+	// Verify priority was adjusted to 10
+	g.Expect(taskGroupLow.Priority).To(Equal(10))
+
+	t.Cleanup(func() {
+		_ = client.TaskGroup.Delete(taskGroupLow.ID)
+	})
+
+	// GET: Retrieve and verify adjusted priority persisted
+	retrieved, err := client.TaskGroup.Get(taskGroupLow.ID)
+	g.Expect(err).To(BeNil())
+	g.Expect(retrieved.Priority).To(Equal(10))
+
+	// CREATE: Create a task group with priority >= 10
+	taskGroupHigh := &api.TaskGroup{
+		Name:     "Test Task Group High Priority",
+		State:    tasking.Created,
+		Priority: 20,
+		Data: api.Map{
+			"mode": api.Map{
+				"binary": false,
+			},
+		},
+	}
+	err = client.TaskGroup.Create(taskGroupHigh)
+	g.Expect(err).To(BeNil())
+	g.Expect(taskGroupHigh.ID).NotTo(BeZero())
+	// Verify priority was NOT adjusted (stays 20)
+	g.Expect(taskGroupHigh.Priority).To(Equal(20))
+
+	t.Cleanup(func() {
+		_ = client.TaskGroup.Delete(taskGroupHigh.ID)
+	})
+
+	// GET: Retrieve and verify priority stayed at 20
+	retrieved, err = client.TaskGroup.Get(taskGroupHigh.ID)
+	g.Expect(err).To(BeNil())
+	g.Expect(retrieved.Priority).To(Equal(20))
+
+	// UPDATE: Update task group with priority < 10
+	taskGroupLow.Priority = 8
+	err = client.TaskGroup.Update(taskGroupLow)
+	g.Expect(err).To(BeNil())
+	// Verify priority was adjusted to 10
+	g.Expect(taskGroupLow.Priority).To(Equal(10))
+
+	// GET: Retrieve and verify adjusted priority after update
+	updated, err := client.TaskGroup.Get(taskGroupLow.ID)
+	g.Expect(err).To(BeNil())
+	g.Expect(updated.Priority).To(Equal(10))
 }
 
 // TestTaskGroupBucket tests task group bucket file operations


### PR DESCRIPTION
closes #1030 
closes #https://github.com/konveyor/tackle2-ui/issues/3110

Ref: https://github.com/konveyor/tackle2-hub/blob/main/internal/task/README.md#priority

This is an integration introduced by AI when used to refactor the API REST resources to create `shared/api`.

Incidental:
- Added missing binding test for Task.Submit()
- Updated PUT /taskgroups to return 200 and the resource instead of (204).
- Ensure PUT /tasks/submit to return 204 (no content).
- Ensure PUT /taskgroups/submit to return 204 (no content).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->+
## Summary by CodeRabbit

* **Bug Fixes**
  * Task and task group priorities are now clamped to a minimum of 10 on create/update; submit flows return 204 No Content and omit response bodies when used.

* **Documentation**
  * API docs updated to clarify priority normalization and submit response behavior.

* **Tests**
  * Added and updated tests to cover priority normalization and submit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->