### PR TITLE
:sparkles: Support users editing their own (user) resource.

### DIFF
--- a/hack/cmd/login/main.go
+++ b/hack/cmd/login/main.go
@@ -145,8 +145,8 @@ func main() {
 		issuerURL = &path
 	}
 	if *route != "" {
-		hubURL = route
-		*hubURL += "/hub"
+		u := *route + "/hub"
+		hubURL = &u
 	}
 
 	fmt.Printf("\nUsing:\n")

--- a/hack/cmd/login/main.go
+++ b/hack/cmd/login/main.go
@@ -146,6 +146,7 @@ func main() {
 	}
 	if *route != "" {
 		hubURL = route
+		*hubURL += "/hub"
 	}
 
 	fmt.Printf("\nUsing:\n")

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -583,7 +583,8 @@ func (h AuthHandler) UserUpdate(ctx *gin.Context) {
 		_ = ctx.Error(err)
 		return
 	}
-	if !h.Admin(ctx) {
+	isAdmin := h.Admin(ctx)
+	if !isAdmin {
 		if m.Subject != h.CurrentSubject(ctx) {
 			err = &Forbidden{
 				Reason: "Must be admin or current user",
@@ -612,7 +613,7 @@ func (h AuthHandler) UserUpdate(ctx *gin.Context) {
 		_ = ctx.Error(err)
 		return
 	}
-	if id > auth.LastId {
+	if id > auth.LastId && isAdmin {
 		err = h.DB(ctx).Model(m).Association("Roles").Replace(m.Roles)
 		if err != nil {
 			_ = ctx.Error(err)

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -93,13 +92,10 @@ func (h AuthHandler) AddRoutes(e *gin.Engine) {
 	routeGroup.GET(api.UsersRoute+"/", h.UserList)
 	routeGroup.POST(api.UsersRoute, h.UserCreate)
 	routeGroup.GET(api.UserRoute, h.UserGet)
+	routeGroup = e.Group("/")
+	routeGroup.Use(Authenticate(), Transaction)
 	routeGroup.PUT(api.UserRoute, h.UserUpdate)
 	routeGroup.DELETE(api.UserRoute, h.UserDelete)
-	// User (current) routes.
-	routeGroup = e.Group("/")
-	routeGroup.Use(Required("user"), Transaction)
-	routeGroup.PUT(api.AuthUserRoute, h.AuthUserUpdate)
-	routeGroup.DELETE(api.AuthUserRoute, h.AuthUserDelete)
 	// Role routes.
 	routeGroup = e.Group("/")
 	routeGroup.Use(Required("roles"), Transaction)
@@ -583,7 +579,20 @@ func (h AuthHandler) UserUpdate(ctx *gin.Context) {
 		_ = ctx.Error(err)
 		return
 	}
-	m := r.Model()
+	m := &model.User{}
+	err = h.DB(ctx).First(m, id).Error
+	if err != nil {
+		_ = ctx.Error(err)
+		return
+	}
+	if !h.HasScope(ctx, "users") {
+		if m.Subject != h.CurrentSubject(ctx) {
+			err = &Forbidden{}
+			_ = ctx.Error(err)
+			return
+		}
+	}
+	m = r.Model()
 	m.ID = id
 	m.UpdateUser = h.CurrentUser(ctx)
 	db := h.DB(ctx).Model(m)
@@ -637,6 +646,13 @@ func (h AuthHandler) UserDelete(ctx *gin.Context) {
 		_ = ctx.Error(err)
 		return
 	}
+	if !h.HasScope(ctx, "users") {
+		if m.Subject != h.CurrentSubject(ctx) {
+			err = &Forbidden{}
+			_ = ctx.Error(err)
+			return
+		}
+	}
 	err = h.DB(ctx).Delete(m).Error
 	if err != nil {
 		_ = ctx.Error(err)
@@ -646,56 +662,6 @@ func (h AuthHandler) UserDelete(ctx *gin.Context) {
 	auth.IdP.Cache().UserDeleted(id)
 
 	h.Status(ctx, http.StatusNoContent)
-}
-
-// AuthUserUpdate godoc
-// @summary Update the current authenticated user.
-// @description Update the current authenticated user.
-// @tags user
-// @accept json
-// @success 204
-// @router /user [put]
-// @param user body api.User true "User data"
-func (h AuthHandler) AuthUserUpdate(ctx *gin.Context) {
-	subject := h.CurrentSubject(ctx)
-	m := &model.User{}
-	err := h.DB(ctx).First(m, "subject", subject).Error
-	if err != nil {
-		_ = ctx.Error(err)
-		return
-	}
-	id := strconv.Itoa(int(m.ID))
-	ctx.Params = append(
-		ctx.Params,
-		gin.Param{
-			Key:   ID,
-			Value: id,
-		})
-	h.UserUpdate(ctx)
-}
-
-// AuthUserDelete godoc
-// @summary Delete the current authenticated user.
-// @description Delete the current authenticated user.
-// @tags user
-// @success 204
-// @router /user [delete]
-func (h AuthHandler) AuthUserDelete(ctx *gin.Context) {
-	subject := h.CurrentSubject(ctx)
-	m := &model.User{}
-	err := h.DB(ctx).First(m, "subject", subject).Error
-	if err != nil {
-		_ = ctx.Error(err)
-		return
-	}
-	id := strconv.Itoa(int(m.ID))
-	ctx.Params = append(
-		ctx.Params,
-		gin.Param{
-			Key:   ID,
-			Value: id,
-		})
-	h.UserDelete(ctx)
 }
 
 //

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -1127,7 +1127,7 @@ func (h AuthHandler) Login(ctx *gin.Context) {
 // @tags auth
 // @produce json
 // @success 200 {object} AuthSelf
-// @router /auth/me [get]
+// @router /auth/self [get]
 func (h AuthHandler) GetSelf(ctx *gin.Context) {
 	r := AuthSelf{}
 	s := h.CurrentSubject(ctx)

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -92,8 +92,6 @@ func (h AuthHandler) AddRoutes(e *gin.Engine) {
 	routeGroup.GET(api.UsersRoute+"/", h.UserList)
 	routeGroup.POST(api.UsersRoute, h.UserCreate)
 	routeGroup.GET(api.UserRoute, h.UserGet)
-	routeGroup = e.Group("/")
-	routeGroup.Use(Authenticate(), Transaction)
 	routeGroup.PUT(api.UserRoute, h.UserUpdate)
 	routeGroup.DELETE(api.UserRoute, h.UserDelete)
 	// Role routes.
@@ -585,9 +583,11 @@ func (h AuthHandler) UserUpdate(ctx *gin.Context) {
 		_ = ctx.Error(err)
 		return
 	}
-	if !h.HasScope(ctx, "users") {
+	if !h.Admin(ctx) {
 		if m.Subject != h.CurrentSubject(ctx) {
-			err = &Forbidden{}
+			err = &Forbidden{
+				Reason: "Must be admin or current user",
+			}
 			_ = ctx.Error(err)
 			return
 		}
@@ -646,9 +646,11 @@ func (h AuthHandler) UserDelete(ctx *gin.Context) {
 		_ = ctx.Error(err)
 		return
 	}
-	if !h.HasScope(ctx, "users") {
+	if !h.Admin(ctx) {
 		if m.Subject != h.CurrentSubject(ctx) {
-			err = &Forbidden{}
+			err = &Forbidden{
+				Reason: "Must be admin or current user",
+			}
 			_ = ctx.Error(err)
 			return
 		}
@@ -1032,6 +1034,15 @@ func (h AuthHandler) TokenGet(ctx *gin.Context) {
 		_ = ctx.Error(err)
 		return
 	}
+	if !h.Admin(ctx) {
+		if m.Subject != h.CurrentSubject(ctx) {
+			err = &Forbidden{
+				Reason: "Must be admin or current user",
+			}
+			_ = ctx.Error(err)
+			return
+		}
+	}
 
 	r := Token{}
 	r.With(m)
@@ -1048,6 +1059,9 @@ func (h AuthHandler) TokenGet(ctx *gin.Context) {
 func (h AuthHandler) TokenList(ctx *gin.Context) {
 	var list []model.Token
 	db := h.preLoad(h.DB(ctx), clause.Associations)
+	if !h.Admin(ctx) {
+		db = db.Where("subject", h.CurrentSubject(ctx))
+	}
 	err := db.Find(&list).Error
 	if err != nil {
 		_ = ctx.Error(err)

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -94,6 +95,11 @@ func (h AuthHandler) AddRoutes(e *gin.Engine) {
 	routeGroup.GET(api.UserRoute, h.UserGet)
 	routeGroup.PUT(api.UserRoute, h.UserUpdate)
 	routeGroup.DELETE(api.UserRoute, h.UserDelete)
+	// User (current) routes.
+	routeGroup = e.Group("/")
+	routeGroup.Use(Required("user"), Transaction)
+	routeGroup.PUT(api.AuthUserRoute, h.AuthUserUpdate)
+	routeGroup.DELETE(api.AuthUserRoute, h.AuthUserDelete)
 	// Role routes.
 	routeGroup = e.Group("/")
 	routeGroup.Use(Required("roles"), Transaction)
@@ -124,10 +130,10 @@ func (h AuthHandler) AddRoutes(e *gin.Engine) {
 	routeGroup.GET(api.AuthTokensRoute+"/", h.TokenList)
 	routeGroup.GET(api.AuthTokenRoute, h.TokenGet)
 	routeGroup.DELETE(api.AuthTokenRoute, h.TokenDelete)
-	// ME route
+	// self route
 	routeGroup = e.Group("/")
 	routeGroup.Use(Authenticate())
-	routeGroup.GET(api.AuthMeRoute, h.GetMe)
+	routeGroup.GET(api.AuthSelfGetRoute, h.GetSelf)
 }
 
 //
@@ -642,6 +648,56 @@ func (h AuthHandler) UserDelete(ctx *gin.Context) {
 	h.Status(ctx, http.StatusNoContent)
 }
 
+// AuthUserUpdate godoc
+// @summary Update the current authenticated user.
+// @description Update the current authenticated user.
+// @tags user
+// @accept json
+// @success 204
+// @router /user [put]
+// @param user body api.User true "User data"
+func (h AuthHandler) AuthUserUpdate(ctx *gin.Context) {
+	subject := h.CurrentSubject(ctx)
+	m := &model.User{}
+	err := h.DB(ctx).First(m, "subject", subject).Error
+	if err != nil {
+		_ = ctx.Error(err)
+		return
+	}
+	id := strconv.Itoa(int(m.ID))
+	ctx.Params = append(
+		ctx.Params,
+		gin.Param{
+			Key:   ID,
+			Value: id,
+		})
+	h.UserUpdate(ctx)
+}
+
+// AuthUserDelete godoc
+// @summary Delete the current authenticated user.
+// @description Delete the current authenticated user.
+// @tags user
+// @success 204
+// @router /user [delete]
+func (h AuthHandler) AuthUserDelete(ctx *gin.Context) {
+	subject := h.CurrentSubject(ctx)
+	m := &model.User{}
+	err := h.DB(ctx).First(m, "subject", subject).Error
+	if err != nil {
+		_ = ctx.Error(err)
+		return
+	}
+	id := strconv.Itoa(int(m.ID))
+	ctx.Params = append(
+		ctx.Params,
+		gin.Param{
+			Key:   ID,
+			Value: id,
+		})
+	h.UserDelete(ctx)
+}
+
 //
 // Role handlers
 //
@@ -1084,15 +1140,16 @@ func (h AuthHandler) Login(ctx *gin.Context) {
 	}
 }
 
-// GetMe godoc
+// GetSelf godoc
 // @summary Get current authenticated subject.
-// @description Get information about the currently authenticated user, identity, or client.
+// @description Get information about the currently authenticated
+// @description user, identity, or client.
 // @tags auth
 // @produce json
-// @success 200 {object} AuthMe
+// @success 200 {object} AuthSelf
 // @router /auth/me [get]
-func (h AuthHandler) GetMe(ctx *gin.Context) {
-	r := AuthMe{}
+func (h AuthHandler) GetSelf(ctx *gin.Context) {
+	r := AuthSelf{}
 	s := h.CurrentSubject(ctx)
 	subject, err := auth.IdP.Cache().FindSubject(s)
 	if err == nil {
@@ -1133,8 +1190,8 @@ type Grant = resource.Grant
 type Token = resource.Token
 type PAT api.PAT
 
-// AuthMe REST resource.
-type AuthMe struct {
+// AuthSelf REST resource.
+type AuthSelf struct {
 	User     *User        `json:"user,omitempty" yaml:",omitempty"`
 	Identity *IdpIdentity `json:"identity,omitempty" yaml:",omitempty"`
 	Client   *IdpClient   `json:"client,omitempty" yaml:",omitempty"`
@@ -1168,22 +1225,23 @@ func Authenticate() func(ctx *gin.Context) {
 	}
 }
 
-// Required authenticates the user and enforces that the user
-// (identified by a token) has been granted the necessary scope
-// to use a specified resource.
-func Required(scope string) func(*gin.Context) {
-	auth.RegisterScope(scope)
+// Required authenticates the user and enforces that
+// the user has been granted the required scope.
+func Required(resource string) func(*gin.Context) {
+	auth.RegisterResource(resource)
 	return func(ctx *gin.Context) {
 		Authenticate()(ctx)
 		if ctx.IsAborted() {
 			return
 		}
 		rtx := RichContext(ctx)
-		rtx.Scope.Required = append(
-			rtx.Scope.Required,
-			scope)
+		rtx.Scope.Required = auth.Scope{
+			Method:   ctx.Request.Method,
+			Resource: resource,
+		}
 		for _, granted := range rtx.Scope.Granted {
-			if granted.Match(scope, ctx.Request.Method) {
+			matched := granted.Match(resource, ctx.Request.Method)
+			if matched {
 				return
 			}
 		}

--- a/internal/api/base.go
+++ b/internal/api/base.go
@@ -125,7 +125,7 @@ func (h *BaseHandler) CurrentSubject(ctx *gin.Context) (subject string) {
 
 // HasScope determines if the token has the specified scope.
 func (h *BaseHandler) HasScope(ctx *gin.Context, scope string) (b bool) {
-	in := auth.BaseScope{}
+	in := auth.Scope{}
 	in.With(scope)
 	rtx := RichContext(ctx)
 	for _, s := range rtx.Scope.Granted {
@@ -154,12 +154,11 @@ func (h *BaseHandler) Decrypt(ctx *gin.Context, m any) (err error) {
 		return
 	}
 	rtx := RichContext(ctx)
-	for _, scope := range rtx.Scope.Required {
-		scope += ":" + MethodDecrypt
-		if h.HasScope(ctx, scope) {
-			err = secret.Decrypt(m)
-			return
-		}
+	scope := rtx.Scope.Required
+	scope.Method = MethodDecrypt
+	if h.HasScope(ctx, scope.String()) {
+		err = secret.Decrypt(m)
+		return
 	}
 	err = &Forbidden{
 		Reason: ":decrypt (scope) required.",

--- a/internal/api/base.go
+++ b/internal/api/base.go
@@ -124,8 +124,12 @@ func (h *BaseHandler) CurrentSubject(ctx *gin.Context) (subject string) {
 }
 
 // Admin returns true when the current user is an admin.
-func (h *BaseHandler) Admin(ctx *gin.Context) (admin bool) {
-	admin = h.HasScope(ctx, auth.ADMIN)
+func (h *BaseHandler) Admin(ctx *gin.Context) (matched bool) {
+	admin := auth.Scope{
+		Method:   ctx.Request.Method,
+		Resource: auth.ADMIN,
+	}
+	matched = h.HasScope(ctx, admin.String())
 	return
 }
 

--- a/internal/api/base.go
+++ b/internal/api/base.go
@@ -123,6 +123,12 @@ func (h *BaseHandler) CurrentSubject(ctx *gin.Context) (subject string) {
 	return
 }
 
+// Admin returns true when the current user is an admin.
+func (h *BaseHandler) Admin(ctx *gin.Context) (admin bool) {
+	admin = h.HasScope(ctx, auth.ADMIN)
+	return
+}
+
 // HasScope determines if the token has the specified scope.
 func (h *BaseHandler) HasScope(ctx *gin.Context, scope string) (b bool) {
 	in := auth.Scope{}

--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -39,8 +39,8 @@ type Context struct {
 	User string
 	// Scope
 	Scope struct {
+		Required auth.Scope
 		Granted  []auth.Scope
-		Required []string
 	}
 	// k8s Client
 	Client client.Client

--- a/internal/api/schema.go
+++ b/internal/api/schema.go
@@ -28,9 +28,11 @@ type SchemaHandler struct {
 func (h *SchemaHandler) AddRoutes(r *gin.Engine) {
 	h.router = r
 	r.GET(api.SchemaRoute, h.GetAPI)
-	r.GET(api.SchemasRoute, h.List)
-	r.GET(api.SchemasGetRoute, h.Get)
-	r.GET(api.SchemaFindRoute, h.Find)
+	routeGroup := r.Group("/")
+	routeGroup.Use(Required("schemas"))
+	routeGroup.GET(api.SchemasRoute, h.List)
+	routeGroup.GET(api.SchemasGetRoute, h.Get)
+	routeGroup.GET(api.SchemaFindRoute, h.Find)
 }
 
 // GetAPI godoc

--- a/internal/auth/README.md
+++ b/internal/auth/README.md
@@ -1156,11 +1156,11 @@ To verify your patterns work correctly:
 
 The `Expiration` field controls how long the cached LDAP identity is trusted before re-authentication:
 
-| Flow | Lifespan Parameter | Purpose |
-|------|-------------------|---------|
-| **Basic Auth** | `BasicAuthLifespan` (1 min) | Fast detection of password/permission changes |
-| **Token Refresh** | `TokenLifespan` (5 min) | Aligned with access token validity |
-| **OIDC Login** | `TokenLifespan` (5 min) | Matches token refresh behavior |
+| Flow | Lifespan Setting | Environment Variable | Default | Purpose |
+|------|-----------------|---------------------|---------|---------|
+| **Basic Auth (LDAP)** | `Settings.Auth.LdapAuthLifespan` | `LDAP_AUTH_LIFESPAN` | 5 min | Balance between LDAP load and permission freshness |
+| **Token Refresh (LDAP)** | `Settings.Auth.LdapAuthLifespan` | `LDAP_AUTH_LIFESPAN` | 5 min | Automatic group membership updates during refresh |
+| **OIDC Login (LDAP)** | `Settings.Auth.LdapAuthLifespan` | `LDAP_AUTH_LIFESPAN` | 5 min | Consistent with other LDAP flows |
 
 When identity is found in cache:
 - If `Expiration > now`: Use cached scopes (no LDAP contact)

--- a/internal/auth/README.md
+++ b/internal/auth/README.md
@@ -99,71 +99,106 @@ Short-lived tokens automatically generated for addon task execution. Scoped to t
 
 ---
 
-## Authentication Staleness
+## Authentication Staleness and Cache Management
 
-Different authentication methods have different staleness characteristics based on their use cases:
+Different authentication methods have different staleness characteristics based on their use cases and security requirements.
 
-| Authentication Method | Staleness | Environment Variable | Default |
-|----------------------|-----------|---------------------|---------|
-| **OAuth Access Tokens** | Token lifespan | `OIDC_TOKEN_LIFESPAN` | 5 minutes |
-| **Basic Auth (LDAP)** | Identity expiration | `AUTH_BASIC_AUTH_LIFESPAN` | 1 minute |
-| **Basic Auth (Local)** | Cache refresh | `AUTH_CACHE_LIFESPAN` | 5 minutes |
-| **OAuth Refresh (LDAP)** | Token lifespan | `OIDC_TOKEN_LIFESPAN` | 5 minutes |
-| **Personal Access Tokens** | Cache refresh | `AUTH_CACHE_LIFESPAN` | 5 minutes |
+### Staleness Control Summary
 
-### Staleness Behavior
+| Authentication Method | Primary Control | Worst Case | Environment Variable | Default |
+|----------------------|----------------|------------|---------------------|---------|
+| **OAuth Access Tokens** | Token `exp` claim | N/A (stateless) | `OIDC_TOKEN_LIFESPAN` | 5 minutes |
+| **Basic Auth (Local Users)** | Cache notifications | 5 minutes | `AUTH_CACHE_LIFESPAN` | 5 minutes |
+| **Basic Auth (LDAP)** | Identity expiration | 5 minutes | `LDAP_AUTH_LIFESPAN` | 5 minutes |
+| **Personal Access Tokens** | Cache notifications | 5 minutes | `AUTH_CACHE_LIFESPAN` | 5 minutes |
+| **OAuth Refresh (LDAP)** | Identity expiration | 5 minutes | `LDAP_AUTH_LIFESPAN` | 5 minutes |
 
-**OAuth Access Tokens:**
-- Signed JWTs with embedded scopes
-- Valid until expiration (typically 5 minutes)
-- Group/role changes don't apply until token refresh
-- Designed staleness for performance
+### Cache Architecture
 
-**Basic Auth with LDAP:**
-- Creates LDAP Identity with expiration based on `BasicAuthLifespan`
-- Cached identity reused until expiration
-- On expiration: re-authenticate with LDAP, update groups/roles
-- Shorter staleness (1 min) for responsive credential/permission changes
+The authentication cache uses a **two-layer strategy** for optimal performance and freshness:
 
-**Basic Auth with Local Users:**
-- User lookup always refreshes from database (security-critical)
-- Password and role changes apply immediately
-- Cache used for role→scope resolution only
+**Primary: Immediate Notifications**
+- When users/roles/identities/tokens are modified via the API, the cache is updated **immediately**
+- Changes propagate in < 1 second (typical in-memory update time)
+- Triggered by: UserSaved, RoleSaved, IdentitySaved, TokenDeleted, etc.
+- Ensures near-instant application of changes made through the hub API
 
-**Token Refresh with LDAP:**
-- Uses Token.Lifespan for Identity expiration
-- Re-authenticates with LDAP when identity expires during refresh
-- Longer staleness (5 min) aligned with access token validity
+**Secondary: Safety-Net Refresh**
+- Periodic refresh every `AUTH_CACHE_LIFESPAN` (default: 5 minutes)
+- Catches changes made directly in the database (external tools, migrations)
+- Ensures eventual consistency even if notifications fail
+- Acts as a backstop, not the primary staleness control
 
-**Cache Safety Net:**
-- All cached data refreshes from database when `CacheLifespan` exceeded
-- Explicit notifications (IdentitySaved, UserSaved, etc.) update cache immediately
-- CacheLifespan is worst-case staleness for notification failures
+From the code comments (`internal/auth/cache/cache.go`):
+```go
+// Cache Strategy:
+//   - Notifications: Saved/Deleted methods immediately update the cache
+//   - Safety-net: Periodic refresh.
+//   - Password changes, role updates, and other changes are propagated
+//     immediately via notifications
+```
 
-### Lifespan vs Staleness
+### Staleness by Authentication Method
 
-**Lifespan** = how long a caller controls when creating authentication data:
-- `LdapHandler.Authenticate(login, password, lifespan)` sets Identity.Expiration
+#### OAuth Access Tokens (JWT)
 
-**Staleness** = resulting delay before changes take effect:
-- Basic Auth passes `BasicAuthLifespan` (1 min) → 1 min staleness
-- Token refresh passes `TokenLifespan` (5 min) → 5 min staleness
+**Staleness:** Controlled by JWT `exp` claim (stateless validation)
+
+Clients send bearer tokens on every request. The server validates the JWT signature and checks the `exp` claim against current time. No database or cache lookup required. Permission changes don't apply until token refresh.
+
+**Trade-off:** Performance and scalability vs immediate permission propagation.
+
+#### Basic Authentication - Local Users
+
+**Staleness:** Near-instant via cache notifications (< 1 second typical)
+
+Clients send username/password on every request. The server looks up the user in cache, validates the password hash, and resolves roles/scopes. When users/roles are modified via the API, the cache is updated immediately via notifications (UserSaved, RoleSaved). 
+
+The server creates an ephemeral JWT with `exp` set to `CacheLifespan` for the internal request context, but this JWT is **never sent to the client** - it exists only for the single request. Actual staleness is controlled by cache notifications, not the JWT expiration.
+
+**Fallback:** Up to 5 minutes (cache safety-net refresh) only for direct database modifications.
+
+#### Basic Authentication - LDAP Users  
+
+**Staleness:** Controlled by `LDAP_AUTH_LIFESPAN` (default: 5 minutes)
+
+Clients send username/password on every request. The server checks for a cached LDAP identity. If the identity is cached and not expired, the cached scopes are used. If expired or not cached, the server authenticates against the LDAP server, queries groups, maps groups to roles, and creates/updates the identity with `Expiration = now + LdapAuthLifespan`.
+
+Password validation always goes to LDAP (bind operation). Role mapping changes propagate via cache notifications. The lifespan controls how often group memberships are refreshed from LDAP.
+
+**Trade-off:** LDAP load vs permission freshness.
+
+#### Personal Access Tokens (PAT/API Keys)
+
+**Staleness:** Near-instant for revocation via cache notifications (< 1 second typical)
+
+Clients send bearer tokens (API keys) on every request. The server computes the SHA256 hash and looks up the token in cache. Token revocation propagates immediately via cache notifications (TokenDeleted). User role changes are resolved fresh on every request from the cached user data.
+
+**Fallback:** Up to 5 minutes (cache safety-net refresh) for cache misses.
+
+#### OAuth Refresh with LDAP Identity
+
+**Staleness:** Controlled by `LDAP_AUTH_LIFESPAN` (default: 5 minutes)
+
+When refreshing tokens, if the associated LDAP identity has expired, the server re-authenticates with LDAP using the stored password and fetches fresh group memberships. This enables automatic permission updates without user interaction.
+
+**Trade-off:** LDAP load vs automatic permission sync during token refresh.
 
 ### Environment Variables
 
 Complete list of authentication-related environment variables:
 
-| Variable | Type | Default                      | Description |
-|----------|------|------------------------------|-------------|
-| `AUTH_ENABLED` | Boolean | `true`                       | Enable authentication system |
-| `AUTH_REQUIRED` | Boolean | `false`                      | Enforce authentication for all API requests |
-| `AUTH_CACHE_LIFESPAN` | Integer | `5`                          | Cache refresh interval in minutes |
-| `AUTH_BASIC_AUTH_LIFESPAN` | Integer | `60`                         | Basic auth identity lifespan for LDAP users in seconds |
-| `OIDC_TOKEN_LIFESPAN` | Integer | `300`                        | OAuth access token lifespan in seconds (5 minutes) |
-| `OIDC_REFRESH_TOKEN_LIFESPAN` | Integer | `172800`                     | OAuth refresh token lifespan in seconds (2 days) |
-| `OIDC_KEY_ROTATION` | Integer | `90`                         | RSA signing key rotation interval in days |
-| `APIKEY_SECRET` | String | `tackle`                     | Secret used for API key generation |
-| `APIKEY_LIFESPAN` | Integer | `87600`                      | Personal Access Token lifespan in hours (10 years) |
+| Variable | Type | Default | Description |
+|----------|------|---------|-------------|
+| `AUTH_ENABLED` | Boolean | `true` | Enable authentication system |
+| `AUTH_REQUIRED` | Boolean | `false` | Enforce authentication for all API requests |
+| `AUTH_CACHE_LIFESPAN` | Integer (minutes) | `5` | Cache safety-net refresh interval; worst-case staleness for basic auth and PATs |
+| `LDAP_AUTH_LIFESPAN` | Integer (minutes) | `5` | LDAP identity cache duration; controls LDAP query frequency |
+| `OIDC_TOKEN_LIFESPAN` | Integer (seconds) | `300` | OAuth access token lifespan in seconds (5 minutes) |
+| `OIDC_REFRESH_TOKEN_LIFESPAN` | Integer (seconds) | `172800` | OAuth refresh token lifespan in seconds (2 days) |
+| `OIDC_KEY_ROTATION` | Integer (days) | `90` | RSA signing key rotation interval in days |
+| `APIKEY_SECRET` | String | `tackle` | Secret used for API key generation |
+| `APIKEY_LIFESPAN` | Integer (hours) | `87600` | Personal Access Token lifespan in hours (10 years) |
 
 **Note on OIDC Issuer:** The OIDC issuer is now **dynamically determined** from the incoming HTTP request rather than configured via environment variable. The issuer is constructed from the request's scheme, host, and path to `/oidc`. This enables the hub to work seamlessly across different deployment environments (localhost, OpenShift routes, custom domains) without configuration changes.
 

--- a/internal/auth/addon.go
+++ b/internal/auth/addon.go
@@ -7,7 +7,6 @@ var AddonScopes = []string{
 	"applications:get",
 	"applications:post",
 	"applications:put",
-	"applications.tags:*",
 	"applications.facts:*",
 	"applications.bucket:*",
 	"applications.analyses:*",

--- a/internal/auth/builtin.go
+++ b/internal/auth/builtin.go
@@ -284,7 +284,7 @@ func (p *Builtin) Scopes(jwToken *jwt.Token) (scopes []Scope) {
 	v := claims[ClaimScope]
 	if sList, cast := v.(string); cast {
 		for _, s := range strings.Fields(sList) {
-			scope := &BaseScope{}
+			scope := Scope{}
 			scope.With(s)
 			scopes = append(
 				scopes,

--- a/internal/auth/builtin.go
+++ b/internal/auth/builtin.go
@@ -555,13 +555,13 @@ func (p *Builtin) authUser(req *Request) (jwToken *jwt.Token, err error) {
 	jwtClaims[ClaimScope] = strings.Join(scopes, " ")
 	jwtClaims[ClaimIss] = Issuer(req.CTX.Request)
 	jwtClaims[ClaimIat] = time.Now().Unix()
-	jwtClaims[ClaimExp] = time.Now().Add(Settings.Auth.BasicAuthLifespan).Unix()
+	jwtClaims[ClaimExp] = time.Now().Add(Settings.Auth.CacheLifespan).Unix()
 	return
 }
 
 // authLdapUser authenticates an LDAP user.
 func (p *Builtin) authLdapUser(req *Request) (jwToken *jwt.Token, err error) {
-	lifespan := Settings.Auth.BasicAuthLifespan
+	lifespan := Settings.Auth.LdapAuthLifespan
 	subject, err := p.dsHandler.Authenticate(req.Login, req.Password, lifespan)
 	if err != nil {
 		return

--- a/internal/auth/builtin.go
+++ b/internal/auth/builtin.go
@@ -163,7 +163,7 @@ func (p *Builtin) NewToken(subject string, lifespan time.Duration) (m Token, err
 			}
 		}
 	}()
-	m = p.newToken(lifespan)
+	m = p.newToken(subject, lifespan)
 	s, err := p.cache.FindSubject(subject)
 	if err != nil {
 		return
@@ -182,7 +182,7 @@ func (p *Builtin) NewToken(subject string, lifespan time.Duration) (m Token, err
 
 // TaskGrant creates a new task api-key.
 func (p *Builtin) TaskGrant(taskId uint) (m Token, err error) {
-	m = p.newToken(0)
+	m = p.newToken("", 0)
 	m.TaskID = &taskId
 	err = p.db.Create(&m).Error
 	if err != nil {
@@ -577,11 +577,12 @@ func (p *Builtin) authLdapUser(req *Request) (jwToken *jwt.Token, err error) {
 }
 
 // newToken returns a new token.
-func (p *Builtin) newToken(lifespan time.Duration) (token Token) {
+func (p *Builtin) newToken(subject string, lifespan time.Duration) (token Token) {
 	if lifespan == 0 {
 		lifespan = Settings.APIKey.Lifespan
 	}
 	token.Kind = KindAPIKey
+	token.Subject = subject
 	token.AuthId = p.storage.genId()
 	token.Secret = p.storage.genId()
 	token.Digest = secret.Hash(token.Secret)

--- a/internal/auth/cache/addon.go
+++ b/internal/auth/cache/addon.go
@@ -7,7 +7,6 @@ var AddonScopes = []string{
 	"applications:get",
 	"applications:post",
 	"applications:put",
-	"applications.tags:*",
 	"applications.facts:*",
 	"applications.bucket:*",
 	"applications.analyses:*",

--- a/internal/auth/domain.go
+++ b/internal/auth/domain.go
@@ -23,7 +23,9 @@ var (
 )
 
 var (
-	registeredResources = make(map[string]bool)
+	registeredResources = map[string]bool{
+		ADMIN: true,
+	}
 )
 
 const (

--- a/internal/auth/domain.go
+++ b/internal/auth/domain.go
@@ -23,7 +23,7 @@ var (
 )
 
 var (
-	registeredScopes = make(map[string]bool)
+	registeredResources = make(map[string]bool)
 )
 
 const (
@@ -38,10 +38,10 @@ func init() {
 	}
 }
 
-// RegisterScope registers a resource scope for permission generation.
-func RegisterScope(scope string) {
-	if scope != "" {
-		registeredScopes[scope] = true
+// RegisterResource registers an api resource for permission (scope) generation.
+func RegisterResource(resource string) {
+	if resource != "" {
+		registeredResources[resource] = true
 	}
 }
 
@@ -68,8 +68,8 @@ func (d *Domain) Seed() (err error) {
 	database.PK.Begin(d.DB, IdpClient{}, LastId)
 	database.PK.Begin(d.DB, User{}, LastId)
 	var resources []string
-	for scope := range registeredScopes {
-		resources = append(resources, scope)
+	for r := range registeredResources {
+		resources = append(resources, r)
 	}
 	sort.Strings(resources)
 	err = d.DB.Transaction(
@@ -130,6 +130,7 @@ func (d *Domain) buildPermissionMap(db *gorm.DB) (err error) {
 // Each resource gets 5 permissions (one per HTTP verb).
 func (d *Domain) generatePermissions(resources []string) (perms []Permission) {
 	verbs := []string{
+		"decrypt",
 		"delete",
 		"get",
 		"patch",

--- a/internal/auth/noauth.go
+++ b/internal/auth/noauth.go
@@ -34,7 +34,7 @@ func (r *NoAuth) NewToken(subject string, lifespan time.Duration) (token Token, 
 // For the NoAuth provider, this just returns a single
 // wildcard scope matching everything.
 func (r *NoAuth) Scopes(jwToken *jwt.Token) (scopes []Scope) {
-	scopes = append(scopes, &BaseScope{"*", "*"})
+	scopes = append(scopes, Scope{"*", "*"})
 	return
 }
 

--- a/internal/auth/noauth.go
+++ b/internal/auth/noauth.go
@@ -25,7 +25,7 @@ func (r *NoAuth) Authenticate(request *Request) (jwToken *jwt.Token, err error) 
 }
 
 func (r *NoAuth) NewToken(subject string, lifespan time.Duration) (token Token, err error) {
-	token = r.newToken(lifespan)
+	token = r.newToken(subject, lifespan)
 	err = r.Builtin.db.Create(&token).Error
 	return
 }

--- a/internal/auth/pkg.go
+++ b/internal/auth/pkg.go
@@ -101,23 +101,15 @@ const (
 	ClaimIat   = "iat"   // Issued At
 )
 
-// Scope represents an authorization scope.
-type Scope interface {
-	// Match returns whether the scope is a match.
-	Match(resource string, method string) bool
-	//String representations of the scope.
-	String() (s string)
-}
-
-// BaseScope provides base behavior.
-type BaseScope struct {
+// Scope provides scope behavior.
+type Scope struct {
 	Resource string
 	Method   string
 }
 
 // With parses a scope and populate fields.
 // Format: <resource>:<method>
-func (r *BaseScope) With(s string) {
+func (r *Scope) With(s string) {
 	part := strings.Split(s, ":")
 	n := len(part)
 	if n > 0 {
@@ -130,7 +122,7 @@ func (r *BaseScope) With(s string) {
 }
 
 // Match returns whether the scope is a match.
-func (r *BaseScope) Match(resource string, method string) (b bool) {
+func (r *Scope) Match(resource string, method string) (b bool) {
 	b = (r.Resource == "*" ||
 		r.Eq(r.Resource, resource)) &&
 		(r.Method == "*" ||
@@ -139,13 +131,13 @@ func (r *BaseScope) Match(resource string, method string) (b bool) {
 }
 
 // Eq returns true when strings matched.
-func (r *BaseScope) Eq(a, b string) (eq bool) {
+func (r *Scope) Eq(a, b string) (eq bool) {
 	eq = strings.EqualFold(a, b)
 	return
 }
 
 // String representations of the scope.
-func (r *BaseScope) String() (s string) {
+func (r *Scope) String() (s string) {
 	s = strings.Join([]string{r.Resource, r.Method}, ":")
 	return
 }

--- a/internal/auth/pkg.go
+++ b/internal/auth/pkg.go
@@ -8,10 +8,15 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/jortel/go-utils/logr"
 	"github.com/konveyor/tackle2-hub/internal/auth/cache"
+	"github.com/konveyor/tackle2-hub/internal/auth/seed"
 	as "github.com/konveyor/tackle2-hub/internal/auth/settings"
 	"github.com/konveyor/tackle2-hub/internal/model"
 	"github.com/konveyor/tackle2-hub/shared/settings"
 	"gorm.io/gorm"
+)
+
+const (
+	ADMIN = seed.ADMIN
 )
 
 const (

--- a/internal/auth/pkg_test.go
+++ b/internal/auth/pkg_test.go
@@ -414,30 +414,30 @@ func TestBaseScopeMatching(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	// Wildcard scope matches everything
-	scope := &BaseScope{Resource: "*", Method: "*"}
+	scope := Scope{Resource: "*", Method: "*"}
 	g.Expect(scope.Match("applications", "GET")).To(BeTrue())
 	g.Expect(scope.Match("tags", "POST")).To(BeTrue())
 
 	// Resource wildcard matches any method for that resource
-	scope = &BaseScope{Resource: "applications", Method: "*"}
+	scope = Scope{Resource: "applications", Method: "*"}
 	g.Expect(scope.Match("applications", "GET")).To(BeTrue())
 	g.Expect(scope.Match("applications", "POST")).To(BeTrue())
 	g.Expect(scope.Match("tags", "GET")).To(BeFalse())
 
 	// Method wildcard matches that method for any resource
-	scope = &BaseScope{Resource: "*", Method: "GET"}
+	scope = Scope{Resource: "*", Method: "GET"}
 	g.Expect(scope.Match("applications", "GET")).To(BeTrue())
 	g.Expect(scope.Match("tags", "GET")).To(BeTrue())
 	g.Expect(scope.Match("applications", "POST")).To(BeFalse())
 
 	// Exact match
-	scope = &BaseScope{Resource: "applications", Method: "GET"}
+	scope = Scope{Resource: "applications", Method: "GET"}
 	g.Expect(scope.Match("applications", "GET")).To(BeTrue())
 	g.Expect(scope.Match("applications", "POST")).To(BeFalse())
 	g.Expect(scope.Match("tags", "GET")).To(BeFalse())
 
 	// Case insensitive
-	scope = &BaseScope{Resource: "Applications", Method: "get"}
+	scope = Scope{Resource: "Applications", Method: "get"}
 	g.Expect(scope.Match("applications", "GET")).To(BeTrue())
 }
 
@@ -445,18 +445,18 @@ func TestBaseScopeMatching(t *testing.T) {
 func TestBaseScopeParsing(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	scope := &BaseScope{}
+	scope := Scope{}
 	scope.With("applications:read")
 	g.Expect(scope.Resource).To(Equal("applications"))
 	g.Expect(scope.Method).To(Equal("read"))
 
-	scope = &BaseScope{}
+	scope = Scope{}
 	scope.With("*:*")
 	g.Expect(scope.Resource).To(Equal("*"))
 	g.Expect(scope.Method).To(Equal("*"))
 
 	// Test String() roundtrip
-	scope = &BaseScope{Resource: "tags", Method: "write"}
+	scope = Scope{Resource: "tags", Method: "write"}
 	g.Expect(scope.String()).To(Equal("tags:write"))
 }
 

--- a/internal/auth/seed/pkg.go
+++ b/internal/auth/seed/pkg.go
@@ -1,5 +1,9 @@
 package seed
 
+const (
+	ADMIN = "ADMIN"
+)
+
 // Role use to read roles.yaml.
 type Role struct {
 	ID        uint   `yaml:"id"`

--- a/internal/auth/seed/pkg.go
+++ b/internal/auth/seed/pkg.go
@@ -1,7 +1,7 @@
 package seed
 
 const (
-	ADMIN = "ADMIN"
+	ADMIN = "admin"
 )
 
 // Role use to read roles.yaml.

--- a/internal/auth/seed/roles.yaml
+++ b/internal/auth/seed/roles.yaml
@@ -779,9 +779,6 @@
         - delete
         - get
         - put
-    - name: users
-      verbs:
-        - get
     - name: tokens
       verbs:
         - post

--- a/internal/auth/seed/roles.yaml
+++ b/internal/auth/seed/roles.yaml
@@ -1,7 +1,7 @@
 - role: admin
   id: 1
   resources:
-    - name: ADMIN
+    - name: admin
       verbs:
         - delete
         - get

--- a/internal/auth/seed/roles.yaml
+++ b/internal/auth/seed/roles.yaml
@@ -513,6 +513,9 @@
     - name: questionnaires
       verbs:
         - get
+    - name: users
+      verbs:
+        - get
     - name: tokens
       verbs:
         - post
@@ -662,6 +665,9 @@
     - name: questionnaires
       verbs:
         - get
+    - name: users
+      verbs:
+        - get
     - name: tokens
       verbs:
         - post
@@ -799,6 +805,9 @@
       verbs:
         - get
     - name: questionnaires
+      verbs:
+        - get
+    - name: users
       verbs:
         - get
     - name: tokens

--- a/internal/auth/seed/roles.yaml
+++ b/internal/auth/seed/roles.yaml
@@ -1,6 +1,9 @@
 - role: admin
   id: 1
   resources:
+    - name: ADMIN
+      verbs:
+        - *
     - name: addons
       verbs:
         - delete
@@ -515,7 +518,9 @@
         - get
     - name: users
       verbs:
+        - delete
         - get
+        - put
     - name: tokens
       verbs:
         - post
@@ -667,7 +672,9 @@
         - get
     - name: users
       verbs:
+        - delete
         - get
+        - put
     - name: tokens
       verbs:
         - post
@@ -807,6 +814,11 @@
     - name: questionnaires
       verbs:
         - get
+    - name: users
+      verbs:
+        - delete
+        - get
+        - put
     - name: users
       verbs:
         - get

--- a/internal/auth/seed/roles.yaml
+++ b/internal/auth/seed/roles.yaml
@@ -34,12 +34,6 @@
         - get
         - post
         - put
-    - name: applications.tags
-      verbs:
-        - delete
-        - get
-        - post
-        - put
     - name: applications.bucket
       verbs:
         - delete
@@ -108,10 +102,6 @@
         - get
         - post
         - put
-    - name: kai
-      verbs:
-        - get
-        - post
     - name: manifests
       verbs:
         - delete
@@ -286,9 +276,6 @@
         - post
         - get
         - delete
-    - name: device
-      verbs:
-        - post
 - role: architect
   id: 2
   resources:
@@ -314,12 +301,6 @@
         - post
         - put
     - name: applications.facts
-      verbs:
-        - delete
-        - get
-        - post
-        - put
-    - name: applications.tags
       verbs:
         - delete
         - get
@@ -390,10 +371,6 @@
         - get
         - post
         - put
-    - name: kai
-      verbs:
-        - get
-        - post
     - name: manifests
       verbs:
         - delete
@@ -527,9 +504,6 @@
     - name: tokens
       verbs:
         - post
-    - name: device
-      verbs:
-        - post
 - role: migrator
   id: 3
   resources:
@@ -546,9 +520,6 @@
       verbs:
         - get
     - name: applications.facts
-      verbs:
-        - get
-    - name: applications.tags
       verbs:
         - get
     - name: applications.bucket
@@ -590,10 +561,6 @@
     - name: jobfunctions
       verbs:
         - get
-    - name: kai
-      verbs:
-        - get
-        - post
     - name: manifests
       verbs:
         - get
@@ -681,9 +648,6 @@
     - name: tokens
       verbs:
         - post
-    - name: device
-      verbs:
-        - post
 - role: project-manager
   id: 4
   resources:
@@ -700,9 +664,6 @@
       verbs:
         - get
     - name: applications.facts
-      verbs:
-        - get
-    - name: applications.tags
       verbs:
         - get
     - name: applications.bucket
@@ -744,10 +705,6 @@
     - name: jobfunctions
       verbs:
         - get
-    - name: kai
-      verbs:
-        - get
-        - post
     - name: platforms
       verbs:
         - get
@@ -826,8 +783,5 @@
       verbs:
         - get
     - name: tokens
-      verbs:
-        - post
-    - name: device
       verbs:
         - post

--- a/internal/auth/seed/roles.yaml
+++ b/internal/auth/seed/roles.yaml
@@ -3,7 +3,10 @@
   resources:
     - name: ADMIN
       verbs:
-        - *
+        - delete
+        - get
+        - post
+        - put
     - name: addons
       verbs:
         - delete

--- a/internal/auth/storage.go
+++ b/internal/auth/storage.go
@@ -59,6 +59,7 @@ func (r *Storage) GetClientByClientID(ctx context.Context, clientId string) (opC
 			grantTypes:      []string{"authorization_code"},
 			redirectURIs:    []string{AppendIssuer(req, api.DeviceCbRoute)},
 			scopes:          []string{"openid"},
+			request:         req,
 		}
 		return
 	}

--- a/internal/k8s/api/tackle/v1alpha1/zz_generated.deepcopy.go
+++ b/internal/k8s/api/tackle/v1alpha1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )

--- a/shared/api/pkg.go
+++ b/shared/api/pkg.go
@@ -131,18 +131,6 @@ const (
 	AssessmentRoute  = AssessmentsRoute + "/:" + ID
 )
 
-// Routes - Auth
-const (
-	AuthRoute           = "/auth"
-	AuthGrantsRoute     = AuthRoute + "/grants"
-	AuthGrantRoute      = AuthGrantsRoute + "/:" + ID
-	AuthTokensRoute     = AuthRoute + "/tokens"
-	AuthTokenRoute      = AuthTokensRoute + "/:" + ID
-	AuthDevAuthRoute    = AuthRoute + "/device"
-	AuthDevAuthCallback = AuthDevAuthRoute + "/callback"
-	AuthMeRoute         = AuthRoute + "/me"
-)
-
 // Routes - Batch
 const (
 	BatchRoute        = "/batch"
@@ -201,18 +189,36 @@ const (
 	AppIdentitiesRoute = ApplicationRoute + "/identities"
 )
 
-// Routes - OIDC
+// Routes - RBAC
 const (
-	OIDCRoutes       = "/oidc"
 	UsersRoute       = "/users"
 	UserRoute        = UsersRoute + "/:" + ID
 	RolesRoute       = "/roles"
 	RoleRoute        = RolesRoute + "/:" + ID
 	PermissionsRoute = "/permissions"
 	PermissionRoute  = PermissionsRoute + "/:" + ID
-	IdpClientsRoute  = AuthRoute + "/clients"
-	IdpClientRoute   = IdpClientsRoute + "/:" + ID
-	// OIDC flow paths (relative to OIDCRoutes)
+)
+
+// Routes - Auth
+const (
+	AuthRoute           = "/auth"
+	AuthSelfGetRoute    = AuthRoute + "/self"
+	AuthUserRoute       = AuthRoute + "/user"
+	AuthGrantsRoute     = AuthRoute + "/grants"
+	AuthGrantRoute      = AuthGrantsRoute + "/:" + ID
+	AuthTokensRoute     = AuthRoute + "/tokens"
+	AuthTokenRoute      = AuthTokensRoute + "/:" + ID
+	AuthDevAuthRoute    = AuthRoute + "/device"
+	AuthDevAuthCallback = AuthDevAuthRoute + "/callback"
+	IdpIdentitiesRoute  = AuthRoute + "/identities"
+	IdpIdentityRoute    = IdpIdentitiesRoute + "/:" + ID
+	IdpClientsRoute     = AuthRoute + "/clients"
+	IdpClientRoute      = IdpClientsRoute + "/:" + ID
+)
+
+// Routes - mounted under OIDC
+const (
+	OIDCRoutes       = "/oidc"
 	LoginRoute       = "/login"
 	IdpLoginRoute    = "/idp/login"
 	IdpCbRoute       = "/idp/callback"
@@ -220,13 +226,6 @@ const (
 	DeviceLoginRoute = "/device/login"
 	DeviceCbRoute    = "/device/callback"
 	AuthorizeCbRoute = "/authorize/callback"
-)
-
-// Routes - External IdP
-const (
-	IdpRoute           = OIDCRoutes + "/idp"
-	IdpIdentitiesRoute = AuthRoute + "/identities"
-	IdpIdentityRoute   = IdpIdentitiesRoute + "/:" + ID
 )
 
 // Routes - Imports

--- a/shared/api/pkg.go
+++ b/shared/api/pkg.go
@@ -203,7 +203,6 @@ const (
 const (
 	AuthRoute           = "/auth"
 	AuthSelfGetRoute    = AuthRoute + "/self"
-	AuthUserRoute       = AuthRoute + "/user"
 	AuthGrantsRoute     = AuthRoute + "/grants"
 	AuthGrantRoute      = AuthGrantsRoute + "/:" + ID
 	AuthTokensRoute     = AuthRoute + "/tokens"

--- a/shared/settings/auth.go
+++ b/shared/settings/auth.go
@@ -13,7 +13,7 @@ const (
 	EnvAPIKeySecret         = "APIKEY_SECRET"
 	EnvAPIKeyLifespan       = "APIKEY_LIFESPAN"
 	EnvCacheLifespan        = "AUTH_CACHE_LIFESPAN"
-	EnvBasicAuthLifespan    = "BASIC_AUTH_LIFESPAN"
+	EnvLdapAuthLifespan     = "LDAP_AUTH_LIFESPAN"
 	EnvTokenKey             = "ADDON_TOKEN" // Deprecated
 	EnvTokenLifespan        = "OIDC_TOKEN_LIFESPAN"
 	EnvRefreshTokenLifespan = "OIDC_REFRESH_TOKEN_LIFESPAN"
@@ -25,10 +25,10 @@ type Auth struct {
 	Enabled bool
 	// Auth required
 	Required bool
-	// Cache
+	// Cache lifespan.
 	CacheLifespan time.Duration
-	// BasicAuth cache lifespan
-	BasicAuthLifespan time.Duration
+	// LDAP auth lifespan.
+	LdapAuthLifespan time.Duration
 	// APIKey settings.
 	APIKey struct {
 		Secret   string
@@ -49,8 +49,8 @@ type Auth struct {
 func (r *Auth) Load() (err error) {
 	r.Enabled = env.GetBool(EnvAuthEnabled, true)
 	r.Required = env.GetBool(EnvAuthRequired, false)
-	r.CacheLifespan = env.GetMinute(EnvCacheLifespan, 5)
-	r.BasicAuthLifespan = env.GetSecond(EnvBasicAuthLifespan, 60) // second: 1 minute.
+	r.CacheLifespan = env.GetMinute(EnvCacheLifespan, 5)       // minute: 5 minutes.
+	r.LdapAuthLifespan = env.GetMinute(EnvLdapAuthLifespan, 5) // minute: 5 minutes.
 	r.APIKey.Secret = env.Get(EnvAPIKeySecret, "tackle")
 	r.APIKey.Lifespan = env.GetHour(EnvAPIKeyLifespan, 10*24*365) // hour: 10 years.
 	r.Token.Key = env.Get(EnvTokenKey, "tackle")

--- a/test/auth/oidc_test.go
+++ b/test/auth/oidc_test.go
@@ -194,7 +194,7 @@ func TestAuthorizationCodeFlow(t *testing.T) {
 	// Should get redirect to login page
 	g.Expect(resp.StatusCode).To(Equal(http.StatusFound))
 	loginURL = resp.Header.Get("Location")
-	g.Expect(loginURL).To(ContainSubstring("/login?authRequestID="))
+	g.Expect(loginURL).To(ContainSubstring("/login?authRequestId="))
 
 	// Follow redirect to get login page
 	resp, err = httpClient.Get(loginURL)
@@ -209,11 +209,11 @@ func TestAuthorizationCodeFlow(t *testing.T) {
 	// Extract auth request ID from URL
 	parsedURL, err := url.Parse(loginURL)
 	g.Expect(err).To(BeNil())
-	authReqID := parsedURL.Query().Get("authRequestID")
+	authReqID := parsedURL.Query().Get("authRequestId")
 	g.Expect(authReqID).NotTo(BeEmpty())
 
-	// Step 2: Submit login form (POST /login?authRequestID=...)
-	loginURL = issuer + "/login?authRequestID=" + authReqID
+	// Step 2: Submit login form (POST /login?authRequestId=...)
+	loginURL = issuer + "/login?authRequestId=" + authReqID
 	loginForm := url.Values{}
 	loginForm.Set("login", username)
 	loginForm.Set("password", password)
@@ -390,7 +390,7 @@ func TestAuthorizationCodeFlowWithScopes(t *testing.T) {
 	// Should get redirect to login page
 	g.Expect(resp.StatusCode).To(Equal(http.StatusFound))
 	loginURL = resp.Header.Get("Location")
-	g.Expect(loginURL).To(ContainSubstring("/login?authRequestID="))
+	g.Expect(loginURL).To(ContainSubstring("/login?authRequestId="))
 
 	// Follow redirect to get login page
 	resp, err = httpClient.Get(loginURL)
@@ -405,11 +405,11 @@ func TestAuthorizationCodeFlowWithScopes(t *testing.T) {
 	// Extract auth request ID from URL
 	parsedURL, err := url.Parse(loginURL)
 	g.Expect(err).To(BeNil())
-	authReqID := parsedURL.Query().Get("authRequestID")
+	authReqID := parsedURL.Query().Get("authRequestId")
 	g.Expect(authReqID).NotTo(BeEmpty())
 
 	// Step 2: Submit login form
-	loginURL = issuer + "/login?authRequestID=" + authReqID
+	loginURL = issuer + "/login?authRequestId=" + authReqID
 	loginForm := url.Values{}
 	loginForm.Set("login", username)
 	loginForm.Set("password", password)


### PR DESCRIPTION
Support current user editing their own User resource.  Mainly to support user changing their own passwords.
Filter tokens: when not admin must be same subject (current user).
Add _special_ `admin` scope.
Clean up references to unregistered scopes.

Fixes:
- Device auth nil pointer.
- hack/login tool URL fixed.
- pat/apikey subject assignment.
- test/auth integration tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated auth "self" endpoint and explicit RBAC routes for auth, identities, clients, users, roles, and permissions.

* **Refactor**
  * Tightened authorization so non-admins are restricted to their own user/token resources; middleware now enforces resource+verb checks. Permission seeding expanded (including decrypt) and admin handling improved.

* **Chores**
  * Removed an obsolete addon scope and updated seeded role permissions.

* **Tests**
  * Updated auth scope unit tests and OIDC flow tests.

* **Documentation**
  * Expanded authentication staleness/cache docs and standardized LDAP auth lifespan configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->