### PR TITLE
:bug: recover from SSE proxy panics on client disconnect

### DIFF
--- a/internal/api/service.go
+++ b/internal/api/service.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httputil"
@@ -83,7 +84,27 @@ func (h ServiceHandler) Forward(ctx *gin.Context) {
 				req.URL.String())
 		},
 		FlushInterval: -1, // Flush immediately for SSE/streaming (MCP, LLM responses)
+		ErrorHandler: func(rw http.ResponseWriter, req *http.Request, err error) {
+			if req.Context().Err() != nil {
+				return
+			}
+			Log.Error(err, "Proxy error", "path", req.URL.Path)
+		},
 	}
+
+	// httputil.ReverseProxy panics with http.ErrAbortHandler when an SSE/streaming
+	// client disconnects mid-response. Recover gracefully instead of crashing the
+	// request pipeline.
+	defer func() {
+		if r := recover(); r != nil {
+			if err, ok := r.(error); ok && errors.Is(err, http.ErrAbortHandler) {
+				Log.V(1).Info("Client disconnected during proxy streaming",
+					"path", ctx.Request.URL.Path)
+				return
+			}
+			panic(r)
+		}
+	}()
 
 	proxy.ServeHTTP(ctx.Writer, ctx.Request)
 }


### PR DESCRIPTION
## Summary

- Fix `httputil.ReverseProxy` panics (`net/http: abort Handler`) that occur when SSE/streaming clients disconnect mid-response in `ServiceHandler.Forward`
- Add `ErrorHandler` to suppress noisy error logging when the client context is already cancelled
- Add `defer/recover` to catch `http.ErrAbortHandler` panics gracefully, re-panicking on any other panic type

## Problem

When an MCP SSE client (e.g., the editor extension's `StreamableHTTPClientTransport`) disconnects while the Hub is streaming a response via the reverse proxy at `service.go:88`, the proxy panics with `net/http: abort Handler`. GIN's Recovery middleware catches each panic, but the cascade (595 panics observed in a single test run) degrades the Hub — subsequent requests hang or timeout.

### Stack trace

```
GET /services/kai/api HTTP/1.1
Accept: text/event-stream

net/http: abort Handler
/usr/lib/golang/src/net/http/httputil/reverseproxy.go:613
/opt/app-root/src/internal/api/service.go:88
```

## Fix

1. **`ErrorHandler`**: When the client's request context is cancelled (i.e., they disconnected), return silently instead of logging a proxy error.
2. **`defer/recover`**: Catch `http.ErrAbortHandler` panics and log at debug level. Any other panic is re-raised so it isn't silently swallowed.

## Test plan

- [x] Verified fix eliminates all 595 panics in editor-extensions e2e test suite (zero panics after fix vs. 595 before)
- [x] Built and deployed patched image to minikube cluster, confirmed Hub remains healthy throughout full test run
- [ ] Existing Hub unit/integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of client disconnections in streaming scenarios
  * Enhanced error logging for increased stability and reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->