### PR TITLE
:sparkles: Support self-signed certificates. (#1014)

### DIFF
--- a/shared/binding/client/http.go
+++ b/shared/binding/client/http.go
@@ -31,7 +31,7 @@ var (
 // Client provides a REST client.
 type Client struct {
 	// transport
-	transport http.RoundTripper
+	transport *http.Transport
 	// baseURL for the nub.
 	BaseURL string
 	// login API resource.
@@ -55,6 +55,17 @@ func (r *Client) Use(login api.Login) {
 // SetRetry set the number of retries.
 func (r *Client) SetRetry(n uint8) {
 	r.Retry = n
+}
+
+// SetTransport set the transport.
+func (r *Client) SetTransport(tp *http.Transport) {
+	r.transport = tp.Clone()
+}
+
+// Transport returns the http transport.
+func (r *Client) Transport() (tp *http.Transport) {
+	tp = r.transport
+	return
 }
 
 // Get a resource.
@@ -715,10 +726,7 @@ func (r *Client) send(rb func() (*http.Request, error)) (response *http.Response
 		err = r.Error
 		return
 	}
-	err = r.buildTransport()
-	if err != nil {
-		return
-	}
+	r.ensureTransport()
 	for i := uint8(0); ; i++ {
 		request, err = rb()
 		if err != nil {
@@ -775,8 +783,8 @@ func (r *Client) send(rb func() (*http.Request, error)) (response *http.Response
 	return
 }
 
-// buildTransport builds transport.
-func (r *Client) buildTransport() (err error) {
+// ensureTransport ensures a transport is set.
+func (r *Client) ensureTransport() {
 	if r.transport != nil {
 		return
 	}
@@ -791,7 +799,6 @@ func (r *Client) buildTransport() (err error) {
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 	}
-	return
 }
 
 // Join the URL.

--- a/shared/binding/client/pkg.go
+++ b/shared/binding/client/pkg.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -19,6 +20,7 @@ func New(baseURL string) (client *Client) {
 	client = &Client{
 		BaseURL: baseURL,
 	}
+	client.ensureTransport()
 	client.Retry = RetryLimit
 	return
 }
@@ -73,6 +75,10 @@ type RestClient interface {
 	Use(login api.Login)
 	// SetRetry set the number of retries.
 	SetRetry(n uint8)
+	// SetTransport set the transport.
+	SetTransport(tp *http.Transport)
+	// Transport returns the client transport.
+	Transport() *http.Transport
 
 	// Get retrieves a resource from the specified path.
 	// The response is unmarshaled into the provided object.

--- a/shared/binding/client/stub.go
+++ b/shared/binding/client/stub.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/konveyor/tackle2-hub/shared/api"
 )
@@ -41,6 +42,15 @@ func (s *Stub) Use(login api.Login) {
 
 // SetRetry set the number of retries.
 func (s *Stub) SetRetry(n uint8) {
+}
+
+// SetTransport set the transport.
+func (s *Stub) SetTransport(tp *http.Transport) {
+}
+
+// Transport returns the http transport.
+func (s *Stub) Transport() (tp *http.Transport) {
+	return
 }
 
 // Get retrieves a resource from the specified path.

--- a/test/binding/client.go
+++ b/test/binding/client.go
@@ -1,6 +1,7 @@
 package binding
 
 import (
+	"crypto/tls"
 	"os"
 
 	"github.com/konveyor/tackle2-hub/shared/binding"
@@ -20,6 +21,9 @@ var (
 func init() {
 	client = binding.New(Settings.Addon.Hub.URL)
 	client.Client.SetRetry(uint8(1))
+	client.Client.Transport().TLSClientConfig = &tls.Config{
+		InsecureSkipVerify: true,
+	}
 	user := os.Getenv(User)
 	password := os.Getenv(Password)
 	if user == "" || password == "" {


### PR DESCRIPTION
Cherry-picks #1014 
Fixes koncur release-0.9 branch:
```
$ go build -o koncur ./cmd/koncur/main.go
# github.com/konveyor/test-harness/pkg/targets
pkg/targets/tackle_hub.go:116:17: client.Client.Transport undefined (type binding.RestClient has no field or method Transport)
```