### PR TITLE
:bug: Fix token deletes.

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -77,6 +77,7 @@ func port() (port string) {
 }
 
 // main.
+// Note: The initialization order is very important.
 func main() {
 	Log.Info("Started:\n" + Settings.String())
 	var err error
@@ -119,6 +120,11 @@ func main() {
 	client, err := k8s.NewClient()
 	if err != nil {
 		err = liberr.Wrap(err)
+		return
+	}
+	// Auth
+	auth.IdP, err = auth.New(db)
+	if err != nil {
 		return
 	}
 	// Document migration.
@@ -168,11 +174,6 @@ func main() {
 		}
 		metricsManager.Run(context.Background())
 	}
-	// Auth
-	auth.IdP, err = auth.New(db)
-	if err != nil {
-		return
-	}
 	// Web
 	router := gin.Default()
 	router.Use(
@@ -190,7 +191,7 @@ func main() {
 		h.AddRoutes(router)
 	}
 	//
-	// Auth
+	// Auth domain.
 	domain := auth.NewDomain(db)
 	err = domain.Seed()
 	if err != nil {

--- a/internal/auth/pkg.go
+++ b/internal/auth/pkg.go
@@ -45,10 +45,6 @@ var (
 	IdP       Provider
 )
 
-func init() {
-	IdP = &NoAuth{}
-}
-
 // New returns an auth provider.
 func New(db *gorm.DB) (p Provider, err error) {
 	err = federated.Load(Settings.Namespace)

--- a/internal/auth/storage.go
+++ b/internal/auth/storage.go
@@ -1143,9 +1143,10 @@ func (r *Storage) deleteToken(_ context.Context, id string) (err error) {
 		return
 	}
 	for _, m := range tokens {
-		r.cache.TokenDeleted(m.ID)
-		err = db.Delete(m).Error
-		if err != nil {
+		err = r.db.Delete(m).Error
+		if err == nil {
+			r.cache.TokenDeleted(m.ID)
+		} else {
 			err = liberr.Wrap(err)
 			return
 		}
@@ -1164,9 +1165,10 @@ func (r *Storage) deleteTokensBySubject(_ context.Context, subject string) (err 
 		return
 	}
 	for _, m := range tokens {
-		r.cache.TokenDeleted(m.ID)
-		err = db.Delete(m).Error
-		if err != nil {
+		err = r.db.Delete(m).Error
+		if err == nil {
+			r.cache.TokenDeleted(m.ID)
+		} else {
 			err = liberr.Wrap(err)
 			return
 		}

--- a/internal/auth/storage.go
+++ b/internal/auth/storage.go
@@ -1134,20 +1134,42 @@ func (r *Storage) token(_ context.Context, id string) (m *Token, err error) {
 
 // deleteToken deletes a token by id.
 func (r *Storage) deleteToken(_ context.Context, id string) (err error) {
-	m := &Token{}
-	err = r.db.Delete(m, "authId", id).Error
+	var tokens []*Token
+	db := r.db.Where("authId", id)
+	db = db.Where("kind", KindAccessToken)
+	err = db.Find(&tokens).Error
 	if err != nil {
 		err = liberr.Wrap(err)
+		return
+	}
+	for _, m := range tokens {
+		r.cache.TokenDeleted(m.ID)
+		err = db.Delete(m).Error
+		if err != nil {
+			err = liberr.Wrap(err)
+			return
+		}
 	}
 	return
 }
 
 // deleteTokensBySubject deletes all tokens for a subject.
 func (r *Storage) deleteTokensBySubject(_ context.Context, subject string) (err error) {
-	m := &Token{}
-	err = r.db.Delete(m, "subject", subject).Error
+	var tokens []*Token
+	db := r.db.Where("subject", subject)
+	db = db.Where("kind", KindAccessToken)
+	err = db.Find(&tokens).Error
 	if err != nil {
 		err = liberr.Wrap(err)
+		return
+	}
+	for _, m := range tokens {
+		r.cache.TokenDeleted(m.ID)
+		err = db.Delete(m).Error
+		if err != nil {
+			err = liberr.Wrap(err)
+			return
+		}
 	}
 	return
 }

--- a/internal/reaper/auth.go
+++ b/internal/reaper/auth.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	liberr "github.com/jortel/go-utils/error"
+	"github.com/konveyor/tackle2-hub/internal/auth"
 	"github.com/konveyor/tackle2-hub/internal/model"
 	"gorm.io/gorm"
 )
@@ -19,7 +20,9 @@ type TokenReaper struct {
 func (r *TokenReaper) Run() {
 	Log.V(1).Info("Reaping tokens.")
 
-	mark := time.Now().Add(-time.Hour)
+	mark := time.Now().Add(-time.Minute)
+
+	cache := auth.IdP.Cache()
 
 	err := r.DB.Transaction(
 		func(tx *gorm.DB) (err error) {
@@ -30,6 +33,7 @@ func (r *TokenReaper) Run() {
 				return
 			}
 			for _, token := range list {
+				cache.TokenDeleted(token.ID)
 				err = tx.Delete(token).Error
 				if err != nil {
 					err = liberr.Wrap(err)

--- a/internal/reaper/pkg_test.go
+++ b/internal/reaper/pkg_test.go
@@ -1,16 +1,43 @@
 package reaper
 
 import (
+	"net/http"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/konveyor/tackle2-hub/internal/auth"
+	"github.com/konveyor/tackle2-hub/internal/auth/cache"
 	"github.com/konveyor/tackle2-hub/internal/database"
 	"github.com/konveyor/tackle2-hub/internal/model"
 	"github.com/konveyor/tackle2-hub/internal/task"
 	"github.com/onsi/gomega"
 	"gorm.io/gorm"
 )
+
+// FakeProvider is a minimal auth.Provider implementation for testing.
+// Only Cache() returns a real implementation; all other methods are stubs.
+type FakeProvider struct {
+	cache *auth.Cache
+}
+
+func (f *FakeProvider) Ready(r *http.Request)                                            {}
+func (f *FakeProvider) Cache() *auth.Cache                                               { return f.cache }
+func (f *FakeProvider) Login(w http.ResponseWriter, r *http.Request, reqId string) error { return nil }
+func (f *FakeProvider) NewToken(subject string, lifespan time.Duration) (auth.Token, error) {
+	return auth.Token{}, nil
+}
+func (f *FakeProvider) TaskGrant(taskId uint) (auth.Token, error)        { return auth.Token{}, nil }
+func (f *FakeProvider) TaskRevoke(taskId uint)                           {}
+func (f *FakeProvider) Revoke(tokenId uint) error                        { return nil }
+func (f *FakeProvider) Authenticate(r *auth.Request) (*jwt.Token, error) { return nil, nil }
+func (f *FakeProvider) Scopes(jwToken *jwt.Token) []auth.Scope           { return nil }
+func (f *FakeProvider) User(jwToken *jwt.Token) string                   { return "" }
+func (f *FakeProvider) Subject(jwToken *jwt.Token) string                { return "" }
+func (f *FakeProvider) Handler() http.Handler                            { return nil }
+func (f *FakeProvider) DagHandler() *auth.DagHandler                     { return nil }
+func (f *FakeProvider) IdpHandler() *auth.FedIdpHandler                  { return nil }
 
 // TestBucketReaper_OrphanDetection tests bucket orphan detection and deletion.
 func TestBucketReaper_OrphanDetection(t *testing.T) {
@@ -522,6 +549,11 @@ func TestManager_Iterate(t *testing.T) {
 
 	db, err := setupDB()
 	g.Expect(err).To(gomega.BeNil())
+
+	// Setup fake auth provider for TokenReaper
+	savedIdP := auth.IdP
+	defer func() { auth.IdP = savedIdP }()
+	auth.IdP = &FakeProvider{cache: cache.New(db)}
 
 	// Create orphan bucket
 	bucket := &model.Bucket{Path: "/tmp/test-bucket"}
@@ -1067,6 +1099,11 @@ func TestTokenReaper_NotExpired(t *testing.T) {
 	db, err := setupDB()
 	g.Expect(err).To(gomega.BeNil())
 
+	// Setup fake auth provider for reaper
+	savedIdP := auth.IdP
+	defer func() { auth.IdP = savedIdP }()
+	auth.IdP = &FakeProvider{cache: cache.New(db)}
+
 	// Create token that expires in the future
 	futureTime := time.Now().Add(2 * time.Hour)
 	token := &model.Token{
@@ -1089,19 +1126,24 @@ func TestTokenReaper_NotExpired(t *testing.T) {
 	g.Expect(tok.ID).To(gomega.Equal(token.ID))
 }
 
-// TestTokenReaper_WithinGracePeriod tests that tokens expired less than 1 hour are not deleted.
+// TestTokenReaper_WithinGracePeriod tests that tokens expired less than 1 minute are not deleted.
 func TestTokenReaper_WithinGracePeriod(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	db, err := setupDB()
 	g.Expect(err).To(gomega.BeNil())
 
-	// Create token expired 30 minutes ago (within 1-hour grace period)
-	expiredTime := time.Now().Add(-30 * time.Minute)
+	// Setup fake auth provider for reaper
+	savedIdP := auth.IdP
+	defer func() { auth.IdP = savedIdP }()
+	auth.IdP = &FakeProvider{cache: cache.New(db)}
+
+	// Create token expired 30 seconds ago (within 1-minute grace period)
+	expiredTime := time.Now().Add(-30 * time.Second)
 	token := &model.Token{
 		Kind:       "access",
 		Scopes:     []string{"read"},
-		Issued:     time.Now().Add(-1 * time.Hour),
+		Issued:     time.Now().Add(-2 * time.Minute),
 		Expiration: expiredTime,
 	}
 	err = db.Create(token).Error
@@ -1118,19 +1160,24 @@ func TestTokenReaper_WithinGracePeriod(t *testing.T) {
 	g.Expect(tok.ID).To(gomega.Equal(token.ID))
 }
 
-// TestTokenReaper_ExpiredPastGracePeriod tests that tokens expired more than 1 hour are deleted.
+// TestTokenReaper_ExpiredPastGracePeriod tests that tokens expired more than 1 minute are deleted.
 func TestTokenReaper_ExpiredPastGracePeriod(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	db, err := setupDB()
 	g.Expect(err).To(gomega.BeNil())
 
-	// Create token expired 2 hours ago (past grace period)
-	expiredTime := time.Now().Add(-2 * time.Hour)
+	// Setup fake auth provider for reaper
+	savedIdP := auth.IdP
+	defer func() { auth.IdP = savedIdP }()
+	auth.IdP = &FakeProvider{cache: cache.New(db)}
+
+	// Create token expired 2 minutes ago (past grace period)
+	expiredTime := time.Now().Add(-2 * time.Minute)
 	token := &model.Token{
 		Kind:       "refresh",
 		Scopes:     []string{"read", "write"},
-		Issued:     time.Now().Add(-3 * time.Hour),
+		Issued:     time.Now().Add(-5 * time.Minute),
 		Expiration: expiredTime,
 	}
 	err = db.Create(token).Error
@@ -1154,6 +1201,11 @@ func TestTokenReaper_MultipleTokens(t *testing.T) {
 	db, err := setupDB()
 	g.Expect(err).To(gomega.BeNil())
 
+	// Setup fake auth provider for reaper
+	savedIdP := auth.IdP
+	defer func() { auth.IdP = savedIdP }()
+	auth.IdP = &FakeProvider{cache: cache.New(db)}
+
 	// Create multiple tokens with different expiration times
 	now := time.Now()
 	futureToken := &model.Token{
@@ -1161,28 +1213,28 @@ func TestTokenReaper_MultipleTokens(t *testing.T) {
 		AuthId:     "a",
 		Scopes:     []string{"read"},
 		Issued:     now,
-		Expiration: now.Add(2 * time.Hour),
+		Expiration: now.Add(10 * time.Minute),
 	}
 	graceToken := &model.Token{
 		Kind:       "access",
 		AuthId:     "b",
 		Scopes:     []string{"write"},
-		Issued:     now.Add(-1 * time.Hour),
-		Expiration: now.Add(-30 * time.Minute),
+		Issued:     now.Add(-2 * time.Minute),
+		Expiration: now.Add(-30 * time.Second),
 	}
 	expiredToken1 := &model.Token{
 		Kind:       "refresh",
 		AuthId:     "c",
 		Scopes:     []string{"read", "write"},
-		Issued:     now.Add(-3 * time.Hour),
-		Expiration: now.Add(-2 * time.Hour),
+		Issued:     now.Add(-5 * time.Minute),
+		Expiration: now.Add(-2 * time.Minute),
 	}
 	expiredToken2 := &model.Token{
 		Kind:       "access",
 		AuthId:     "d",
 		Scopes:     []string{"read"},
-		Issued:     now.Add(-4 * time.Hour),
-		Expiration: now.Add(-3 * time.Hour),
+		Issued:     now.Add(-10 * time.Minute),
+		Expiration: now.Add(-5 * time.Minute),
 	}
 
 	err = db.Create(futureToken).Error

--- a/internal/reaper/pkg_test.go
+++ b/internal/reaper/pkg_test.go
@@ -1,17 +1,15 @@
 package reaper
 
 import (
-	"net/http"
 	"os"
 	"testing"
 	"time"
 
-	"github.com/golang-jwt/jwt/v5"
 	"github.com/konveyor/tackle2-hub/internal/auth"
-	"github.com/konveyor/tackle2-hub/internal/auth/cache"
 	"github.com/konveyor/tackle2-hub/internal/database"
 	"github.com/konveyor/tackle2-hub/internal/model"
 	"github.com/konveyor/tackle2-hub/internal/task"
+	"github.com/konveyor/tackle2-hub/shared/settings"
 	"github.com/onsi/gomega"
 	"gorm.io/gorm"
 )
@@ -527,10 +525,11 @@ func TestManager_Iterate(t *testing.T) {
 	db, err := setupDB()
 	g.Expect(err).To(gomega.BeNil())
 
-	// Setup fake auth provider for TokenReaper
+	// Setup auth provider for TokenReaper
 	savedIdP := auth.IdP
 	defer func() { auth.IdP = savedIdP }()
-	auth.IdP = &FakeProvider{cache: cache.New(db)}
+	auth.IdP, err = setupIdp(db)
+	g.Expect(err).To(gomega.BeNil())
 
 	// Create orphan bucket
 	bucket := &model.Bucket{Path: "/tmp/test-bucket"}
@@ -1076,10 +1075,11 @@ func TestTokenReaper_NotExpired(t *testing.T) {
 	db, err := setupDB()
 	g.Expect(err).To(gomega.BeNil())
 
-	// Setup fake auth provider for reaper
+	// Setup auth provider for reaper
 	savedIdP := auth.IdP
 	defer func() { auth.IdP = savedIdP }()
-	auth.IdP = &FakeProvider{cache: cache.New(db)}
+	auth.IdP, err = setupIdp(db)
+	g.Expect(err).To(gomega.BeNil())
 
 	// Create token that expires in the future
 	futureTime := time.Now().Add(2 * time.Hour)
@@ -1110,10 +1110,11 @@ func TestTokenReaper_WithinGracePeriod(t *testing.T) {
 	db, err := setupDB()
 	g.Expect(err).To(gomega.BeNil())
 
-	// Setup fake auth provider for reaper
+	// Setup auth provider for reaper
 	savedIdP := auth.IdP
 	defer func() { auth.IdP = savedIdP }()
-	auth.IdP = &FakeProvider{cache: cache.New(db)}
+	auth.IdP, err = setupIdp(db)
+	g.Expect(err).To(gomega.BeNil())
 
 	// Create token expired 30 seconds ago (within 1-minute grace period)
 	expiredTime := time.Now().Add(-30 * time.Second)
@@ -1144,10 +1145,11 @@ func TestTokenReaper_ExpiredPastGracePeriod(t *testing.T) {
 	db, err := setupDB()
 	g.Expect(err).To(gomega.BeNil())
 
-	// Setup fake auth provider for reaper
+	// Setup auth provider for reaper
 	savedIdP := auth.IdP
 	defer func() { auth.IdP = savedIdP }()
-	auth.IdP = &FakeProvider{cache: cache.New(db)}
+	auth.IdP, err = setupIdp(db)
+	g.Expect(err).To(gomega.BeNil())
 
 	// Create token expired 2 minutes ago (past grace period)
 	expiredTime := time.Now().Add(-2 * time.Minute)
@@ -1178,10 +1180,11 @@ func TestTokenReaper_MultipleTokens(t *testing.T) {
 	db, err := setupDB()
 	g.Expect(err).To(gomega.BeNil())
 
-	// Setup fake auth provider for reaper
+	// Setup auth provider for reaper
 	savedIdP := auth.IdP
 	defer func() { auth.IdP = savedIdP }()
-	auth.IdP = &FakeProvider{cache: cache.New(db)}
+	auth.IdP, err = setupIdp(db)
+	g.Expect(err).To(gomega.BeNil())
 
 	// Create multiple tokens with different expiration times
 	now := time.Now()
@@ -1399,28 +1402,18 @@ func TestGrantReaper_MultipleGrants(t *testing.T) {
 	g.Expect(err).To(gomega.Equal(gorm.ErrRecordNotFound))
 }
 
-// FakeProvider is a minimal auth.Provider implementation for testing.
-// Only Cache() returns a real implementation; all other methods are stubs.
-type FakeProvider struct {
-	cache *auth.Cache
+// setupIdp creates an auth provider for testing without federated IdP configuration.
+func setupIdp(db *gorm.DB) (p auth.Provider, err error) {
+	builtin, err := auth.NewBuiltin(db)
+	if err != nil {
+		return
+	}
+	p = auth.NewNoAuth(builtin)
+	if settings.Settings.Auth.Required {
+		p = builtin
+	}
+	return
 }
-
-func (f *FakeProvider) Ready(r *http.Request)                                            {}
-func (f *FakeProvider) Cache() *auth.Cache                                               { return f.cache }
-func (f *FakeProvider) Login(w http.ResponseWriter, r *http.Request, reqId string) error { return nil }
-func (f *FakeProvider) NewToken(subject string, lifespan time.Duration) (auth.Token, error) {
-	return auth.Token{}, nil
-}
-func (f *FakeProvider) TaskGrant(taskId uint) (auth.Token, error)        { return auth.Token{}, nil }
-func (f *FakeProvider) TaskRevoke(taskId uint)                           {}
-func (f *FakeProvider) Revoke(tokenId uint) error                        { return nil }
-func (f *FakeProvider) Authenticate(r *auth.Request) (*jwt.Token, error) { return nil, nil }
-func (f *FakeProvider) Scopes(jwToken *jwt.Token) []auth.Scope           { return nil }
-func (f *FakeProvider) User(jwToken *jwt.Token) string                   { return "" }
-func (f *FakeProvider) Subject(jwToken *jwt.Token) string                { return "" }
-func (f *FakeProvider) Handler() http.Handler                            { return nil }
-func (f *FakeProvider) DagHandler() *auth.DagHandler                     { return nil }
-func (f *FakeProvider) IdpHandler() *auth.FedIdpHandler                  { return nil }
 
 // setupDB creates an in-memory SQLite database for testing.
 func setupDB() (db *gorm.DB, err error) {
@@ -1443,6 +1436,7 @@ func setupDB() (db *gorm.DB, err error) {
 		&model.AnalysisProfile{},
 		&model.Token{},
 		&model.Grant{},
+		&model.RsaKey{},
 	)
 
 	return

--- a/internal/reaper/pkg_test.go
+++ b/internal/reaper/pkg_test.go
@@ -16,29 +16,6 @@ import (
 	"gorm.io/gorm"
 )
 
-// FakeProvider is a minimal auth.Provider implementation for testing.
-// Only Cache() returns a real implementation; all other methods are stubs.
-type FakeProvider struct {
-	cache *auth.Cache
-}
-
-func (f *FakeProvider) Ready(r *http.Request)                                            {}
-func (f *FakeProvider) Cache() *auth.Cache                                               { return f.cache }
-func (f *FakeProvider) Login(w http.ResponseWriter, r *http.Request, reqId string) error { return nil }
-func (f *FakeProvider) NewToken(subject string, lifespan time.Duration) (auth.Token, error) {
-	return auth.Token{}, nil
-}
-func (f *FakeProvider) TaskGrant(taskId uint) (auth.Token, error)        { return auth.Token{}, nil }
-func (f *FakeProvider) TaskRevoke(taskId uint)                           {}
-func (f *FakeProvider) Revoke(tokenId uint) error                        { return nil }
-func (f *FakeProvider) Authenticate(r *auth.Request) (*jwt.Token, error) { return nil, nil }
-func (f *FakeProvider) Scopes(jwToken *jwt.Token) []auth.Scope           { return nil }
-func (f *FakeProvider) User(jwToken *jwt.Token) string                   { return "" }
-func (f *FakeProvider) Subject(jwToken *jwt.Token) string                { return "" }
-func (f *FakeProvider) Handler() http.Handler                            { return nil }
-func (f *FakeProvider) DagHandler() *auth.DagHandler                     { return nil }
-func (f *FakeProvider) IdpHandler() *auth.FedIdpHandler                  { return nil }
-
 // TestBucketReaper_OrphanDetection tests bucket orphan detection and deletion.
 func TestBucketReaper_OrphanDetection(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
@@ -1421,6 +1398,29 @@ func TestGrantReaper_MultipleGrants(t *testing.T) {
 	err = db.First(&g4, expiredGrant2.ID).Error
 	g.Expect(err).To(gomega.Equal(gorm.ErrRecordNotFound))
 }
+
+// FakeProvider is a minimal auth.Provider implementation for testing.
+// Only Cache() returns a real implementation; all other methods are stubs.
+type FakeProvider struct {
+	cache *auth.Cache
+}
+
+func (f *FakeProvider) Ready(r *http.Request)                                            {}
+func (f *FakeProvider) Cache() *auth.Cache                                               { return f.cache }
+func (f *FakeProvider) Login(w http.ResponseWriter, r *http.Request, reqId string) error { return nil }
+func (f *FakeProvider) NewToken(subject string, lifespan time.Duration) (auth.Token, error) {
+	return auth.Token{}, nil
+}
+func (f *FakeProvider) TaskGrant(taskId uint) (auth.Token, error)        { return auth.Token{}, nil }
+func (f *FakeProvider) TaskRevoke(taskId uint)                           {}
+func (f *FakeProvider) Revoke(tokenId uint) error                        { return nil }
+func (f *FakeProvider) Authenticate(r *auth.Request) (*jwt.Token, error) { return nil, nil }
+func (f *FakeProvider) Scopes(jwToken *jwt.Token) []auth.Scope           { return nil }
+func (f *FakeProvider) User(jwToken *jwt.Token) string                   { return "" }
+func (f *FakeProvider) Subject(jwToken *jwt.Token) string                { return "" }
+func (f *FakeProvider) Handler() http.Handler                            { return nil }
+func (f *FakeProvider) DagHandler() *auth.DagHandler                     { return nil }
+func (f *FakeProvider) IdpHandler() *auth.FedIdpHandler                  { return nil }
 
 // setupDB creates an in-memory SQLite database for testing.
 func setupDB() (db *gorm.DB, err error) {


### PR DESCRIPTION
closes #1064 

The cmd.main() initialization order needed to be changed to initialize auth before the reaper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of authentication token deletion by ensuring only access tokens are removed for matching identifiers.
  * Strengthened cache synchronization by invalidating cached entries as tokens are cleaned up.
  * Adjusted expired-token cleanup behavior and grace-period handling to use a ~1-minute window (instead of ~1 hour).
* **Tests / Maintenance**
  * Updated token reaper test coverage and timing expectations; expanded test DB migrations to include RSA keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->