### PR TITLE
:bug: Fix auth.Cache mutex

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -181,8 +181,8 @@ func main() {
 			rtx.TaskManager = taskManager
 			rtx.DB = db
 			rtx.Client = client
+			defer rtx.Detach()
 			ctx.Next()
-			rtx.Detach()
 		})
 	router.Use(api.Render())
 	router.Use(api.ErrorHandler())

--- a/internal/api/context.go
+++ b/internal/api/context.go
@@ -107,8 +107,10 @@ func Transaction(ctx *gin.Context) {
 		err := rtx.DB.Transaction(func(tx *gorm.DB) (err error) {
 			db := rtx.DB
 			rtx.DB = tx
+			defer func() {
+				rtx.DB = db
+			}()
 			ctx.Next()
-			rtx.DB = db
 			if len(ctx.Errors) > 0 {
 				err = ctx.Errors[0]
 				ctx.Errors = nil

--- a/internal/api/resource/pkg_test.go
+++ b/internal/api/resource/pkg_test.go
@@ -3787,7 +3787,6 @@ func TestToken_With(t *testing.T) {
 	userID := uint(5)
 	issued := time.Now()
 	expiration := issued.Add(5 * time.Minute)
-	revoked := issued.Add(3 * time.Minute)
 
 	m := &model.Token{
 		Model: model.Model{
@@ -3801,7 +3800,6 @@ func TestToken_With(t *testing.T) {
 		Scopes:     []string{"openid", "profile", "email"},
 		Issued:     issued,
 		Expiration: expiration,
-		Revoked:    revoked,
 		UserID:     &userID,
 		User: &model.User{
 			Model: model.Model{ID: 5},

--- a/internal/auth/builtin.go
+++ b/internal/auth/builtin.go
@@ -26,6 +26,10 @@ func NewBuiltin(db *gorm.DB) (builtin *Builtin, err error) {
 		cache: cache,
 		db:    db,
 	}
+	err = cache.Refresh()
+	if err != nil {
+		return
+	}
 	keyManager := NewKeyManager(db)
 	builtin.keySet, err = keyManager.KeySet()
 	if err != nil {
@@ -200,7 +204,6 @@ func (p *Builtin) TaskGrant(taskId uint) (m Token, err error) {
 		return
 	}
 	p.cache.TokenSaved(&m)
-	p.cache.TaskGranted(taskId)
 	return
 }
 

--- a/internal/auth/cache/cache.go
+++ b/internal/auth/cache/cache.go
@@ -178,13 +178,13 @@ func (r *Cache) FindToken(token string) (m *Token, err error) {
 			return
 		}
 		m.Subject = user.Subject
-		m.Scopes = strings.Join(user.GetScopes(r), " ")
+		m.Scopes = user.GetScopes(r)
 		return
 	}
 	// task binding.
 	if m.TaskID != nil {
 		m.Subject = "task:" + strconv.Itoa(int(*m.TaskID))
-		m.Scopes = strings.Join(AddonScopes, " ")
+		m.Scopes = AddonScopes
 		return
 	}
 	// IdP identity binding.
@@ -198,7 +198,7 @@ func (r *Cache) FindToken(token string) (m *Token, err error) {
 			return
 		}
 		m.Subject = identity.Subject
-		m.Scopes = identity.Scopes
+		m.Scopes = strings.Fields(identity.Scopes)
 		return
 	}
 	// IdP client binding.
@@ -212,7 +212,7 @@ func (r *Cache) FindToken(token string) (m *Token, err error) {
 			return
 		}
 		m.Subject = client.Subject
-		m.Scopes = strings.Join(client.GetScopes(), " ")
+		m.Scopes = client.GetScopes()
 		return
 	}
 	return

--- a/internal/auth/cache/cache.go
+++ b/internal/auth/cache/cache.go
@@ -4,19 +4,26 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	liberr "github.com/jortel/go-utils/error"
+	"github.com/jortel/go-utils/logr"
 	"github.com/konveyor/tackle2-hub/internal/secret"
-	"github.com/konveyor/tackle2-hub/shared/task"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
 
+var (
+	Log = logr.WithName("auth.cache")
+)
+
 // New returns a cache.
 func New(db *gorm.DB) (cache *Cache) {
+	d := Data{}
+	d.reset()
 	cache = &Cache{db: db}
-	cache.reset()
+	cache.data.Store(&d)
 	return
 }
 
@@ -28,38 +35,33 @@ func New(db *gorm.DB) (cache *Cache) {
 //   - Safety-net: Periodic refresh.
 //   - Password changes, role updates, and other changes are propagated
 //     immediately via notifications
+//
+// The cache is optimized for reads. Concurrent reads are safe
+// because of the copy-on-write behavior. The txMutex just ensures
+// Tx are committed sequentially.
 type Cache struct {
-	db              *gorm.DB
-	mutex           sync.RWMutex
-	permById        map[uint]*Permission
-	roleById        map[uint]*Role
-	roleByName      map[string]*Role
-	userById        map[uint]*User
-	userBySubject   map[string]*User
-	userByLogin     map[string]*User
-	taskById        map[uint]*Task
-	identById       map[uint]*Identity
-	identBySubject  map[string]*Identity
-	identByLogin    map[string]*Identity
-	clientById      map[uint]*IdpClient
-	clientBySubject map[string]*IdpClient
-	tokenById       map[uint]*Token
-	tokenByDigest   map[string]*Token
-	refreshed       time.Time
+	txMutex     sync.Mutex
+	data        atomic.Pointer[Data]
+	refreshOnce sync.Once
+	db          *gorm.DB
 }
 
 // Reset clears all cached data.
 func (r *Cache) Reset() {
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
-	r.reset()
+	d := Data{}
+	d.reset()
+	r.data.Store(&d)
 }
 
 // Refresh reloads all data from the database.
 func (r *Cache) Refresh() (err error) {
-	r.mutex.Lock()
-	defer r.mutex.Unlock()
-	err = r.refresh()
+	d := Data{}
+	d.reset()
+	err = d.refresh(r.db)
+	if err != nil {
+		return
+	}
+	r.data.Store(&d)
 	return
 }
 
@@ -91,14 +93,6 @@ func (r *Cache) UserSaved(m *User) {
 func (r *Cache) UserDeleted(id uint) {
 	_ = r.Transaction(func(tx *Tx) (_ error) {
 		tx.UserDeleted(id)
-		return
-	})
-}
-
-// TaskGranted task token granted.
-func (r *Cache) TaskGranted(id uint) {
-	_ = r.Transaction(func(tx *Tx) (_ error) {
-		tx.TaskGranted(id)
 		return
 	})
 }
@@ -161,44 +155,103 @@ func (r *Cache) TokenDeleted(id uint) {
 
 // FindToken returns a PAT.
 func (r *Cache) FindToken(token string) (m *Token, err error) {
-	err = r.ensureFresh()
-	if err != nil {
+	defer r.ensureRefreshed()
+	d := r.data.Load()
+	cached, found := d.tokenByDigest[secret.Hash(token)]
+	if !found {
+		err = &NotFound{
+			Resource: "token",
+			Id:       token,
+		}
 		return
 	}
-	r.mutex.RLock()
-	defer r.mutex.RUnlock()
-	m, err = r.getToken(token)
+	// Create a copy to avoid modifying cached instance
+	m = &Token{Token: cached.Token}
+	// user binding.
+	if m.UserID != nil {
+		user, found := d.userById[*m.UserID]
+		if !found {
+			err = &NotFound{
+				Resource: "user",
+				Id:       strconv.Itoa(int(*m.UserID)),
+			}
+			return
+		}
+		m.Subject = user.Subject
+		m.Scopes = strings.Join(user.GetScopes(r), " ")
+		return
+	}
+	// task binding.
+	if m.TaskID != nil {
+		m.Subject = "task:" + strconv.Itoa(int(*m.TaskID))
+		m.Scopes = strings.Join(AddonScopes, " ")
+		return
+	}
+	// IdP identity binding.
+	if m.IdpIdentityID != nil {
+		identity, found := d.identById[*m.IdpIdentityID]
+		if !found {
+			err = &NotFound{
+				Resource: "identity",
+				Id:       strconv.Itoa(int(*m.IdpIdentityID)),
+			}
+			return
+		}
+		m.Subject = identity.Subject
+		m.Scopes = identity.Scopes
+		return
+	}
+	// IdP client binding.
+	if m.IdpClientID != nil {
+		client, found := d.clientById[*m.IdpClientID]
+		if !found {
+			err = &NotFound{
+				Resource: "client",
+				Id:       strconv.Itoa(int(*m.IdpClientID)),
+			}
+			return
+		}
+		m.Subject = client.Subject
+		m.Scopes = strings.Join(client.GetScopes(), " ")
+		return
+	}
 	return
 }
 
 // FindSubject returns a subject.
-func (r *Cache) FindSubject(subject string) (m *Subject, err error) {
-	err = r.ensureFresh()
-	if err != nil {
+func (r *Cache) FindSubject(subject string) (s *Subject, err error) {
+	defer r.ensureRefreshed()
+	d := r.data.Load()
+	user, found := d.userBySubject[subject]
+	if found {
+		s = &Subject{}
+		s.WithUser(user, r)
 		return
 	}
-	r.mutex.RLock()
-	defer r.mutex.RUnlock()
-	var found bool
-	m, found = r.findSubject(subject)
-	if !found {
-		err = &NotFound{
-			Resource: "subject",
-			Id:       subject,
-		}
+	identity, found := d.identBySubject[subject]
+	if found {
+		s = &Subject{}
+		s.WithIdentity(identity)
+		return
+	}
+	client, found := d.clientBySubject[subject]
+	if found {
+		s = &Subject{}
+		s.WithClient(client, r)
+		return
+	}
+	err = &NotFound{
+		Resource: "subject",
+		Id:       subject,
 	}
 	return
 }
 
 // FindIdentityByLogin finds and returns identities by login.
 func (r *Cache) FindIdentityByLogin(login string) (m *Identity, err error) {
-	err = r.ensureFresh()
-	if err != nil {
-		return
-	}
-	r.mutex.RLock()
-	defer r.mutex.RUnlock()
-	m, found := r.identByLogin[login]
+	defer r.ensureRefreshed()
+	d := r.data.Load()
+	m, found := d.identByLogin[login]
 	if !found {
 		err = &NotFound{
 			Resource: "identity",
@@ -210,13 +263,9 @@ func (r *Cache) FindIdentityByLogin(login string) (m *Identity, err error) {
 
 // FindRoleById return a role by id.
 func (r *Cache) FindRoleById(id uint) (m *Role, err error) {
-	err = r.ensureFresh()
-	if err != nil {
-		return
-	}
-	r.mutex.RLock()
-	defer r.mutex.RUnlock()
-	m, found := r.roleById[id]
+	defer r.ensureRefreshed()
+	d := r.data.Load()
+	m, found := d.roleById[id]
 	if !found {
 		err = &NotFound{
 			Resource: "Role",
@@ -228,13 +277,9 @@ func (r *Cache) FindRoleById(id uint) (m *Role, err error) {
 
 // FindRoleByName return a role by name.
 func (r *Cache) FindRoleByName(name string) (m *Role, err error) {
-	err = r.ensureFresh()
-	if err != nil {
-		return
-	}
-	r.mutex.RLock()
-	defer r.mutex.RUnlock()
-	m, found := r.roleByName[name]
+	defer r.ensureRefreshed()
+	d := r.data.Load()
+	m, found := d.roleByName[name]
 	if !found {
 		err = &NotFound{
 			Resource: "Role",
@@ -246,53 +291,13 @@ func (r *Cache) FindRoleByName(name string) (m *Role, err error) {
 
 // FindUserByLogin returns a user by login.
 func (r *Cache) FindUserByLogin(login string) (m *User, err error) {
-	err = r.ensureFresh()
-	if err != nil {
-		return
-	}
-	r.mutex.RLock()
-	defer r.mutex.RUnlock()
-	m, found := r.userByLogin[login]
+	defer r.ensureRefreshed()
+	d := r.data.Load()
+	m, found := d.userByLogin[login]
 	if !found {
 		err = &NotFound{
 			Resource: "user",
 			Id:       login,
-		}
-	}
-	return
-}
-
-// FindTaskById returns a task by ID.
-func (r *Cache) FindTaskById(id uint) (m *Task, err error) {
-	err = r.ensureFresh()
-	if err != nil {
-		return
-	}
-	r.mutex.RLock()
-	defer r.mutex.RUnlock()
-	m, found := r.taskById[id]
-	if !found {
-		err = &NotFound{
-			Resource: "task",
-			Id:       strconv.Itoa(int(id)),
-		}
-	}
-	return
-}
-
-// ensureFresh refreshes the cache if CacheLifespan has elapsed.
-func (r *Cache) ensureFresh() (err error) {
-	var needsRefresh bool
-	func() {
-		r.mutex.RLock()
-		defer r.mutex.RUnlock()
-		needsRefresh = time.Since(r.refreshed) > Settings.CacheLifespan
-	}()
-	if needsRefresh {
-		r.mutex.Lock()
-		defer r.mutex.Unlock()
-		if time.Since(r.refreshed) > Settings.CacheLifespan {
-			err = r.refresh()
 		}
 	}
 	return
@@ -303,8 +308,8 @@ func (r *Cache) ensureFresh() (err error) {
 // Changes are applied atomically on Commit().
 func (r *Cache) Begin() (tx *Tx) {
 	tx = &Tx{
+		changes: make([]func(*Data), 0),
 		cache:   r,
-		changes: make([]func(), 0),
 	}
 	return
 }
@@ -322,131 +327,166 @@ func (r *Cache) Transaction(fn func(*Tx) error) (err error) {
 	return
 }
 
-// reset allocate cache content backing maps.
-func (r *Cache) reset() {
-	r.permById = make(map[uint]*Permission)
-	r.roleById = make(map[uint]*Role)
-	r.roleByName = make(map[string]*Role)
-	r.userById = make(map[uint]*User)
-	r.userBySubject = make(map[string]*User)
-	r.userByLogin = make(map[string]*User)
-	r.taskById = make(map[uint]*Task)
-	r.tokenById = make(map[uint]*Token)
-	r.identById = make(map[uint]*Identity)
-	r.identBySubject = make(map[string]*Identity)
-	r.identByLogin = make(map[string]*Identity)
-	r.clientById = make(map[uint]*IdpClient)
-	r.clientBySubject = make(map[string]*IdpClient)
-	r.tokenByDigest = make(map[string]*Token)
-	r.refreshed = time.Time{}
+// ensureRefreshed detected the cache is stale and
+// refresh (Asynchronously) as needed.
+func (r *Cache) ensureRefreshed() {
+	d := r.data.Load()
+	if time.Since(d.refreshed) < Settings.CacheLifespan {
+		return
+	}
+	d.refreshOnce.Do(func() {
+		go func() {
+			err := r.Refresh()
+			if err != nil {
+				Log.Error(err, "REFRESH FAILED:"+err.Error())
+				r.Reset()
+			}
+		}()
+	})
+}
+
+// Data contains cached maps.
+type Data struct {
+	refreshOnce sync.Once
+	refreshed   time.Time
+	//
+	permById        map[uint]*Permission
+	roleById        map[uint]*Role
+	roleByName      map[string]*Role
+	userById        map[uint]*User
+	userBySubject   map[string]*User
+	userByLogin     map[string]*User
+	identById       map[uint]*Identity
+	identBySubject  map[string]*Identity
+	identByLogin    map[string]*Identity
+	clientById      map[uint]*IdpClient
+	clientBySubject map[string]*IdpClient
+	tokenById       map[uint]*Token
+	tokenByDigest   map[string]*Token
+}
+
+// reset creates new maps.
+func (d *Data) reset() {
+	d.permById = make(map[uint]*Permission)
+	d.roleById = make(map[uint]*Role)
+	d.roleByName = make(map[string]*Role)
+	d.userById = make(map[uint]*User)
+	d.userBySubject = make(map[string]*User)
+	d.userByLogin = make(map[string]*User)
+	d.tokenById = make(map[uint]*Token)
+	d.identById = make(map[uint]*Identity)
+	d.identBySubject = make(map[string]*Identity)
+	d.identByLogin = make(map[string]*Identity)
+	d.clientById = make(map[uint]*IdpClient)
+	d.clientBySubject = make(map[string]*IdpClient)
+	d.tokenByDigest = make(map[string]*Token)
+}
+
+// clone returns cloned data.
+// the refreshed timestamp is copied, but the
+// refreshOnce is new.
+func (d *Data) clone() *Data {
+	return &Data{
+		refreshOnce:     sync.Once{},
+		refreshed:       d.refreshed,
+		permById:        cloneMap(d.permById),
+		roleById:        cloneMap(d.roleById),
+		roleByName:      cloneMap(d.roleByName),
+		userById:        cloneMap(d.userById),
+		userBySubject:   cloneMap(d.userBySubject),
+		userByLogin:     cloneMap(d.userByLogin),
+		tokenById:       cloneMap(d.tokenById),
+		identById:       cloneMap(d.identById),
+		identBySubject:  cloneMap(d.identBySubject),
+		identByLogin:    cloneMap(d.identByLogin),
+		clientById:      cloneMap(d.clientById),
+		clientBySubject: cloneMap(d.clientBySubject),
+		tokenByDigest:   cloneMap(d.tokenByDigest),
+	}
 }
 
 // refresh cached content.
-func (r *Cache) refresh() (err error) {
-	r.reset()
-	err = r.getPerms()
+func (d *Data) refresh(db *gorm.DB) (err error) {
+	d.reset()
+	err = d.getPerms(db)
 	if err != nil {
 		return
 	}
-	err = r.getRoles()
+	err = d.getRoles(db)
 	if err != nil {
 		return
 	}
-	err = r.getUsers()
+	err = d.getUsers(db)
 	if err != nil {
 		return
 	}
-	err = r.getTasks()
+	err = d.getIdentities(db)
 	if err != nil {
 		return
 	}
-	err = r.getIdentities()
+	err = d.getClients(db)
 	if err != nil {
 		return
 	}
-	err = r.getClients()
+	err = d.getTokens(db)
 	if err != nil {
 		return
 	}
-	err = r.getTokens()
-	if err != nil {
-		return
-	}
-	r.refreshed = time.Now()
+	d.refreshed = time.Now()
 	return
 }
 
 // getPerms fetches permissions from the DB and populates.
-func (r *Cache) getPerms() (err error) {
+func (d *Data) getPerms(db *gorm.DB) (err error) {
 	list := make([]*Permission, 0)
-	err = r.db.Find(&list).Error
+	err = db.Find(&list).Error
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
 	}
 	for _, m := range list {
-		r.permById[m.ID] = m
+		d.permById[m.ID] = m
 	}
 	return
 }
 
 // getRoles fetches roles from the DB and populates.
-func (r *Cache) getRoles() (err error) {
+func (d *Data) getRoles(db *gorm.DB) (err error) {
 	list := make([]*Role, 0)
-	db := r.db.Preload(clause.Associations)
+	db = db.Preload(clause.Associations)
 	err = db.Find(&list).Error
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
 	}
 	for _, m := range list {
-		r.roleById[m.ID] = m
-		r.roleByName[m.Name] = m
+		d.roleById[m.ID] = m
+		d.roleByName[m.Name] = m
 	}
 	return
 }
 
 // getUsers fetches users from the DB and populates.
-func (r *Cache) getUsers() (err error) {
+func (d *Data) getUsers(db *gorm.DB) (err error) {
 	list := make([]*User, 0)
-	db := r.db.Preload(clause.Associations)
+	db = db.Preload(clause.Associations)
 	err = db.Find(&list).Error
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
 	}
 	for _, m := range list {
-		r.userById[m.ID] = m
-		r.userBySubject[m.Subject] = m
-		r.userByLogin[m.Login] = m
-	}
-	return
-}
-
-// getTasks fetches tasks state=(pending|running) from the DB and populates.
-func (r *Cache) getTasks() (err error) {
-	list := make([]*Task, 0)
-	err = r.db.Find(
-		&list,
-		"state IN ?",
-		[]string{
-			task.Pending,
-			task.Running,
-		}).Error
-	if err != nil {
-		err = liberr.Wrap(err)
-		return
-	}
-	for _, m := range list {
-		r.taskById[m.ID] = m
+		d.userById[m.ID] = m
+		d.userBySubject[m.Subject] = m
+		d.userByLogin[m.Login] = m
 	}
 	return
 }
 
 // getIdentities fetches idp identities from the DB and populates.
-func (r *Cache) getIdentities() (err error) {
+func (d *Data) getIdentities(db *gorm.DB) (err error) {
 	list := make([]*Identity, 0)
-	err = r.db.Find(&list).Error
+	err = db.Find(&list).Error
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
@@ -454,9 +494,9 @@ func (r *Cache) getIdentities() (err error) {
 	for _, m := range list {
 		err = secret.Decrypt(m)
 		if err == nil {
-			r.identById[m.ID] = m
-			r.identBySubject[m.Subject] = m
-			r.identByLogin[m.Login] = m
+			d.identById[m.ID] = m
+			d.identBySubject[m.Subject] = m
+			d.identByLogin[m.Login] = m
 		} else {
 			return
 		}
@@ -465,24 +505,24 @@ func (r *Cache) getIdentities() (err error) {
 }
 
 // getClients fetches idp clients from the DB and populates.
-func (r *Cache) getClients() (err error) {
+func (d *Data) getClients(db *gorm.DB) (err error) {
 	list := make([]*IdpClient, 0)
-	err = r.db.Find(&list).Error
+	err = db.Find(&list).Error
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
 	}
 	for _, m := range list {
-		r.clientById[m.ID] = m
-		r.clientBySubject[m.Subject] = m
+		d.clientById[m.ID] = m
+		d.clientBySubject[m.Subject] = m
 	}
 	return
 }
 
 // getTokens fetches permissions from the DB and populates.
-func (r *Cache) getTokens() (err error) {
+func (d *Data) getTokens(db *gorm.DB) (err error) {
 	list := []*Token{}
-	db := r.db.Preload(clause.Associations)
+	db = db.Preload(clause.Associations)
 	db = db.Where("kind", KindAPIKey)
 	db = db.Where("expiration > ?", time.Now())
 	err = db.Find(&list).Error
@@ -491,102 +531,20 @@ func (r *Cache) getTokens() (err error) {
 		return
 	}
 	for _, m := range list {
-		r.tokenById[m.ID] = m
-		r.tokenByDigest[m.Digest] = m
+		d.tokenById[m.ID] = m
+		d.tokenByDigest[m.Digest] = m
 	}
 	return
 }
 
-// getToken returns a PAT.
-func (r *Cache) getToken(token string) (m *Token, err error) {
-	cached, found := r.tokenByDigest[secret.Hash(token)]
-	if !found {
-		err = &NotFound{
-			Resource: "token",
-			Id:       token,
-		}
-		return
+// cloneMap returns a shallow clone.
+func cloneMap[K comparable, V any](m map[K]V) (m2 map[K]V) {
+	if m == nil {
+		return nil
 	}
-	// Create a copy to avoid modifying cached instance
-	m = &Token{Token: cached.Token}
-	// user binding.
-	if m.UserID != nil {
-		user, found := r.userById[*m.UserID]
-		if !found {
-			err = &NotFound{
-				Resource: "user",
-				Id:       strconv.Itoa(int(*m.UserID)),
-			}
-			return
-		}
-		m.Subject = user.Subject
-		m.Scopes = user.GetScopes(r)
-		return
-	}
-	// task binding.
-	if m.TaskID != nil {
-		task, found := r.taskById[*m.TaskID]
-		if !found {
-			err = &NotFound{
-				Resource: "task",
-				Id:       strconv.Itoa(int(*m.TaskID)),
-			}
-			return
-		}
-		m.Subject = "task:" + strconv.Itoa(int(task.ID))
-		m.Scopes = AddonScopes
-		return
-	}
-	// IdP identity binding.
-	if m.IdpIdentityID != nil {
-		identity, found := r.identById[*m.IdpIdentityID]
-		if !found {
-			err = &NotFound{
-				Resource: "identity",
-				Id:       strconv.Itoa(int(*m.IdpIdentityID)),
-			}
-			return
-		}
-		m.Subject = identity.Subject
-		m.Scopes = strings.Fields(identity.Scopes)
-		return
-	}
-	// IdP client binding.
-	if m.IdpClientID != nil {
-		client, found := r.clientById[*m.IdpClientID]
-		if !found {
-			err = &NotFound{
-				Resource: "client",
-				Id:       strconv.Itoa(int(*m.IdpClientID)),
-			}
-			return
-		}
-		m.Subject = client.Subject
-		m.Scopes = client.GetScopes()
-		return
-	}
-	return
-}
-
-// findSubject returns the subject.
-func (r *Cache) findSubject(subject string) (s *Subject, found bool) {
-	user, found := r.userBySubject[subject]
-	if found {
-		s = &Subject{}
-		s.WithUser(user, r)
-		return
-	}
-	identity, found := r.identBySubject[subject]
-	if found {
-		s = &Subject{}
-		s.WithIdentity(identity)
-		return
-	}
-	client, found := r.clientBySubject[subject]
-	if found {
-		s = &Subject{}
-		s.WithClient(client, r)
-		return
+	m2 = make(map[K]V, len(m))
+	for k, v := range m {
+		m2[k] = v
 	}
 	return
 }

--- a/internal/auth/cache/cache.go
+++ b/internal/auth/cache/cache.go
@@ -38,7 +38,7 @@ func New(db *gorm.DB) (cache *Cache) {
 //
 // The cache is optimized for reads. Concurrent reads are safe
 // because of the copy-on-write behavior. The txMutex just ensures
-// Tx are committed sequentially.
+// Tx, Reset and Refresh are committed sequentially.
 type Cache struct {
 	txMutex     sync.Mutex
 	data        atomic.Pointer[Data]
@@ -48,6 +48,8 @@ type Cache struct {
 
 // Reset clears all cached data.
 func (r *Cache) Reset() {
+	r.txMutex.Lock()
+	defer r.txMutex.Unlock()
 	d := Data{}
 	d.reset()
 	r.data.Store(&d)
@@ -55,6 +57,8 @@ func (r *Cache) Reset() {
 
 // Refresh reloads all data from the database.
 func (r *Cache) Refresh() (err error) {
+	r.txMutex.Lock()
+	defer r.txMutex.Unlock()
 	d := Data{}
 	d.reset()
 	err = d.refresh(r.db)

--- a/internal/auth/cache/pkg.go
+++ b/internal/auth/cache/pkg.go
@@ -48,7 +48,7 @@ func (m *User) GetScopes(cache *Cache) (scopes []string) {
 // Role alias.
 type Role model.Role
 
-// ScopeNames returns the roles scopes.
+// GetScopes returns the roles scopes.
 func (m *Role) GetScopes() (scopes []string) {
 	for _, p := range m.Permissions {
 		scopes = append(scopes, p.Scope)

--- a/internal/auth/cache/pkg_test.go
+++ b/internal/auth/cache/pkg_test.go
@@ -74,14 +74,23 @@ func TestCacheEntityUpdates(t *testing.T) {
 	_, err = cache.FindUserByLogin("testuser")
 	g.Expect(err).NotTo(BeNil())
 
-	// Test TaskGranted/TaskRevoked
+	// Test TokenSaved/TaskRevoked
 	taskID := uint(300)
-	cache.TaskGranted(taskID)
-	_, err = cache.FindTaskById(taskID)
+	taskToken := &Token{
+		Token: model.Token{
+			Model:      Model{ID: 300},
+			TaskID:     &taskID,
+			Digest:     secret.Hash("task-token-300"),
+			Expiration: time.Now().Add(24 * time.Hour),
+		},
+		Secret: "task-token-300",
+	}
+	cache.TokenSaved(taskToken)
+	_, err = cache.FindToken("task-token-300")
 	g.Expect(err).To(BeNil())
 
 	cache.TaskRevoked(taskID)
-	_, err = cache.FindTaskById(taskID)
+	_, err = cache.FindToken("task-token-300")
 	g.Expect(err).NotTo(BeNil())
 
 	// Test IdentitySaved/IdentityDeleted
@@ -129,10 +138,9 @@ func TestCacheTransaction(t *testing.T) {
 	g.Expect(err).To(BeNil())
 
 	// Both roles should be in cache
-	cache.mutex.RLock()
-	_, found1 := cache.roleById[101]
-	_, found2 := cache.roleById[102]
-	cache.mutex.RUnlock()
+	d := cache.data.Load()
+	_, found1 := d.roleById[101]
+	_, found2 := d.roleById[102]
 	g.Expect(found1).To(BeTrue())
 	g.Expect(found2).To(BeTrue())
 
@@ -149,9 +157,8 @@ func TestCacheTransaction(t *testing.T) {
 	g.Expect(err).NotTo(BeNil())
 
 	// Role3 should NOT be in cache (rolled back)
-	cache.mutex.RLock()
-	_, found3 := cache.roleById[103]
-	cache.mutex.RUnlock()
+	d = cache.data.Load()
+	_, found3 := d.roleById[103]
 	g.Expect(found3).To(BeFalse())
 
 	// Test explicit Begin/Commit/Rollback
@@ -164,9 +171,8 @@ func TestCacheTransaction(t *testing.T) {
 	tx.UserSaved(user)
 	tx.Commit()
 
-	cache.mutex.RLock()
-	_, foundUser := cache.userById[201]
-	cache.mutex.RUnlock()
+	d = cache.data.Load()
+	_, foundUser := d.userById[201]
 	g.Expect(foundUser).To(BeTrue())
 
 	// Test rollback
@@ -179,9 +185,8 @@ func TestCacheTransaction(t *testing.T) {
 	tx.UserSaved(user2)
 	tx.Rollback() // Discard changes
 
-	cache.mutex.RLock()
-	_, foundUser2 := cache.userById[202]
-	cache.mutex.RUnlock()
+	d = cache.data.Load()
+	_, foundUser2 := d.userById[202]
 	g.Expect(foundUser2).To(BeFalse())
 }
 
@@ -206,10 +211,8 @@ func TestCacheDoubleCheckRefresh(t *testing.T) {
 	err = cache.Refresh()
 	g.Expect(err).To(BeNil())
 
-	// Force cache to be stale
-	cache.mutex.Lock()
-	cache.refreshed = time.Now().Add(-10 * time.Minute)
-	cache.mutex.Unlock()
+	// Force cache to be stale - not needed with new design
+	// (background refresh runs independently)
 
 	// Launch multiple concurrent calls to FindUserByLogin (which calls ensureFresh)
 	var wg sync.WaitGroup
@@ -259,37 +262,15 @@ func TestCacheInconsistency(t *testing.T) {
 			Digest: userTokenDigest,
 		},
 	}
-	cache.mutex.Lock()
-	cache.tokenByDigest[userTokenDigest] = userToken
-	cache.tokenById[1] = userToken
-	cache.mutex.Unlock()
+	d := cache.data.Load()
+	d.tokenByDigest[userTokenDigest] = userToken
+	d.tokenById[1] = userToken
 
-	_, err = cache.getToken(userTokenSecret)
+	_, err = cache.FindToken(userTokenSecret)
 	g.Expect(err).NotTo(BeNil())
 	var notFound *NotFound
 	g.Expect(errors.As(err, &notFound)).To(BeTrue())
 	g.Expect(notFound.Resource).To(Equal("user"))
-
-	// Create token referencing non-existent task
-	taskID := uint(8888)
-	taskTokenSecret := "inconsistent-task-token"
-	taskTokenDigest := secret.Hash(taskTokenSecret)
-	taskToken := &Token{
-		Token: model.Token{
-			Model:  Model{ID: 2},
-			TaskID: &taskID,
-			Digest: taskTokenDigest,
-		},
-	}
-	cache.mutex.Lock()
-	cache.tokenByDigest[taskTokenDigest] = taskToken
-	cache.tokenById[2] = taskToken
-	cache.mutex.Unlock()
-
-	_, err = cache.getToken(taskTokenSecret)
-	g.Expect(err).NotTo(BeNil())
-	g.Expect(errors.As(err, &notFound)).To(BeTrue())
-	g.Expect(notFound.Resource).To(Equal("task"))
 
 	// Create token referencing non-existent identity
 	identityID := uint(7777)
@@ -302,12 +283,10 @@ func TestCacheInconsistency(t *testing.T) {
 			Digest:        identityTokenDigest,
 		},
 	}
-	cache.mutex.Lock()
-	cache.tokenByDigest[identityTokenDigest] = identityToken
-	cache.tokenById[3] = identityToken
-	cache.mutex.Unlock()
+	d.tokenByDigest[identityTokenDigest] = identityToken
+	d.tokenById[3] = identityToken
 
-	_, err = cache.getToken(identityTokenSecret)
+	_, err = cache.FindToken(identityTokenSecret)
 	g.Expect(err).NotTo(BeNil())
 	g.Expect(errors.As(err, &notFound)).To(BeTrue())
 	g.Expect(notFound.Resource).To(Equal("identity"))
@@ -323,12 +302,10 @@ func TestCacheInconsistency(t *testing.T) {
 			Digest:      clientTokenDigest,
 		},
 	}
-	cache.mutex.Lock()
-	cache.tokenByDigest[clientTokenDigest] = clientToken
-	cache.tokenById[4] = clientToken
-	cache.mutex.Unlock()
+	d.tokenByDigest[clientTokenDigest] = clientToken
+	d.tokenById[4] = clientToken
 
-	_, err = cache.getToken(clientTokenSecret)
+	_, err = cache.FindToken(clientTokenSecret)
 	g.Expect(err).NotTo(BeNil())
 	g.Expect(errors.As(err, &notFound)).To(BeTrue())
 	g.Expect(notFound.Resource).To(Equal("client"))
@@ -358,23 +335,16 @@ func TestTaskRevokedRemovesTokens(t *testing.T) {
 		Secret: tokenSecret,
 	}
 
-	// Add task and token to cache
-	cache.TaskGranted(taskID)
+	// Add token to cache
 	cache.TokenSaved(token)
 
-	// Verify task and token are in cache
-	_, err = cache.FindTaskById(taskID)
-	g.Expect(err).To(BeNil())
+	// Verify token is in cache
 	found, err := cache.FindToken(tokenSecret)
 	g.Expect(err).To(BeNil())
 	g.Expect(found.ID).To(Equal(uint(100)))
 
 	// Revoke task
 	cache.TaskRevoked(taskID)
-
-	// Verify task removed from cache
-	_, err = cache.FindTaskById(taskID)
-	g.Expect(err).NotTo(BeNil())
 
 	// Verify token removed from cache
 	_, err = cache.FindToken(tokenSecret)
@@ -422,9 +392,7 @@ func TestTaskRevokedMultipleTokens(t *testing.T) {
 		Secret: token2Secret,
 	}
 
-	// Add tasks and tokens to cache
-	cache.TaskGranted(task1ID)
-	cache.TaskGranted(task2ID)
+	// Add tokens to cache
 	cache.TokenSaved(token1)
 	cache.TokenSaved(token2)
 
@@ -445,10 +413,6 @@ func TestTaskRevokedMultipleTokens(t *testing.T) {
 	found, err := cache.FindToken(token2Secret)
 	g.Expect(err).To(BeNil())
 	g.Expect(found.ID).To(Equal(uint(102)))
-
-	// Verify task2 still in cache
-	_, err = cache.FindTaskById(task2ID)
-	g.Expect(err).To(BeNil())
 }
 
 // TestTaskRevokedTransaction tests TaskRevoked within a transaction.
@@ -474,13 +438,10 @@ func TestTaskRevokedTransaction(t *testing.T) {
 		Secret: tokenSecret,
 	}
 
-	// Add task and token
-	cache.TaskGranted(taskID)
+	// Add token
 	cache.TokenSaved(token)
 
 	// Verify in cache
-	_, err = cache.FindTaskById(taskID)
-	g.Expect(err).To(BeNil())
 	_, err = cache.FindToken(tokenSecret)
 	g.Expect(err).To(BeNil())
 
@@ -491,9 +452,7 @@ func TestTaskRevokedTransaction(t *testing.T) {
 	})
 	g.Expect(err).To(BeNil())
 
-	// Verify task and token removed
-	_, err = cache.FindTaskById(taskID)
-	g.Expect(err).NotTo(BeNil())
+	// Verify token removed
 	_, err = cache.FindToken(tokenSecret)
 	g.Expect(err).NotTo(BeNil())
 
@@ -510,7 +469,6 @@ func TestTaskRevokedTransaction(t *testing.T) {
 		Secret: token2Secret,
 	}
 
-	cache.TaskGranted(task2ID)
 	cache.TokenSaved(token2)
 
 	// Rollback transaction
@@ -520,9 +478,7 @@ func TestTaskRevokedTransaction(t *testing.T) {
 	})
 	g.Expect(err).NotTo(BeNil())
 
-	// Verify task and token still exist (rollback successful)
-	_, err = cache.FindTaskById(task2ID)
-	g.Expect(err).To(BeNil())
+	// Verify token still exists (rollback successful)
 	_, err = cache.FindToken(token2Secret)
 	g.Expect(err).To(BeNil())
 }
@@ -551,10 +507,9 @@ func TestCacheUserSavedBySubject(t *testing.T) {
 	cache.UserSaved(user)
 
 	// Verify it's in both maps
-	cache.mutex.RLock()
-	userById, foundById := cache.userById[999]
-	userBySubject, foundBySubject := cache.userBySubject["cached-user-subject"]
-	cache.mutex.RUnlock()
+	d := cache.data.Load()
+	userById, foundById := d.userById[999]
+	userBySubject, foundBySubject := d.userBySubject["cached-user-subject"]
 
 	g.Expect(foundById).To(BeTrue())
 	g.Expect(foundBySubject).To(BeTrue())
@@ -593,10 +548,9 @@ func TestCacheIdentitySavedBySubject(t *testing.T) {
 	cache.IdentitySaved(identity)
 
 	// Verify it's in both maps
-	cache.mutex.RLock()
-	identById, foundById := cache.identById[888]
-	identBySubject, foundBySubject := cache.identBySubject["cached-identity-subject"]
-	cache.mutex.RUnlock()
+	d := cache.data.Load()
+	identById, foundById := d.identById[888]
+	identBySubject, foundBySubject := d.identBySubject["cached-identity-subject"]
 
 	g.Expect(foundById).To(BeTrue())
 	g.Expect(foundBySubject).To(BeTrue())
@@ -630,10 +584,9 @@ func TestCacheUserDeletedBySubject(t *testing.T) {
 	cache.UserSaved(user)
 
 	// Verify it's in both maps
-	cache.mutex.RLock()
-	_, foundById := cache.userById[777]
-	_, foundBySubject := cache.userBySubject["delete-user-subject"]
-	cache.mutex.RUnlock()
+	d := cache.data.Load()
+	_, foundById := d.userById[777]
+	_, foundBySubject := d.userBySubject["delete-user-subject"]
 	g.Expect(foundById).To(BeTrue())
 	g.Expect(foundBySubject).To(BeTrue())
 
@@ -641,10 +594,9 @@ func TestCacheUserDeletedBySubject(t *testing.T) {
 	cache.UserDeleted(777)
 
 	// Verify removed from both maps
-	cache.mutex.RLock()
-	_, foundById = cache.userById[777]
-	_, foundBySubject = cache.userBySubject["delete-user-subject"]
-	cache.mutex.RUnlock()
+	d = cache.data.Load()
+	_, foundById = d.userById[777]
+	_, foundBySubject = d.userBySubject["delete-user-subject"]
 	g.Expect(foundById).To(BeFalse())
 	g.Expect(foundBySubject).To(BeFalse())
 
@@ -673,10 +625,9 @@ func TestCacheIdentityDeletedBySubject(t *testing.T) {
 	cache.IdentitySaved(identity)
 
 	// Verify it's in both maps
-	cache.mutex.RLock()
-	_, foundById := cache.identById[666]
-	_, foundBySubject := cache.identBySubject["delete-identity-subject"]
-	cache.mutex.RUnlock()
+	d := cache.data.Load()
+	_, foundById := d.identById[666]
+	_, foundBySubject := d.identBySubject["delete-identity-subject"]
 	g.Expect(foundById).To(BeTrue())
 	g.Expect(foundBySubject).To(BeTrue())
 
@@ -684,10 +635,9 @@ func TestCacheIdentityDeletedBySubject(t *testing.T) {
 	cache.IdentityDeleted(666)
 
 	// Verify removed from both maps
-	cache.mutex.RLock()
-	_, foundById = cache.identById[666]
-	_, foundBySubject = cache.identBySubject["delete-identity-subject"]
-	cache.mutex.RUnlock()
+	d = cache.data.Load()
+	_, foundById = d.identById[666]
+	_, foundBySubject = d.identBySubject["delete-identity-subject"]
 	g.Expect(foundById).To(BeFalse())
 	g.Expect(foundBySubject).To(BeFalse())
 
@@ -720,11 +670,10 @@ func TestCacheUserByUseridMaps(t *testing.T) {
 	cache.UserSaved(user)
 
 	// Verify it's in all three maps
-	cache.mutex.RLock()
-	userById, foundById := cache.userById[555]
-	userBySubject, foundBySubject := cache.userBySubject["map-test-subject"]
-	userByLogin, foundByLogin := cache.userByLogin["maptestuser"]
-	cache.mutex.RUnlock()
+	d := cache.data.Load()
+	userById, foundById := d.userById[555]
+	userBySubject, foundBySubject := d.userBySubject["map-test-subject"]
+	userByLogin, foundByLogin := d.userByLogin["maptestuser"]
 
 	g.Expect(foundById).To(BeTrue())
 	g.Expect(foundBySubject).To(BeTrue())
@@ -737,11 +686,10 @@ func TestCacheUserByUseridMaps(t *testing.T) {
 	cache.UserDeleted(555)
 
 	// Verify removed from all three maps
-	cache.mutex.RLock()
-	_, foundById = cache.userById[555]
-	_, foundBySubject = cache.userBySubject["map-test-subject"]
-	_, foundByLogin = cache.userByLogin["maptestuser"]
-	cache.mutex.RUnlock()
+	d = cache.data.Load()
+	_, foundById = d.userById[555]
+	_, foundBySubject = d.userBySubject["map-test-subject"]
+	_, foundByLogin = d.userByLogin["maptestuser"]
 
 	g.Expect(foundById).To(BeFalse())
 	g.Expect(foundBySubject).To(BeFalse())
@@ -782,16 +730,6 @@ func TestCacheConcurrency(t *testing.T) {
 			_, err := cache.FindUserByLogin(fmt.Sprintf("concurrentuser%d", userIdx))
 			g.Expect(err).To(BeNil())
 		}(i)
-	}
-
-	// Launch concurrent Refresh operations
-	for i := 0; i < 5; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			err := cache.Refresh()
-			g.Expect(err).To(BeNil())
-		}()
 	}
 
 	// Launch concurrent UserSaved operations
@@ -835,12 +773,11 @@ func TestManualCacheRefresh(t *testing.T) {
 	// Call Reset - should clear cache
 	cache.Reset()
 
-	// User should still be found via automatic refresh (ensureFresh)
-	found, err = cache.FindUserByLogin("manualrefreshuser")
-	g.Expect(err).To(BeNil())
-	g.Expect(found).NotTo(BeNil())
+	// Cache is now empty, user not found
+	_, err = cache.FindUserByLogin("manualrefreshuser")
+	g.Expect(err).NotTo(BeNil())
 
-	// Call manual Refresh
+	// Call manual Refresh to reload
 	err = cache.Refresh()
 	g.Expect(err).To(BeNil())
 
@@ -1232,4 +1169,424 @@ func TestIdpClientWith(t *testing.T) {
 	g.Expect(cachePublic.ClientId).To(Equal("public-client"))
 	g.Expect(cachePublic.Secret).To(BeEmpty())
 	g.Expect(cachePublic.ApplicationType).To(Equal("native"))
+}
+
+// TestCopyOnWriteCommit verifies Commit clones Data instead of mutating.
+func TestCopyOnWriteCommit(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	db, err := setupTestDB()
+	g.Expect(err).To(BeNil())
+
+	cache := New(db)
+	err = cache.Refresh()
+	g.Expect(err).To(BeNil())
+
+	// Load Data before Tx
+	oldData := cache.data.Load()
+
+	// Execute transaction
+	user := &User{
+		Model:   Model{ID: 100},
+		Subject: "cow-test",
+		Login:   "cowtest",
+	}
+	cache.UserSaved(user)
+
+	// Load Data after Tx
+	newData := cache.data.Load()
+
+	// Verify Data pointer changed (copy-on-write)
+	g.Expect(oldData).NotTo(Equal(newData))
+
+	// Verify old Data unchanged
+	_, found := oldData.userById[100]
+	g.Expect(found).To(BeFalse())
+
+	// Verify new Data has change
+	_, found = newData.userById[100]
+	g.Expect(found).To(BeTrue())
+}
+
+// TestConcurrentCommitsNoLostUpdates verifies mutex prevents lost updates.
+func TestConcurrentCommitsNoLostUpdates(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	db, err := setupTestDB()
+	g.Expect(err).To(BeNil())
+
+	cache := New(db)
+	err = cache.Refresh()
+	g.Expect(err).To(BeNil())
+
+	// Spawn 10 concurrent UserSaved operations
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			user := &User{
+				Model:   Model{ID: uint(id + 100)},
+				Subject: fmt.Sprintf("concurrent-%d", id),
+				Login:   fmt.Sprintf("concurrent%d", id),
+			}
+			cache.UserSaved(user)
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify ALL 10 users are in cache (no lost updates)
+	d := cache.data.Load()
+	for i := 0; i < 10; i++ {
+		_, found := d.userById[uint(i+100)]
+		g.Expect(found).To(BeTrue(), fmt.Sprintf("user %d not found", i))
+	}
+}
+
+// TestDataClone verifies clone creates independent copy.
+func TestDataClone(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	// Create original Data with content
+	original := &Data{}
+	original.reset()
+	original.userById[1] = &User{Model: Model{ID: 1}, Login: "user1"}
+	original.roleById[2] = &Role{Model: Model{ID: 2}, Name: "role1"}
+	original.refreshed = time.Now().Add(-5 * time.Minute)
+
+	// Clone it
+	clone := original.clone()
+
+	// Verify refreshed timestamp copied
+	g.Expect(clone.refreshed).To(Equal(original.refreshed))
+
+	// Verify maps copied (share same objects)
+	g.Expect(clone.userById[1]).To(Equal(original.userById[1]))
+	g.Expect(clone.roleById[2]).To(Equal(original.roleById[2]))
+
+	// Mutate clone - should NOT affect original
+	clone.userById[3] = &User{Model: Model{ID: 3}, Login: "user3"}
+	delete(clone.roleById, 2)
+
+	// Verify original unchanged
+	_, found := original.userById[3]
+	g.Expect(found).To(BeFalse())
+	_, found = original.roleById[2]
+	g.Expect(found).To(BeTrue())
+
+	// Verify clone has mutations
+	_, found = clone.userById[3]
+	g.Expect(found).To(BeTrue())
+	_, found = clone.roleById[2]
+	g.Expect(found).To(BeFalse())
+}
+
+// TestOnDemandRefresh verifies ensureRefreshed triggers when stale.
+func TestOnDemandRefresh(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	db, err := setupTestDB()
+	g.Expect(err).To(BeNil())
+
+	cache := New(db)
+	err = cache.Refresh()
+	g.Expect(err).To(BeNil())
+
+	// Get original Data and manually age it
+	d := cache.data.Load()
+	oldRefreshed := d.refreshed
+
+	// Create a new stale Data and swap it in
+	staleData := d.clone()
+	staleData.refreshed = time.Now().Add(-10 * time.Minute) // Stale
+	cache.data.Store(staleData)
+
+	// Create new user in DB (bypassing cache notifications)
+	user := &User{
+		Subject:  "on-demand-user",
+		Login:    "ondemanduser",
+		Password: secret.HashPassword("password"),
+		Email:    "ondemand@example.com",
+	}
+	err = db.Create(user).Error
+	g.Expect(err).To(BeNil())
+
+	// First FindXXX should trigger refresh
+	cache.FindUserByLogin("ondemanduser")
+
+	// Poll until refresh completes (max 2 seconds)
+	refreshed := false
+	for i := 0; i < 20; i++ {
+		time.Sleep(100 * time.Millisecond)
+		d = cache.data.Load()
+		if d.refreshed.After(oldRefreshed) {
+			refreshed = true
+			break
+		}
+	}
+	g.Expect(refreshed).To(BeTrue(), "refresh should complete within 2 seconds")
+
+	// Verify new user now in cache
+	found, err := cache.FindUserByLogin("ondemanduser")
+	g.Expect(err).To(BeNil())
+	g.Expect(found).NotTo(BeNil())
+}
+
+// TestAuthStorm tests lock-free reads under concurrent load.
+func TestAuthStorm(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	db, err := setupTestDB()
+	g.Expect(err).To(BeNil())
+
+	// Create test tokens
+	for i := 0; i < 10; i++ {
+		token := &Token{
+			Token: model.Token{
+				Kind:       KindAPIKey,
+				AuthId:     fmt.Sprintf("storm-auth-%d", i),
+				Digest:     secret.Hash(fmt.Sprintf("storm-token-%d", i)),
+				Expiration: time.Now().Add(24 * time.Hour),
+			},
+			Secret: fmt.Sprintf("storm-token-%d", i),
+		}
+		err = db.Create(&token.Token).Error
+		g.Expect(err).To(BeNil())
+	}
+
+	cache := New(db)
+	err = cache.Refresh()
+	g.Expect(err).To(BeNil())
+
+	// 100 goroutines each doing 10 FindToken calls
+	var wg sync.WaitGroup
+	successCount := make([]int, 100)
+
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			for j := 0; j < 10; j++ {
+				tokenIdx := j % 10
+				_, err := cache.FindToken(fmt.Sprintf("storm-token-%d", tokenIdx))
+				if err == nil {
+					successCount[idx]++
+				}
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// All reads should succeed
+	totalSuccess := 0
+	for _, count := range successCount {
+		totalSuccess += count
+	}
+	g.Expect(totalSuccess).To(Equal(1000))
+}
+
+// TestTaskChurnUnderLoad tests copy-on-write under write load.
+func TestTaskChurnUnderLoad(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	db, err := setupTestDB()
+	g.Expect(err).To(BeNil())
+
+	cache := New(db)
+	err = cache.Refresh()
+	g.Expect(err).To(BeNil())
+
+	var wg sync.WaitGroup
+	doneChan := make(chan struct{})
+
+	// 10 writers: create/revoke task tokens
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			taskID := uint(1000 + id)
+			tokenSecret := fmt.Sprintf("churn-token-%d", id)
+
+			for j := 0; j < 10; j++ {
+				select {
+				case <-doneChan:
+					return
+				default:
+				}
+
+				// Add token
+				token := &Token{
+					Token: model.Token{
+						Model:      Model{ID: uint(id*100 + j)},
+						TaskID:     &taskID,
+						Digest:     secret.Hash(tokenSecret),
+						Expiration: time.Now().Add(24 * time.Hour),
+					},
+					Secret: tokenSecret,
+				}
+				cache.TokenSaved(token)
+
+				// Revoke it
+				cache.TaskRevoked(taskID)
+			}
+		}(i)
+	}
+
+	// 50 readers: continuously try to find tokens
+	readErrors := make([]int, 50)
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			for j := 0; j < 20; j++ {
+				select {
+				case <-doneChan:
+					return
+				default:
+				}
+				tokenIdx := j % 10
+				_, err := cache.FindToken(fmt.Sprintf("churn-token-%d", tokenIdx))
+				// Token may or may not exist (being churned)
+				// Just verify no panic/crash
+				if err != nil {
+					readErrors[idx]++
+				}
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(doneChan)
+
+	// Test passes if no panics occurred
+	// Read errors are expected due to churn
+}
+
+// TestRefreshRace tests that Data.refreshOnce prevents stampede.
+func TestRefreshRace(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	db, err := setupTestDB()
+	g.Expect(err).To(BeNil())
+
+	cache := New(db)
+	err = cache.Refresh()
+	g.Expect(err).To(BeNil())
+
+	// Make cache stale
+	d := cache.data.Load()
+	staleData := d.clone()
+	staleData.refreshed = time.Now().Add(-10 * time.Minute)
+	cache.data.Store(staleData)
+
+	// 50 goroutines all detect staleness simultaneously
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// This triggers ensureRefreshed
+			cache.FindUserByLogin("nonexistent")
+		}()
+	}
+
+	wg.Wait()
+
+	// Give refresh time to complete
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify cache refreshed (exactly once via sync.Once)
+	d = cache.data.Load()
+	g.Expect(d.refreshed).To(BeTemporally(">", staleData.refreshed))
+}
+
+// TestMixedConcurrentOperations tests all operations work concurrently.
+func TestMixedConcurrentOperations(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	db, err := setupTestDB()
+	g.Expect(err).To(BeNil())
+
+	cache := New(db)
+	err = cache.Refresh()
+	g.Expect(err).To(BeNil())
+
+	var wg sync.WaitGroup
+	iterations := 20
+
+	// Concurrent UserSaved
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				user := &User{
+					Model:   Model{ID: uint(id*1000 + j)},
+					Subject: fmt.Sprintf("mixed-user-%d-%d", id, j),
+					Login:   fmt.Sprintf("mixeduser%d-%d", id, j),
+				}
+				cache.UserSaved(user)
+			}
+		}(i)
+	}
+
+	// Concurrent RoleSaved/Deleted
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				role := &Role{
+					Model: Model{ID: uint(id*1000 + j)},
+					Name:  fmt.Sprintf("mixed-role-%d-%d", id, j),
+				}
+				cache.RoleSaved(role)
+				if j%2 == 0 {
+					cache.RoleDeleted(role.ID)
+				}
+			}
+		}(i)
+	}
+
+	// Concurrent TokenSaved
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				taskID := uint(id*1000 + j)
+				token := &Token{
+					Token: model.Token{
+						Model:      Model{ID: uint(id*1000 + j)},
+						TaskID:     &taskID,
+						Digest:     secret.Hash(fmt.Sprintf("mixed-token-%d-%d", id, j)),
+						Expiration: time.Now().Add(24 * time.Hour),
+					},
+					Secret: fmt.Sprintf("mixed-token-%d-%d", id, j),
+				}
+				cache.TokenSaved(token)
+			}
+		}(i)
+	}
+
+	// Concurrent FindUserByLogin
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				userIdx := j % 10
+				cache.FindUserByLogin(fmt.Sprintf("mixeduser%d-%d", userIdx, j))
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify final state is consistent
+	d := cache.data.Load()
+	// Should have some users (not all, some deleted/not found)
+	g.Expect(len(d.userById)).To(BeNumerically(">", 0))
 }

--- a/internal/auth/cache/tx.go
+++ b/internal/auth/cache/tx.go
@@ -1,30 +1,28 @@
 package cache
 
-import "github.com/konveyor/tackle2-hub/shared/task"
-
 // Tx is a cache transaction.
 type Tx struct {
 	cache   *Cache
-	changes []func()
+	changes []func(d *Data)
 }
 
 // RoleSaved updates the cache when a role is saved.
 func (r *Tx) RoleSaved(m *Role) {
 	r.changes = append(
-		r.changes, func() {
-			r.cache.roleById[m.ID] = m
-			r.cache.roleByName[m.Name] = m
+		r.changes, func(d *Data) {
+			d.roleById[m.ID] = m
+			d.roleByName[m.Name] = m
 		})
 }
 
 // RoleDeleted removes a role from the cache.
 func (r *Tx) RoleDeleted(id uint) {
 	r.changes = append(
-		r.changes, func() {
-			m, found := r.cache.roleById[id]
+		r.changes, func(d *Data) {
+			m, found := d.roleById[id]
 			if found {
-				delete(r.cache.roleById, id)
-				delete(r.cache.roleByName, m.Name)
+				delete(d.roleById, id)
+				delete(d.roleByName, m.Name)
 			}
 		})
 }
@@ -32,46 +30,34 @@ func (r *Tx) RoleDeleted(id uint) {
 // UserSaved updates the cache when a user is saved.
 func (r *Tx) UserSaved(m *User) {
 	r.changes = append(
-		r.changes, func() {
-			r.cache.userById[m.ID] = m
-			r.cache.userBySubject[m.Subject] = m
-			r.cache.userByLogin[m.Login] = m
+		r.changes, func(d *Data) {
+			d.userById[m.ID] = m
+			d.userBySubject[m.Subject] = m
+			d.userByLogin[m.Login] = m
 		})
 }
 
 // UserDeleted removes a user from the cache.
 func (r *Tx) UserDeleted(id uint) {
 	r.changes = append(
-		r.changes, func() {
-			m, found := r.cache.userById[id]
+		r.changes, func(d *Data) {
+			m, found := d.userById[id]
 			if found {
-				delete(r.cache.userBySubject, m.Subject)
-				delete(r.cache.userByLogin, m.Login)
-				delete(r.cache.userById, id)
+				delete(d.userBySubject, m.Subject)
+				delete(d.userByLogin, m.Login)
+				delete(d.userById, id)
 			}
-		})
-}
-
-// TaskGranted token granted.
-func (r *Tx) TaskGranted(id uint) {
-	r.changes = append(
-		r.changes, func() {
-			m := &Task{}
-			m.ID = id
-			m.State = task.Running
-			r.cache.taskById[id] = m
 		})
 }
 
 // TaskRevoked task token revoked.
 func (r *Tx) TaskRevoked(id uint) {
 	r.changes = append(
-		r.changes, func() {
-			delete(r.cache.taskById, id)
-			for _, m := range r.cache.tokenById {
+		r.changes, func(d *Data) {
+			for _, m := range d.tokenById {
 				if m.TaskID != nil && *m.TaskID == id {
-					delete(r.cache.tokenByDigest, m.Digest)
-					delete(r.cache.tokenById, m.ID)
+					delete(d.tokenByDigest, m.Digest)
+					delete(d.tokenById, m.ID)
 				}
 			}
 		})
@@ -80,22 +66,22 @@ func (r *Tx) TaskRevoked(id uint) {
 // IdentitySaved updates the cache when an identity is saved.
 func (r *Tx) IdentitySaved(m *Identity) {
 	r.changes = append(
-		r.changes, func() {
-			r.cache.identById[m.ID] = m
-			r.cache.identBySubject[m.Subject] = m
-			r.cache.identByLogin[m.Login] = m
+		r.changes, func(d *Data) {
+			d.identById[m.ID] = m
+			d.identBySubject[m.Subject] = m
+			d.identByLogin[m.Login] = m
 		})
 }
 
 // IdentityDeleted removes an identity from the cache.
 func (r *Tx) IdentityDeleted(id uint) {
 	r.changes = append(
-		r.changes, func() {
-			m, found := r.cache.identById[id]
+		r.changes, func(d *Data) {
+			m, found := d.identById[id]
 			if found {
-				delete(r.cache.identByLogin, m.Login)
-				delete(r.cache.identBySubject, m.Subject)
-				delete(r.cache.identById, id)
+				delete(d.identByLogin, m.Login)
+				delete(d.identBySubject, m.Subject)
+				delete(d.identById, id)
 			}
 		})
 }
@@ -103,20 +89,20 @@ func (r *Tx) IdentityDeleted(id uint) {
 // ClientSaved updates the cache when a client is saved.
 func (r *Tx) ClientSaved(m *IdpClient) {
 	r.changes = append(
-		r.changes, func() {
-			r.cache.clientById[m.ID] = m
-			r.cache.clientBySubject[m.Subject] = m
+		r.changes, func(d *Data) {
+			d.clientById[m.ID] = m
+			d.clientBySubject[m.Subject] = m
 		})
 }
 
 // ClientDeleted removes a client from the cache.
 func (r *Tx) ClientDeleted(id uint) {
 	r.changes = append(
-		r.changes, func() {
-			m, found := r.cache.clientById[id]
+		r.changes, func(d *Data) {
+			m, found := d.clientById[id]
 			if found {
-				delete(r.cache.clientBySubject, m.Subject)
-				delete(r.cache.clientById, id)
+				delete(d.clientBySubject, m.Subject)
+				delete(d.clientById, id)
 			}
 		})
 }
@@ -124,31 +110,34 @@ func (r *Tx) ClientDeleted(id uint) {
 // TokenSaved updates the cache when a token is saved.
 func (r *Tx) TokenSaved(m *Token) {
 	r.changes = append(
-		r.changes, func() {
-			r.cache.tokenById[m.ID] = m
-			r.cache.tokenByDigest[m.Digest] = m
+		r.changes, func(d *Data) {
+			d.tokenById[m.ID] = m
+			d.tokenByDigest[m.Digest] = m
 		})
 }
 
 // TokenDeleted removes a token from the cache.
 func (r *Tx) TokenDeleted(id uint) {
 	r.changes = append(
-		r.changes, func() {
-			token, found := r.cache.tokenById[id]
+		r.changes, func(d *Data) {
+			token, found := d.tokenById[id]
 			if found {
-				delete(r.cache.tokenByDigest, token.Digest)
-				delete(r.cache.tokenById, id)
+				delete(d.tokenByDigest, token.Digest)
+				delete(d.tokenById, id)
 			}
 		})
 }
 
 // Commit applies all changelog operations atomically.
 func (r *Tx) Commit() {
-	r.cache.mutex.Lock()
-	defer r.cache.mutex.Unlock()
+	r.cache.txMutex.Lock()
+	defer r.cache.txMutex.Unlock()
+	d := r.cache.data.Load()
+	clone := d.clone()
 	for _, fn := range r.changes {
-		fn()
+		fn(clone)
 	}
+	r.cache.data.Store(clone)
 	r.changes = nil
 }
 

--- a/internal/auth/cache/tx.go
+++ b/internal/auth/cache/tx.go
@@ -10,6 +10,10 @@ type Tx struct {
 func (r *Tx) RoleSaved(m *Role) {
 	r.changes = append(
 		r.changes, func(d *Data) {
+			p, found := d.roleById[m.ID]
+			if found {
+				delete(d.roleByName, p.Name)
+			}
 			d.roleById[m.ID] = m
 			d.roleByName[m.Name] = m
 		})

--- a/internal/auth/dag.go
+++ b/internal/auth/dag.go
@@ -281,7 +281,7 @@ func (h *DagHandler) currentUser(ctx *gin.Context) (user string) {
 // Uses server-side state storage to avoid cookie domain issues when hub
 // acts as both IdP and RP.
 type OIDCAuth struct {
-	mutex     sync.RWMutex
+	mutex     sync.Mutex
 	cookies   *httphelper.CookieHandler
 	pkceState map[string]*PKCEState
 	initOnce  sync.Once

--- a/internal/auth/pkg_test.go
+++ b/internal/auth/pkg_test.go
@@ -577,9 +577,6 @@ func TestNoAuthProvider(t *testing.T) {
 		db.Delete(task)
 	})
 
-	// Notify cache about new task
-	provider.Builtin.cache.TaskGranted(task.ID)
-
 	key, err = provider.TaskGrant(task.ID)
 	g.Expect(err).To(BeNil())
 	g.Expect(key.Secret).ToNot(BeEmpty())
@@ -710,10 +707,6 @@ func TestTaskRevoke(t *testing.T) {
 	_, err = provider.Authenticate(request)
 	g.Expect(err).NotTo(BeNil())
 	g.Expect(err.Error()).To(ContainSubstring("not-authenticated"))
-
-	// Verify task removed from task cache
-	_, err = provider.cache.FindTaskById(task.ID)
-	g.Expect(err).NotTo(BeNil())
 }
 
 // TestTaskRevokeMultipleTokens tests revoking when task has multiple tokens (edge case).
@@ -802,9 +795,6 @@ func TestTaskRevokeNoTokens(t *testing.T) {
 
 	provider, err := NewBuiltin(db)
 	g.Expect(err).To(BeNil())
-
-	// Add task to cache but don't create token
-	provider.cache.TaskGranted(task.ID)
 
 	// Revoke should not error even though no tokens exist
 	provider.TaskRevoke(task.ID)
@@ -1569,76 +1559,6 @@ func TestCacheNotificationPropagation(t *testing.T) {
 	g.Expect(err).NotTo(BeNil()) // Should fail immediately, not wait for refresh
 }
 
-// TestCacheTimeBasedRefresh tests time-based cache expiration.
-func TestCacheTimeBasedRefresh(t *testing.T) {
-	g := NewGomegaWithT(t)
-
-	db, err := setupTestDB()
-	g.Expect(err).To(BeNil())
-
-	// Save original cache lifespan and restore after test
-	originalLifespan := Settings.CacheLifespan
-	defer func() {
-		Settings.CacheLifespan = originalLifespan
-	}()
-
-	// Set very short cache lifespan
-	Settings.CacheLifespan = 100 * time.Millisecond
-
-	user := &model.User{
-		Subject:  "time-refresh-user",
-		Login:    "timerefreshuser",
-		Password: secret.HashPassword("password"),
-		Email:    "timerefresh@example.com",
-	}
-	err = db.Create(user).Error
-	g.Expect(err).To(BeNil())
-
-	provider, err := NewBuiltin(db)
-	g.Expect(err).To(BeNil())
-
-	token, err := provider.NewToken(user.Subject, 24*time.Hour)
-	g.Expect(err).To(BeNil())
-
-	// Authenticate successfully (cache is fresh)
-	request := newTestRequest()
-	request.With("Bearer " + token.Secret)
-	_, err = provider.Authenticate(request)
-	g.Expect(err).To(BeNil())
-
-	// Wait for cache to expire
-	time.Sleep(150 * time.Millisecond)
-
-	// Create new token while cache is stale
-	newUser := &model.User{
-		Subject:  "new-time-user",
-		Login:    "newtimeuser",
-		Password: secret.HashPassword("password"),
-		Email:    "newtime@example.com",
-	}
-	err = db.Create(newUser).Error
-	g.Expect(err).To(BeNil())
-
-	newToken := Token{
-		Token: model.Token{
-			Kind:       KindAPIKey,
-			AuthId:     "time-auth-id",
-			Digest:     secret.Hash("time-secret-token"),
-			Expiration: time.Now().Add(24 * time.Hour),
-			UserID:     &newUser.ID,
-		},
-		Secret: "time-secret-token",
-	}
-	err = db.Create(&newToken.Token).Error
-	g.Expect(err).To(BeNil())
-
-	// Authenticate with new token - should trigger time-based refresh
-	request = newTestRequest()
-	request.With("Bearer " + newToken.Secret)
-	_, err = provider.Authenticate(request)
-	g.Expect(err).To(BeNil())
-}
-
 // TestIdpIdentityTokenBinding tests token binding to IdP identities.
 func TestIdpIdentityTokenBinding(t *testing.T) {
 	g := NewGomegaWithT(t)
@@ -1867,42 +1787,6 @@ func TestTokenBindingEdgeCases(t *testing.T) {
 	g.Expect(subject).To(ContainSubstring("task:"))
 }
 
-// TestManualCacheRefresh tests explicit Refresh() and Reset() calls.
-func TestTaskStateFiltering(t *testing.T) {
-	g := NewGomegaWithT(t)
-
-	db, err := setupTestDB()
-	g.Expect(err).To(BeNil())
-
-	// Create tasks in various states
-	states := []string{"Pending", "Running", "Succeeded", "Failed", "Canceled"}
-	tasks := make([]*model.Task, len(states))
-	for i, state := range states {
-		tasks[i] = &model.Task{
-			Name:  "task-" + state,
-			State: state,
-		}
-		err = db.Create(tasks[i]).Error
-		g.Expect(err).To(BeNil())
-	}
-
-	provider, err := NewBuiltin(db)
-	g.Expect(err).To(BeNil())
-
-	// Verify only Pending and Running are in cache
-	_, errPending := provider.cache.FindTaskById(tasks[0].ID)
-	_, errRunning := provider.cache.FindTaskById(tasks[1].ID)
-	_, errSucceeded := provider.cache.FindTaskById(tasks[2].ID)
-	_, errFailed := provider.cache.FindTaskById(tasks[3].ID)
-	_, errCanceled := provider.cache.FindTaskById(tasks[4].ID)
-
-	g.Expect(errPending).To(BeNil())
-	g.Expect(errRunning).To(BeNil())
-	g.Expect(errSucceeded).NotTo(BeNil())
-	g.Expect(errFailed).NotTo(BeNil())
-	g.Expect(errCanceled).NotTo(BeNil())
-}
-
 // TestCacheFindSubject tests finding subjects (users and identities) by subject string.
 func TestCacheFindSubject(t *testing.T) {
 	g := NewGomegaWithT(t)
@@ -2040,67 +1924,6 @@ func TestCacheFindSubjectMiss(t *testing.T) {
 	g.Expect(err).To(BeNil())
 	g.Expect(subject).NotTo(BeNil())
 	g.Expect(subject.IsUser()).To(BeTrue())
-}
-
-// TestCacheFindSubjectTimeBasedRefresh tests time-based refresh with FindSubject.
-func TestCacheFindSubjectTimeBasedRefresh(t *testing.T) {
-	g := NewGomegaWithT(t)
-
-	db, err := setupTestDB()
-	g.Expect(err).To(BeNil())
-
-	// Save original cache lifespan and restore after test
-	originalLifespan := Settings.CacheLifespan
-	defer func() {
-		Settings.CacheLifespan = originalLifespan
-	}()
-
-	// Set very short cache lifespan
-	Settings.CacheLifespan = 100 * time.Millisecond
-
-	user := &model.User{
-		Subject:  uuid.New().String(),
-		Login:    "timesubjectuser",
-		Password: secret.HashPassword("password"),
-		Email:    "timesubject@example.com",
-	}
-	err = db.Create(user).Error
-	g.Expect(err).To(BeNil())
-
-	// Reload user to get auto-generated subject
-	err = db.First(user, user.ID).Error
-	g.Expect(err).To(BeNil())
-
-	provider, err := NewBuiltin(db)
-	g.Expect(err).To(BeNil())
-
-	// Find subject successfully (cache is fresh)
-	subject, err := provider.cache.FindSubject(user.Subject)
-	g.Expect(err).To(BeNil())
-	g.Expect(subject.Key).To(Equal(user.Subject))
-	g.Expect(subject.User.Login).To(Equal("timesubjectuser"))
-
-	// Wait for cache to expire
-	time.Sleep(150 * time.Millisecond)
-
-	// Create new user while cache is stale
-	newUser := &model.User{
-		Login:    "newtimesubject",
-		Password: secret.HashPassword("password"),
-		Email:    "newtimesubject@example.com",
-	}
-	err = db.Create(newUser).Error
-	g.Expect(err).To(BeNil())
-
-	// Reload newUser to get auto-generated subject
-	err = db.First(newUser, newUser.ID).Error
-	g.Expect(err).To(BeNil())
-
-	// FindSubject should trigger time-based refresh and find new user
-	subject, err = provider.cache.FindSubject(newUser.Subject)
-	g.Expect(err).To(BeNil())
-	g.Expect(subject.Key).To(Equal(newUser.Subject))
-	g.Expect(subject.User.Login).To(Equal("newtimesubject"))
 }
 
 // TestCacheUserSavedBySubject tests that UserSaved updates bySubject map.
@@ -2242,184 +2065,6 @@ func TestCacheFindUserByLoginNotification(t *testing.T) {
 	g.Expect(err).To(BeNil())
 	g.Expect(found).NotTo(BeNil())
 	g.Expect(found.Subject).To(Equal(user.Subject))
-}
-
-// TestCacheFindUserByLoginTimeRefresh tests time-based refresh for userid lookup.
-func TestCacheFindUserByLoginTimeRefresh(t *testing.T) {
-	g := NewGomegaWithT(t)
-
-	db, err := setupTestDB()
-	g.Expect(err).To(BeNil())
-
-	// Save original cache lifespan and restore after test
-	originalLifespan := Settings.CacheLifespan
-	defer func() {
-		Settings.CacheLifespan = originalLifespan
-	}()
-
-	// Set very short cache lifespan
-	Settings.CacheLifespan = 100 * time.Millisecond
-
-	user := &model.User{
-		Subject:  uuid.New().String(),
-		Login:    "timeuserid",
-		Password: secret.HashPassword("password"),
-		Email:    "timeuserid@example.com",
-	}
-	err = db.Create(user).Error
-	g.Expect(err).To(BeNil())
-
-	// Reload user to get auto-generated subject
-	err = db.First(user, user.ID).Error
-	g.Expect(err).To(BeNil())
-
-	provider, err := NewBuiltin(db)
-	g.Expect(err).To(BeNil())
-
-	// Find successfully (cache is fresh)
-	found, err := provider.cache.FindUserByLogin("timeuserid")
-	g.Expect(err).To(BeNil())
-	g.Expect(found.Subject).To(Equal(user.Subject))
-
-	// Wait for cache to expire
-	time.Sleep(150 * time.Millisecond)
-
-	// Create new user while cache is stale
-	newUser := &model.User{
-		Login:    "newtimeuserid",
-		Password: secret.HashPassword("password"),
-		Email:    "newtimeuserid@example.com",
-	}
-	err = db.Create(newUser).Error
-	g.Expect(err).To(BeNil())
-
-	// Reload newUser to get auto-generated subject
-	err = db.First(newUser, newUser.ID).Error
-	g.Expect(err).To(BeNil())
-
-	// FindUserByLogin should trigger time-based refresh
-	found, err = provider.cache.FindUserByLogin("newtimeuserid")
-	g.Expect(err).To(BeNil())
-	g.Expect(found.Subject).To(Equal(newUser.Subject))
-}
-
-// TestCacheGetTask tests finding task by ID.
-func TestCacheGetTask(t *testing.T) {
-	g := NewGomegaWithT(t)
-
-	db, err := setupTestDB()
-	g.Expect(err).To(BeNil())
-
-	// Create test task
-	task := &model.Task{
-		Name:  "cache-test-task",
-		State: "Running",
-	}
-	err = db.Create(task).Error
-	g.Expect(err).To(BeNil())
-
-	provider, err := NewBuiltin(db)
-	g.Expect(err).To(BeNil())
-
-	// Get task by ID
-	found, err := provider.cache.FindTaskById(task.ID)
-	g.Expect(err).To(BeNil())
-	g.Expect(found).NotTo(BeNil())
-	g.Expect(found.ID).To(Equal(task.ID))
-	g.Expect(found.State).To(Equal("Running"))
-
-	// Get non-existent task
-	_, err = provider.cache.FindTaskById(9999)
-	g.Expect(err).NotTo(BeNil())
-	var notFound *NotFound
-	g.Expect(errors.As(err, &notFound)).To(BeTrue())
-	g.Expect(notFound.Resource).To(Equal("task"))
-}
-
-// TestCacheFindTaskByIdNotification tests notification-based cache updates for tasks.
-func TestCacheFindTaskByIdNotification(t *testing.T) {
-	g := NewGomegaWithT(t)
-
-	db, err := setupTestDB()
-	g.Expect(err).To(BeNil())
-
-	provider, err := NewBuiltin(db)
-	g.Expect(err).To(BeNil())
-
-	// Force initial cache load
-	_, _ = provider.cache.FindTaskById(9999)
-
-	// Create task after cache is loaded (NOT notified)
-	task := &model.Task{
-		Name:  "new-cache-task",
-		State: "Pending",
-	}
-	err = db.Create(task).Error
-	g.Expect(err).To(BeNil())
-
-	// FindTaskById should NOT find it (cache is fresh, no notification)
-	found, err := provider.cache.FindTaskById(task.ID)
-	g.Expect(err).NotTo(BeNil()) // NotFound
-	g.Expect(found).To(BeNil())
-
-	// Notify cache of task grant
-	provider.cache.TaskGranted(task.ID)
-
-	// Now it should be found immediately
-	found, err = provider.cache.FindTaskById(task.ID)
-	g.Expect(err).To(BeNil())
-	g.Expect(found).NotTo(BeNil())
-	g.Expect(found.State).To(Equal("Running")) // TaskGranted creates minimal Task{ID, State: Running}
-}
-
-// TestCacheGetTaskTimeRefresh tests time-based refresh for task lookup.
-func TestCacheGetTaskTimeRefresh(t *testing.T) {
-	g := NewGomegaWithT(t)
-
-	db, err := setupTestDB()
-	g.Expect(err).To(BeNil())
-
-	// Save original cache lifespan and restore after test
-	originalLifespan := Settings.CacheLifespan
-	defer func() {
-		Settings.CacheLifespan = originalLifespan
-	}()
-
-	// Set very short cache lifespan
-	Settings.CacheLifespan = 100 * time.Millisecond
-
-	task := &model.Task{
-		Name:  "time-task",
-		State: "Running",
-	}
-	err = db.Create(task).Error
-	g.Expect(err).To(BeNil())
-
-	provider, err := NewBuiltin(db)
-	g.Expect(err).To(BeNil())
-
-	// Get successfully (cache is fresh)
-	found, err := provider.cache.FindTaskById(task.ID)
-	g.Expect(err).To(BeNil())
-	g.Expect(found.ID).To(Equal(task.ID))
-	g.Expect(found.State).To(Equal("Running"))
-
-	// Wait for cache to expire
-	time.Sleep(150 * time.Millisecond)
-
-	// Create new task while cache is stale
-	newTask := &model.Task{
-		Name:  "new-time-task",
-		State: "Pending",
-	}
-	err = db.Create(newTask).Error
-	g.Expect(err).To(BeNil())
-
-	// GetTask should trigger time-based refresh
-	found, err = provider.cache.FindTaskById(newTask.ID)
-	g.Expect(err).To(BeNil())
-	g.Expect(found.ID).To(Equal(newTask.ID))
-	g.Expect(found.State).To(Equal("Pending"))
 }
 
 // TestCacheUserByUseridMaps tests that all userid maps are maintained.

--- a/internal/auth/storage.go
+++ b/internal/auth/storage.go
@@ -26,7 +26,7 @@ import (
 
 // Storage implements op.Storage.
 type Storage struct {
-	mutex               sync.RWMutex
+	mutex               sync.Mutex
 	keySet              KeySet
 	db                  *gorm.DB
 	authReqById         map[string]*AuthRequest
@@ -181,8 +181,8 @@ func (r *Storage) CreateAuthRequest(
 
 // AuthRequestByID retrieves an auth request by ID.
 func (r *Storage) AuthRequestByID(_ context.Context, id string) (req op.AuthRequest, err error) {
-	r.mutex.RLock()
-	defer r.mutex.RUnlock()
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
 	defer func() {
 		if err != nil {
 			Log.Error(err, "")
@@ -203,8 +203,8 @@ func (r *Storage) AuthRequestByID(_ context.Context, id string) (req op.AuthRequ
 
 // AuthRequestByCode retrieves auth request by authorization code.
 func (r *Storage) AuthRequestByCode(_ context.Context, code string) (req op.AuthRequest, err error) {
-	r.mutex.RLock()
-	defer r.mutex.RUnlock()
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
 	defer func() {
 		if err != nil {
 			Log.Error(err, "")
@@ -1233,8 +1233,8 @@ func (r *Storage) createGrant(
 
 // authCodeById returns the auth code for an auth request.
 func (r *Storage) authCodeById(id string) (code string) {
-	r.mutex.RLock()
-	defer r.mutex.RUnlock()
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
 	authReq, found := r.authReqById[id]
 	if found {
 		code = authReq.authCode
@@ -1331,9 +1331,9 @@ func (r *Storage) GetDeviceAuthorizatonState(
 			Log.Error(err, "")
 		}
 	}()
-	r.mutex.RLock()
+	r.mutex.Lock()
 	devAuth, found := r.devAuthReqByDevCode[deviceCode]
-	r.mutex.RUnlock()
+	r.mutex.Unlock()
 
 	if !found {
 		err = oidc.ErrInvalidGrant().WithDescription("deviceCode not-found.")
@@ -1365,8 +1365,8 @@ func (r *Storage) DeleteDevAuthByCode(deviceCode string) {
 
 // devAuthCodeBySubject returns device code for completed device authorization by subject.
 func (r *Storage) devAuthCodeBySubject(subject string) (deviceCode string) {
-	r.mutex.RLock()
-	defer r.mutex.RUnlock()
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
 	for code, req := range r.devAuthReqByDevCode {
 		if req.subject == subject && req.done {
 			deviceCode = code
@@ -1379,8 +1379,8 @@ func (r *Storage) devAuthCodeBySubject(subject string) (deviceCode string) {
 // GetDevAuthByUserCode returns device authorization by user code.
 // Returns the device authorization request and true if found, otherwise nil and false.
 func (r *Storage) GetDevAuthByUserCode(userCode string) (devAuth *DeviceAuthRequest, found bool) {
-	r.mutex.RLock()
-	defer r.mutex.RUnlock()
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
 	deviceCode, found := r.devAuthByUserCode[userCode]
 	if !found {
 		return

--- a/internal/migration/v23/model/core.go
+++ b/internal/migration/v23/model/core.go
@@ -290,7 +290,7 @@ type Token struct {
 	Subject       string       `gorm:"<-:create;index"`
 	Digest        string       `gorm:"<-:create;index"`
 	Issued        time.Time    `gorm:"<-:create;not null"`
-	Scopes        []string     `gorm:"<-:create;type:json;serializer:json"`
+	Scopes        []string     `gorm:"type:json;serializer:json"`
 	Expiration    time.Time    `gorm:"index"`
 	GrantID       *uint        `gorm:"index"`
 	Grant         *Grant       `gorm:"constraint:OnDelete:CASCADE"`

--- a/internal/migration/v23/model/core.go
+++ b/internal/migration/v23/model/core.go
@@ -251,9 +251,9 @@ type IdpClient struct {
 
 type IdpIdentity struct {
 	Model
-	Kind              string    `gorm:"index;not null"`
-	Issuer            string    `gorm:"not null"`
-	Subject           string    `gorm:"uniqueIndex;not null"`
+	Kind              string    `gorm:"<-:create;index;not null"`
+	Issuer            string    `gorm:"<-:create;not null"`
+	Subject           string    `gorm:"<-:create;uniqueIndex;not null"`
 	RefreshToken      string    `gorm:"not null" secret:""`
 	Expiration        time.Time `gorm:"index"`
 	LastAuthenticated time.Time
@@ -272,10 +272,10 @@ type RsaKey struct {
 
 type Grant struct {
 	Model
-	Kind         string `gorm:"not null"`
-	ClientId     string `gorm:"index;not null"`
-	AuthId       string `gorm:"uniqueIndex;not null"`
-	Subject      string `gorm:"index"`
+	Kind         string `gorm:"<-:create;not null"`
+	ClientId     string `gorm:"<-:create;index;not null"`
+	AuthId       string `gorm:"<-:create;uniqueIndex;not null"`
+	Subject      string `gorm:"<-:create;index"`
 	RefreshToken string `gorm:"uniqueIndex"` // digest
 	AuthCode     string `gorm:"index"`
 	Scopes       string
@@ -285,14 +285,13 @@ type Grant struct {
 
 type Token struct {
 	Model
-	Kind          string    `gorm:"not null"`
-	AuthId        string    `gorm:"uniqueIndex;not null"`
-	Subject       string    `gorm:"index"`
-	Digest        string    `gorm:"index"`
-	Scopes        []string  `gorm:"type:json;serializer:json"`
-	Issued        time.Time `gorm:"not null"`
-	Expiration    time.Time
-	Revoked       time.Time
+	Kind          string       `gorm:"<-:create;not null"`
+	AuthId        string       `gorm:"<-:create;uniqueIndex;not null"`
+	Subject       string       `gorm:"<-:create;index"`
+	Digest        string       `gorm:"<-:create;index"`
+	Issued        time.Time    `gorm:"<-:create;not null"`
+	Scopes        []string     `gorm:"<-:create;type:json;serializer:json"`
+	Expiration    time.Time    `gorm:"index"`
 	GrantID       *uint        `gorm:"index"`
 	Grant         *Grant       `gorm:"constraint:OnDelete:CASCADE"`
 	UserID        *uint        `gorm:"index"`

--- a/internal/reaper/manager.go
+++ b/internal/reaper/manager.go
@@ -22,7 +22,7 @@ type Task = task.Task
 
 // Manager provides task management.
 type Manager struct {
-	mutex sync.RWMutex
+	mutex sync.Mutex
 	// DB
 	DB *gorm.DB
 	// k8s client.

--- a/internal/task/cluster.go
+++ b/internal/task/cluster.go
@@ -22,7 +22,7 @@ func NewCluster(client k8s.Client) (cluster Cluster) {
 // Maps must NOT be accessed directly.
 type Cluster struct {
 	k8s.Client
-	mutex      sync.RWMutex
+	mutex      sync.Mutex
 	tackle     *crd.Tackle
 	addons     map[string]*crd.Addon
 	extensions map[string]*crd.Extension
@@ -68,24 +68,24 @@ func (k *Cluster) Refresh() (err error) {
 
 // Tackle returns the tackle resource.
 func (k *Cluster) Tackle() (r *crd.Tackle) {
-	k.mutex.RLock()
-	defer k.mutex.RUnlock()
+	k.mutex.Lock()
+	defer k.mutex.Unlock()
 	r = k.tackle
 	return
 }
 
 // Addon returns an addon by name.
 func (k *Cluster) Addon(name string) (r *crd.Addon, found bool) {
-	k.mutex.RLock()
-	defer k.mutex.RUnlock()
+	k.mutex.Lock()
+	defer k.mutex.Unlock()
 	r, found = k.addons[name]
 	return
 }
 
 // Addons returns an addon by name.
 func (k *Cluster) Addons() (list []*crd.Addon) {
-	k.mutex.RLock()
-	defer k.mutex.RUnlock()
+	k.mutex.Lock()
+	defer k.mutex.Unlock()
 	for _, r := range k.addons {
 		list = append(list, r)
 	}
@@ -94,16 +94,16 @@ func (k *Cluster) Addons() (list []*crd.Addon) {
 
 // Extension returns an extension by name.
 func (k *Cluster) Extension(name string) (r *crd.Extension, found bool) {
-	k.mutex.RLock()
-	defer k.mutex.RUnlock()
+	k.mutex.Lock()
+	defer k.mutex.Unlock()
 	r, found = k.extensions[name]
 	return
 }
 
 // Extensions returns an extension by name.
 func (k *Cluster) Extensions() (list []*crd.Extension) {
-	k.mutex.RLock()
-	defer k.mutex.RUnlock()
+	k.mutex.Lock()
+	defer k.mutex.Unlock()
 	for _, r := range k.extensions {
 		list = append(list, r)
 	}
@@ -112,8 +112,8 @@ func (k *Cluster) Extensions() (list []*crd.Extension) {
 
 // FindExtensions returns extensions by name.
 func (k *Cluster) FindExtensions(names []string) (list []*crd.Extension, err error) {
-	k.mutex.RLock()
-	defer k.mutex.RUnlock()
+	k.mutex.Lock()
+	defer k.mutex.Unlock()
 	for _, name := range names {
 		r, found := k.extensions[name]
 		if !found {
@@ -127,24 +127,24 @@ func (k *Cluster) FindExtensions(names []string) (list []*crd.Extension, err err
 
 // Task returns a task by name.
 func (k *Cluster) Task(name string) (r *crd.Task, found bool) {
-	k.mutex.RLock()
-	defer k.mutex.RUnlock()
+	k.mutex.Lock()
+	defer k.mutex.Unlock()
 	r, found = k.tasks[name]
 	return
 }
 
 // Pod returns a pod by name.
 func (k *Cluster) Pod(name string) (r *core.Pod, found bool) {
-	k.mutex.RLock()
-	defer k.mutex.RUnlock()
+	k.mutex.Lock()
+	defer k.mutex.Unlock()
 	r, found = k.pods.tasks[name]
 	return
 }
 
 // OtherPods returns a list of non-task pods.
 func (k *Cluster) OtherPods() (list []*core.Pod) {
-	k.mutex.RLock()
-	defer k.mutex.RUnlock()
+	k.mutex.Lock()
+	defer k.mutex.Unlock()
 	for _, r := range k.pods.other {
 		list = append(list, r)
 	}
@@ -153,8 +153,8 @@ func (k *Cluster) OtherPods() (list []*core.Pod) {
 
 // TaskPods returns a list of task pods.
 func (k *Cluster) TaskPods() (list []*core.Pod) {
-	k.mutex.RLock()
-	defer k.mutex.RUnlock()
+	k.mutex.Lock()
+	defer k.mutex.Unlock()
 	for _, r := range k.pods.tasks {
 		list = append(list, r)
 	}
@@ -163,8 +163,8 @@ func (k *Cluster) TaskPods() (list []*core.Pod) {
 
 // TaskPodsScheduled returns a list of task pods scheduled.
 func (k *Cluster) TaskPodsScheduled() (list []*core.Pod) {
-	k.mutex.RLock()
-	defer k.mutex.RUnlock()
+	k.mutex.Lock()
+	defer k.mutex.Unlock()
 	for _, r := range k.pods.tasks {
 		if r.Status.Phase == core.PodFailed || r.Status.Phase == core.PodSucceeded {
 			continue
@@ -176,8 +176,8 @@ func (k *Cluster) TaskPodsScheduled() (list []*core.Pod) {
 
 // Quotas returns quotas.
 func (k *Cluster) Quotas() (list []*core.ResourceQuota) {
-	k.mutex.RLock()
-	defer k.mutex.RUnlock()
+	k.mutex.Lock()
+	defer k.mutex.Unlock()
 	for _, r := range k.quotas {
 		list = append(list, r)
 	}

--- a/shared/binding/auth/oidc.go
+++ b/shared/binding/auth/oidc.go
@@ -50,7 +50,7 @@ func NewOIDC(issuerURL, clientId string) (h *OIDC) {
 
 // OIDC provides OIDC authentication with automatic token refresh.
 type OIDC struct {
-	mutex        sync.RWMutex
+	mutex        sync.Mutex
 	issuerURL    string
 	clientId     string
 	httpClient   *http.Client
@@ -67,8 +67,8 @@ func (p *OIDC) Use(token string) {
 
 // Token returns the access token.
 func (p *OIDC) Token() (token string) {
-	p.mutex.RLock()
-	defer p.mutex.RUnlock()
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
 	token = p.accessToken
 	return
 }
@@ -111,8 +111,8 @@ func (p *OIDC) Login() (err error) {
 
 // Header returns the Authorization header value.
 func (p *OIDC) Header() (header string) {
-	p.mutex.RLock()
-	defer p.mutex.RUnlock()
+	p.mutex.Lock()
+	defer p.mutex.Unlock()
 	header = "Bearer " + p.accessToken
 	return
 }


### PR DESCRIPTION
Fix deadlock in auth.Cache.

closes #1057 

Rewrote the auth.Cache to not require a mutex. The cause of the lockup was a classic gotcha when using RWMutex.

Sequence:
1. Goroutine A acquires `RLock()`.
2. Goroutine B calls `Lock()` → blocks (writer waiting).
3. Goroutine A (still holding the outer read lock) calls `RLock()` again (nested) → blocks (no new readers allowed while writer is pending).
4. Writer B cannot proceed because A still holds a read lock.
5. **Permanent deadlock.**

This is a well-know pipfall.
> "If a goroutine holds a RWMutex for reading and another goroutine might call Lock, **no goroutine should expect to be able to acquire a read lock** until the initial read lock is released. In particular, this prohibits recursive read-locking."  
> — [sync.RWMutex docs](https://pkg.go.dev/sync#RWMutex)

The  cache is a read-many, write-few cache that needs to be optimized for read performance.  The approach taken was to not require a mutex for reads and copy-on-write for cache updates and safety-net refresh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request middleware and transactional cleanup to reset resources more reliably, including on early exits and errors.
  * Hardened built-in auth initialization so cache refresh failures abort provider setup.
* **Refactor**
  * Reworked the authentication cache to use copy-on-write snapshots with on-demand refresh and atomic updates.
  * Simplified internal synchronization by switching from read/write locks to exclusive locks in multiple components.
  * Removed task-grant cache notifications to align token handling with the new cache model.
* **Tests**
  * Added extensive concurrency/copy-on-write coverage and updated existing auth/cache tests to match the new behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->