### PR TITLE
:bug: recover from SSE proxy panics on client disconnect

### DIFF
--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httputil"
@@ -83,7 +84,27 @@ func (h ServiceHandler) Forward(ctx *gin.Context) {
 				req.URL.String())
 		},
 		FlushInterval: -1, // Flush immediately for SSE/streaming (MCP, LLM responses)
+		ErrorHandler: func(rw http.ResponseWriter, req *http.Request, err error) {
+			if req.Context().Err() != nil {
+				return
+			}
+			Log.Error(err, "Proxy error", "path", req.URL.Path)
+		},
 	}
+
+	// httputil.ReverseProxy panics with http.ErrAbortHandler when an SSE/streaming
+	// client disconnects mid-response. Recover gracefully instead of crashing the
+	// request pipeline.
+	defer func() {
+		if r := recover(); r != nil {
+			if err, ok := r.(error); ok && errors.Is(err, http.ErrAbortHandler) {
+				Log.V(1).Info("Client disconnected during proxy streaming",
+					"path", ctx.Request.URL.Path)
+				return
+			}
+			panic(r)
+		}
+	}()
 
 	proxy.ServeHTTP(ctx.Writer, ctx.Request)
 }


### PR DESCRIPTION
## Summary

- Recover from `http.ErrAbortHandler` panics in the service reverse proxy when SSE/streaming clients disconnect mid-response
- Add `ErrorHandler` to suppress noisy error logs when the client context is already cancelled

## Problem

When the VS Code extension establishes MCP streamable-http connections (`GET /services/kai/api` with `Accept: text/event-stream`) and later disconnects, `httputil.ReverseProxy` panics with `net/http: abort Handler`. Gin's recovery middleware catches the panic, but the repeated recoveries destabilize the Hub:

- 13 panics fire in a burst at the same timestamp
- The task scheduler enters `Capacity exceeded: pod creation paused` state
- `/hub/auth/tokens` becomes unresponsive for minutes
- Downstream clients (profile sync, solution server) can't authenticate

**Full logs and reproduction steps:** https://github.com/konveyor/tackle2-hub/issues/1057

## Fix

Two changes in `internal/api/service.go`:

1. **`defer recover()`** — catches `http.ErrAbortHandler` panics specifically and logs at debug level. Any other panic is re-raised so existing error handling is preserved.

2. **`ErrorHandler` on the reverse proxy** — suppresses error logging when `req.Context().Err() != nil` (client already disconnected). Real proxy errors (backend unreachable, etc.) are still logged.

## Test plan

- [ ] Verify Hub builds: `go build ./...`
- [ ] Verify existing tests pass: `go test ./internal/api/...`
- [ ] Deploy to minikube, connect VS Code extension with solution server enabled, disconnect — confirm no panics in Hub logs
- [ ] Confirm SSE/MCP streaming to kai-api still works normally

Fixes https://github.com/konveyor/tackle2-hub/issues/1057