### PR TITLE
:bug: enable streaming flush for service reverse proxy

### DIFF
--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -82,6 +82,7 @@ func (h ServiceHandler) Forward(ctx *gin.Context) {
 				"route",
 				req.URL.String())
 		},
+		FlushInterval: -1, // Flush immediately for SSE/streaming (MCP, LLM responses)
 	}
 
 	proxy.ServeHTTP(ctx.Writer, ctx.Request)


### PR DESCRIPTION
## Problem

The service proxy in `internal/api/service.go` uses `httputil.ReverseProxy` with default settings, which buffers responses. This causes MCP (Model Context Protocol) clients using SSE (Server-Sent Events) via `StreamableHTTPClientTransport` to hang indefinitely when connecting through the hub's service proxy route (`/hub/services/kai/api`).

The editor-extensions `SolutionServerClient` connects to kai-api via `${hubUrl}/hub/services/kai/api`. The hub correctly routes this to `http://kai-solution-server:8000/api/mcp/`, but the response is never flushed back to the client because Go's default reverse proxy buffers the full response body.

## Fix

Add `FlushInterval: -1` to the `httputil.ReverseProxy`. This enables immediate flushing of each write, which is required for:
- MCP streamable-http transport (SSE-based)
- LLM streaming chat completions
- Any server-sent events through the service proxy

## Impact

This is a one-line change. The only behavioral difference is that streaming responses are flushed immediately instead of buffered — which is the correct behavior for SSE/streaming protocols.

Without this fix, the editor-extensions E2E infrastructure tests (`@requires-minikube`) time out because the MCP connection never completes.

Fixes #1052

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved streaming and server-sent event response performance by enabling immediate data flushing, reducing latency for real-time updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->