### PR TITLE
:sparkles: Dynamic ext idp host

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -33,6 +33,7 @@ func (h AuthHandler) AddRoutes(e *gin.Engine) {
 	e.Any(
 		api.OIDCRoutes+"/*path",
 		func(ctx *gin.Context) {
+			auth.IdP.Ready(ctx.Request)
 			reqCtx := context.WithValue(
 				ctx.Request.Context(),
 				auth.ReqInCtx, // inject

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -24,51 +24,9 @@ type AuthHandler struct {
 
 // AddRoutes adds routes.
 func (h AuthHandler) AddRoutes(e *gin.Engine) {
-	// OIDC routes (hub as provider)
-	baseHandler := auth.IdP.Handler()
-	strippedHandler := http.StripPrefix(api.OIDCRoutes, baseHandler)
-	idpHandler := auth.IdP.IdpHandler()
-	dagHandler := auth.IdP.DagHandler()
-	oidcAuth := dagHandler.OIDCAuth()
-	e.Any(
-		api.OIDCRoutes+"/*path",
-		func(ctx *gin.Context) {
-			auth.IdP.Ready(ctx.Request)
-			reqCtx := context.WithValue(
-				ctx.Request.Context(),
-				auth.ReqInCtx, // inject
-				ctx.Request)
-			ctx.Request = ctx.Request.WithContext(reqCtx)
-			path := ctx.Param("path")
-			switch path {
-			case api.LoginRoute:
-				h.Login(ctx)
-			case api.IdpLoginRoute:
-				if idpHandler != nil {
-					idpHandler.Login(ctx)
-				}
-			case api.IdpCbRoute:
-				if idpHandler != nil {
-					idpHandler.LoginFinished(ctx)
-				}
-			case api.DeviceRoute:
-				oidcAuth.AuthRequired(ctx)
-				if !ctx.IsAborted() {
-					if ctx.Request.Method == http.MethodPost {
-						dagHandler.VerifySubmit(ctx)
-					} else {
-						dagHandler.Verify(ctx)
-					}
-				}
-			case api.DeviceLoginRoute:
-				oidcAuth.Login(ctx)
-			case api.DeviceCbRoute:
-				oidcAuth.Callback(ctx)
-			default:
-				strippedHandler.ServeHTTP(ctx.Writer, ctx.Request)
-			}
-		})
-	// IdpClient routes
+	// OIDC routes.
+	e.Any(api.OIDCRoutes+"/*path", h.OIDC())
+	// IdpClient routes.
 	routeGroup := e.Group("/")
 	routeGroup.Use(Required("idp.clients"))
 	routeGroup.GET(api.IdpClientsRoute, h.IdpClientList)
@@ -1160,6 +1118,54 @@ func (h AuthHandler) GetSelf(ctx *gin.Context) {
 	}
 
 	h.Respond(ctx, http.StatusOK, r)
+}
+
+// OIDC returns the handler for OIDC routes.
+func (h AuthHandler) OIDC() func(*gin.Context) {
+	baseHandler := auth.IdP.Handler()
+	strippedHandler := http.StripPrefix(api.OIDCRoutes, baseHandler)
+	idpHandler := auth.IdP.IdpHandler()
+	dagHandler := auth.IdP.DagHandler()
+	oidcAuth := dagHandler.OIDCAuth()
+
+	return func(ctx *gin.Context) {
+		auth.IdP.Ready(ctx.Request)
+
+		reqCtx := context.WithValue(
+			ctx.Request.Context(),
+			auth.ReqInCtx, // inject
+			ctx.Request)
+		ctx.Request = ctx.Request.WithContext(reqCtx)
+
+		path := ctx.Param("path")
+		switch path {
+		case api.LoginRoute:
+			h.Login(ctx)
+		case api.IdpLoginRoute:
+			if idpHandler != nil {
+				idpHandler.Login(ctx)
+			}
+		case api.IdpCbRoute:
+			if idpHandler != nil {
+				idpHandler.LoginFinished(ctx)
+			}
+		case api.DeviceRoute:
+			oidcAuth.AuthRequired(ctx)
+			if !ctx.IsAborted() {
+				if ctx.Request.Method == http.MethodPost {
+					dagHandler.VerifySubmit(ctx)
+				} else {
+					dagHandler.Verify(ctx)
+				}
+			}
+		case api.DeviceLoginRoute:
+			oidcAuth.Login(ctx)
+		case api.DeviceCbRoute:
+			oidcAuth.Callback(ctx)
+		default:
+			strippedHandler.ServeHTTP(ctx.Writer, ctx.Request)
+		}
+	}
 }
 
 // Auth REST Resources.

--- a/internal/auth/README.md
+++ b/internal/auth/README.md
@@ -765,11 +765,11 @@ sequenceDiagram
 
 ### Configuration
 
-To enable federation to an external OIDC provider, create an `OpenidProvider` Custom Resource:
+To enable federation to an external OIDC provider, create an `IdentityProvider` Custom Resource:
 
 ```yaml
 apiVersion: tackle.konveyor.io/v1alpha1
-kind: OpenidProvider
+kind: IdentityProvider
 metadata:
   name: corporate-sso
   namespace: konveyor-tackle
@@ -805,7 +805,7 @@ Template variables are substituted with values from the incoming HTTP request's 
 
 ```yaml
 apiVersion: tackle.konveyor.io/v1alpha1
-kind: OpenidProvider
+kind: IdentityProvider
 metadata:
   name: corporate-sso
   namespace: konveyor-tackle
@@ -1703,7 +1703,7 @@ OIDC clients (web applications, CLI tools, IDE extensions) are configured using 
 - **Runtime configurability** - Add/modify clients without code changes
 - **Kubernetes-native management** - Use kubectl/operators to manage clients
 - **Secret management** - Reference Kubernetes Secrets for client credentials
-- **Consistent with IdP/LDAP** - Same CRD pattern as OpenidProvider and LdapProvider
+- **Consistent with IdP/LDAP** - Same CRD pattern as IdentityProvider and LdapProvider
 
 ### IdpClient CRD Structure
 

--- a/internal/auth/README.md
+++ b/internal/auth/README.md
@@ -787,6 +787,61 @@ spec:
     - email
 ```
 
+#### Template Variables for Dynamic Deployment
+
+The `issuer` and `redirectURI` fields support **template variables** to enable portable configurations across different deployment environments (localhost, OpenShift routes, custom domains).
+
+Template variables are substituted with values from the incoming HTTP request's issuer URL at runtime:
+
+| Variable | Substitution | Example Request | Result |
+|----------|-------------|-----------------|--------|
+| `${issuer}` | Full issuer URL | `https://hub.example.com:8080/oidc` | `https://hub.example.com:8080/oidc` |
+| `${issuer.proto}` | Protocol/scheme | `https://hub.example.com:8080/oidc` | `https` |
+| `${issuer.host}` | Host (hostname:port) | `https://hub.example.com:8080/oidc` | `hub.example.com:8080` |
+| `${issuer.port}` | Port only | `https://hub.example.com:8080/oidc` | `8080` |
+| `${issuer.path}` | Path only | `https://hub.example.com:8080/oidc` | `/oidc` |
+
+**Example: Portable configuration for OpenShift routes**
+
+```yaml
+apiVersion: tackle.konveyor.io/v1alpha1
+kind: OpenidProvider
+metadata:
+  name: corporate-sso
+  namespace: konveyor-tackle
+spec:
+  name: "Corporate SSO"
+  # External IdP - can use template for dynamic cluster deployments
+  issuer: "${issuer.proto}://${issuer.host}/auth/realms/tackle"
+  clientId: "tackle-hub"
+  clientSecret:
+    name: idp-client-secret
+    namespace: konveyor-tackle
+  # Dynamic redirect URI - uses template to match hub's deployment URL
+  redirectURI: "${issuer.proto}://${issuer.host}/oidc/idp/callback"
+  scopes:
+    - openid
+    - profile
+    - email
+```
+
+**When the hub is accessed at `https://tackle-konveyor-tackle.apps.cluster.example.com/oidc`:**
+- `issuer` becomes: `https://keycloak-tackle-konveyor-tackle.apps.cluster.example.com/auth/realms/tackle`
+- `redirectURI` becomes: `https://tackle-konveyor-tackle.apps.cluster.example.com/oidc/idp/callback`
+
+**Template injection is idempotent:**
+- Variables are injected once on first authentication request
+- Subsequent requests reuse the injected values
+- Thread-safe implementation with mutex protection
+
+**Common patterns:**
+
+| Pattern | Use Case | Example |
+|---------|----------|---------|
+| `${issuer}/callback` | Hub callback endpoint | `https://hub.example.com/oidc/callback` |
+| `https://${issuer.host}/auth` | Same host, different path | `https://hub.example.com:8080/auth` |
+| `${issuer.proto}://${issuer.host}/app` | Match scheme and host | `https://hub.example.com/app` |
+
 If the external IdP requires a client secret, store it in a Kubernetes Secret:
 
 ```yaml

--- a/internal/auth/builtin.go
+++ b/internal/auth/builtin.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-jose/go-jose/v4"
@@ -108,6 +109,7 @@ func NewBuiltin(db *gorm.DB) (builtin *Builtin, err error) {
 
 // Builtin provides OIDC authentication.
 type Builtin struct {
+	ready      sync.Once
 	db         *gorm.DB
 	provider   op.OpenIDProvider
 	idpHandler *FedIdpHandler
@@ -139,6 +141,14 @@ func (p *Builtin) IdpHandler() (h *FedIdpHandler) {
 // Cache returns the provider cache.
 func (p *Builtin) Cache() *Cache {
 	return p.cache
+}
+
+// Ready notification of an incoming request.
+func (p *Builtin) Ready(r *http.Request) {
+	p.ready.Do(func() {
+		federated.Idp.Inject(Issuer(r))
+		Log.Info("Injected:\n" + federated.String())
+	})
 }
 
 // Login handles the custom login page.

--- a/internal/auth/idp.go
+++ b/internal/auth/idp.go
@@ -41,7 +41,11 @@ func (h *FedIdpHandler) Login(ctx *gin.Context) {
 		ctx.AbortWithStatus(http.StatusNotFound)
 		return
 	}
-	federated.Idp.Inject(Issuer(ctx.Request))
+	func() {
+		h.mutex.Lock()
+		defer h.mutex.Unlock()
+		federated.Idp.Inject(Issuer(ctx.Request))
+	}()
 	_, err := h.RpClient()
 	if err != nil {
 		_ = ctx.Error(err)

--- a/internal/auth/idp.go
+++ b/internal/auth/idp.go
@@ -41,11 +41,6 @@ func (h *FedIdpHandler) Login(ctx *gin.Context) {
 		ctx.AbortWithStatus(http.StatusNotFound)
 		return
 	}
-	func() {
-		h.mutex.Lock()
-		defer h.mutex.Unlock()
-		federated.Idp.Inject(Issuer(ctx.Request))
-	}()
 	_, err := h.RpClient()
 	if err != nil {
 		_ = ctx.Error(err)

--- a/internal/auth/idp.go
+++ b/internal/auth/idp.go
@@ -41,6 +41,7 @@ func (h *FedIdpHandler) Login(ctx *gin.Context) {
 		ctx.AbortWithStatus(http.StatusNotFound)
 		return
 	}
+	federated.Idp.Inject(Issuer(ctx.Request))
 	_, err := h.RpClient()
 	if err != nil {
 		_ = ctx.Error(err)

--- a/internal/auth/pkg.go
+++ b/internal/auth/pkg.go
@@ -68,6 +68,8 @@ func New(db *gorm.DB) (p Provider, err error) {
 
 // Provider provides RBAC.
 type Provider interface {
+	// Ready notification of an incoming request.
+	Ready(r *http.Request)
 	// Cache returns the provider cache.
 	Cache() *Cache
 	// Login begin OIDC auth.

--- a/internal/auth/pkg_test.go
+++ b/internal/auth/pkg_test.go
@@ -3267,18 +3267,18 @@ type mockRelyingParty struct {
 	endSessionEndpoint string
 }
 
-func (m *mockRelyingParty) OAuthConfig() *oauth2.Config             { return &oauth2.Config{} }
-func (m *mockRelyingParty) Issuer() string                          { return "" }
-func (m *mockRelyingParty) IsPKCE() bool                            { return false }
+func (m *mockRelyingParty) OAuthConfig() *oauth2.Config              { return &oauth2.Config{} }
+func (m *mockRelyingParty) Issuer() string                           { return "" }
+func (m *mockRelyingParty) IsPKCE() bool                             { return false }
 func (m *mockRelyingParty) CookieHandler() *httphelper.CookieHandler { return nil }
-func (m *mockRelyingParty) HttpClient() *http.Client                { return nil }
-func (m *mockRelyingParty) IsOAuth2Only() bool                      { return false }
-func (m *mockRelyingParty) Signer() jose.Signer                    { return nil }
-func (m *mockRelyingParty) GetEndSessionEndpoint() string           { return m.endSessionEndpoint }
-func (m *mockRelyingParty) GetRevokeEndpoint() string               { return "" }
-func (m *mockRelyingParty) UserinfoEndpoint() string                { return "" }
-func (m *mockRelyingParty) GetDeviceAuthorizationEndpoint() string  { return "" }
-func (m *mockRelyingParty) IDTokenVerifier() *rp.IDTokenVerifier    { return nil }
+func (m *mockRelyingParty) HttpClient() *http.Client                 { return nil }
+func (m *mockRelyingParty) IsOAuth2Only() bool                       { return false }
+func (m *mockRelyingParty) Signer() jose.Signer                      { return nil }
+func (m *mockRelyingParty) GetEndSessionEndpoint() string            { return m.endSessionEndpoint }
+func (m *mockRelyingParty) GetRevokeEndpoint() string                { return "" }
+func (m *mockRelyingParty) UserinfoEndpoint() string                 { return "" }
+func (m *mockRelyingParty) GetDeviceAuthorizationEndpoint() string   { return "" }
+func (m *mockRelyingParty) IDTokenVerifier() *rp.IDTokenVerifier     { return nil }
 func (m *mockRelyingParty) ErrorHandler() func(http.ResponseWriter, *http.Request, string, string, string) {
 	return nil
 }
@@ -3288,8 +3288,8 @@ func (m *mockRelyingParty) Logger(context.Context) (*slog.Logger, bool) { return
 func TestEndSessionURL(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	savedFederated := *federated
-	defer func() { *federated = savedFederated }()
+	savedIdp := federated.Idp
+	defer func() { federated.Idp = savedIdp }()
 
 	federated.Idp = as.IdentityProvider{
 		Enabled:  true,
@@ -3317,8 +3317,8 @@ func TestEndSessionURL(t *testing.T) {
 func TestEndSessionURLNoRedirect(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	savedFederated := *federated
-	defer func() { *federated = savedFederated }()
+	savedIdp := federated.Idp
+	defer func() { federated.Idp = savedIdp }()
 
 	federated.Idp = as.IdentityProvider{
 		Enabled:  true,

--- a/internal/auth/settings/pkg.go
+++ b/internal/auth/settings/pkg.go
@@ -3,6 +3,9 @@ package settings
 import (
 	"context"
 	"crypto/tls"
+	"net/url"
+	"strings"
+	"sync"
 
 	liberr "github.com/jortel/go-utils/error"
 	"github.com/jortel/go-utils/logr"
@@ -50,7 +53,7 @@ func (r *Federated) Load(namespace string) (err error) {
 }
 
 // String returns a string representation.
-func (r Federated) String() (s string) {
+func (r *Federated) String() (s string) {
 	r.Idp.TLS = nil
 	r.Ldap.TLS = nil
 	b, _ := yaml.Marshal(r)
@@ -166,6 +169,8 @@ func (r *Federated) secret(ref *core.ObjectReference, key string) (s string, err
 
 // IdentityProvider defines a federated IdP.
 type IdentityProvider struct {
+	once sync.Once
+	//
 	Enabled      bool
 	Primary      bool
 	Name         string
@@ -175,6 +180,28 @@ type IdentityProvider struct {
 	RedirectURI  string
 	Scopes       []string
 	TLS          *tls.Config
+}
+
+// Inject template values:
+// - ${issuer}
+// - ${issuer.proto}
+// - ${issuer.host}
+// - ${issuer.port}
+// - ${issuer.path}
+func (r *IdentityProvider) Inject(issuer string) {
+	r.once.Do(func() {
+		issuerURL, _ := url.Parse(issuer)
+		for _, u := range []*string{
+			&r.Issuer,
+			&r.RedirectURI,
+		} {
+			*u = strings.Replace(*u, "${issuer}", issuer, -1)
+			*u = strings.Replace(*u, "${issuer.proto}", issuerURL.Scheme, -1)
+			*u = strings.Replace(*u, "${issuer.host}", issuerURL.Hostname(), -1)
+			*u = strings.Replace(*u, "${issuer.port}", issuerURL.Port(), -1)
+			*u = strings.Replace(*u, "${issuer.path}", issuerURL.Path, -1)
+		}
+	})
 }
 
 // with populates self with the crd.

--- a/internal/auth/settings/pkg.go
+++ b/internal/auth/settings/pkg.go
@@ -53,9 +53,10 @@ func (r *Federated) Load(namespace string) (err error) {
 
 // String returns a string representation.
 func (r *Federated) String() (s string) {
-	r.Idp.TLS = nil
-	r.Ldap.TLS = nil
-	b, _ := yaml.Marshal(r)
+	clone := *r
+	clone.Idp.TLS = nil
+	clone.Ldap.TLS = nil
+	b, _ := yaml.Marshal(clone)
 	s = string(b)
 	return
 }

--- a/internal/auth/settings/pkg.go
+++ b/internal/auth/settings/pkg.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"net/url"
 	"strings"
-	"sync"
 
 	liberr "github.com/jortel/go-utils/error"
 	"github.com/jortel/go-utils/logr"
@@ -169,8 +168,6 @@ func (r *Federated) secret(ref *core.ObjectReference, key string) (s string, err
 
 // IdentityProvider defines a federated IdP.
 type IdentityProvider struct {
-	once sync.Once
-	//
 	Enabled      bool
 	Primary      bool
 	Name         string
@@ -180,6 +177,8 @@ type IdentityProvider struct {
 	RedirectURI  string
 	Scopes       []string
 	TLS          *tls.Config
+	//
+	injected bool
 }
 
 // Inject template values:
@@ -188,20 +187,23 @@ type IdentityProvider struct {
 // - ${issuer.host}
 // - ${issuer.port}
 // - ${issuer.path}
+// Note: not thread-safe.
 func (r *IdentityProvider) Inject(issuer string) {
-	r.once.Do(func() {
-		issuerURL, _ := url.Parse(issuer)
-		for _, u := range []*string{
-			&r.Issuer,
-			&r.RedirectURI,
-		} {
-			*u = strings.Replace(*u, "${issuer}", issuer, -1)
-			*u = strings.Replace(*u, "${issuer.proto}", issuerURL.Scheme, -1)
-			*u = strings.Replace(*u, "${issuer.host}", issuerURL.Hostname(), -1)
-			*u = strings.Replace(*u, "${issuer.port}", issuerURL.Port(), -1)
-			*u = strings.Replace(*u, "${issuer.path}", issuerURL.Path, -1)
-		}
-	})
+	if r.injected {
+		return
+	}
+	issuerURL, _ := url.Parse(issuer)
+	for _, u := range []*string{
+		&r.Issuer,
+		&r.RedirectURI,
+	} {
+		*u = strings.Replace(*u, "${issuer}", issuer, -1)
+		*u = strings.Replace(*u, "${issuer.proto}", issuerURL.Scheme, -1)
+		*u = strings.Replace(*u, "${issuer.host}", issuerURL.Hostname(), -1)
+		*u = strings.Replace(*u, "${issuer.port}", issuerURL.Port(), -1)
+		*u = strings.Replace(*u, "${issuer.path}", issuerURL.Path, -1)
+	}
+	r.injected = true
 }
 
 // with populates self with the crd.

--- a/internal/auth/settings/pkg_test.go
+++ b/internal/auth/settings/pkg_test.go
@@ -187,3 +187,140 @@ func TestFederatedGetClientsFields(t *testing.T) {
 	g.Expect(kaiIDE.Grants).To(ContainElement("authorization_code"))
 	g.Expect(kaiIDE.Scopes).To(ContainElement("openid"))
 }
+
+// TestIdentityProviderInject tests template variable injection.
+func TestIdentityProviderInject(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	idp := &IdentityProvider{
+		Issuer:      "https://${issuer.host}/auth",
+		RedirectURI: "${issuer.proto}://${issuer.host}:${issuer.port}/callback",
+	}
+
+	issuer := "https://hub.example.com:8443/oidc"
+	idp.Inject(issuer)
+
+	g.Expect(idp.Issuer).To(Equal("https://hub.example.com/auth"))
+	g.Expect(idp.RedirectURI).To(Equal("https://hub.example.com:8443/callback"))
+}
+
+// TestIdentityProviderInjectIssuerVariable tests ${issuer} template variable.
+func TestIdentityProviderInjectIssuerVariable(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	idp := &IdentityProvider{
+		Issuer:      "${issuer}/external",
+		RedirectURI: "${issuer}/callback",
+	}
+
+	issuer := "https://auth.example.com"
+	idp.Inject(issuer)
+
+	g.Expect(idp.Issuer).To(Equal("https://auth.example.com/external"))
+	g.Expect(idp.RedirectURI).To(Equal("https://auth.example.com/callback"))
+}
+
+// TestIdentityProviderInjectIdempotent tests that Inject() is idempotent.
+func TestIdentityProviderInjectIdempotent(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	idp := &IdentityProvider{
+		Issuer:      "https://${issuer.host}/auth",
+		RedirectURI: "${issuer}/callback",
+	}
+
+	issuer := "https://hub.example.com/oidc"
+
+	// First injection
+	idp.Inject(issuer)
+	firstIssuer := idp.Issuer
+	firstRedirect := idp.RedirectURI
+
+	// Second injection with different issuer
+	idp.Inject("https://different.example.com/oidc")
+
+	// Values should not change (idempotent)
+	g.Expect(idp.Issuer).To(Equal(firstIssuer))
+	g.Expect(idp.RedirectURI).To(Equal(firstRedirect))
+}
+
+// TestIdentityProviderInjectNoTemplates tests Inject() with no template variables.
+func TestIdentityProviderInjectNoTemplates(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	idp := &IdentityProvider{
+		Issuer:      "https://static.example.com/auth",
+		RedirectURI: "https://app.example.com/callback",
+	}
+
+	issuer := "https://hub.example.com/oidc"
+	idp.Inject(issuer)
+
+	// Values should remain unchanged
+	g.Expect(idp.Issuer).To(Equal("https://static.example.com/auth"))
+	g.Expect(idp.RedirectURI).To(Equal("https://app.example.com/callback"))
+}
+
+// TestIdentityProviderInjectAllVariables tests all template variables.
+func TestIdentityProviderInjectAllVariables(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	idp := &IdentityProvider{
+		Issuer:      "${issuer.proto}://${issuer.host}:${issuer.port}${issuer.path}/auth",
+		RedirectURI: "${issuer}/callback",
+	}
+
+	issuer := "https://hub.example.com:9443/oidc"
+	idp.Inject(issuer)
+
+	g.Expect(idp.Issuer).To(Equal("https://hub.example.com:9443/oidc/auth"))
+	g.Expect(idp.RedirectURI).To(Equal("https://hub.example.com:9443/oidc/callback"))
+}
+
+// TestIdentityProviderInjectDefaultPort tests template variables with default port.
+func TestIdentityProviderInjectDefaultPort(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	idp := &IdentityProvider{
+		Issuer:      "https://${issuer.host}:${issuer.port}/auth",
+		RedirectURI: "http://${issuer.host}:${issuer.port}/callback",
+	}
+
+	// HTTPS default port (443) - url.Parse returns empty string for default ports
+	issuer := "https://hub.example.com/oidc"
+	idp.Inject(issuer)
+
+	// When port is default (443 for https), ${issuer.port} expands to empty string
+	g.Expect(idp.Issuer).To(Equal("https://hub.example.com:/auth"))
+	g.Expect(idp.RedirectURI).To(Equal("http://hub.example.com:/callback"))
+}
+
+// TestIdentityProviderInjectConcurrent tests thread-safety of Inject().
+func TestIdentityProviderInjectConcurrent(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	idp := &IdentityProvider{
+		Issuer:      "https://${issuer.host}/auth",
+		RedirectURI: "${issuer}/callback",
+	}
+
+	issuer := "https://hub.example.com/oidc"
+
+	// Call Inject concurrently from multiple goroutines
+	done := make(chan bool, 10)
+	for i := 0; i < 10; i++ {
+		go func() {
+			idp.Inject(issuer)
+			done <- true
+		}()
+	}
+
+	// Wait for all goroutines
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+
+	// Verify injection happened correctly (only once due to idempotency)
+	g.Expect(idp.Issuer).To(Equal("https://hub.example.com/auth"))
+	g.Expect(idp.RedirectURI).To(Equal("https://hub.example.com/oidc/callback"))
+}


### PR DESCRIPTION
closes #1055 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dynamic template variable support (${issuer}, ${issuer.proto}, ${issuer.host}, ${issuer.port}, ${issuer.path}) for IdentityProvider configuration substitution in deployment scenarios.

* **Documentation**
  * Updated IdP federation configuration guidance with template variables and OpenShift-focused examples.

* **Improvements**
  * Enhanced OIDC request handling with readiness validation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->