### PR TITLE
:sparkles: Better task subject support.

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -1124,6 +1124,18 @@ func (h AuthHandler) GetSelf(ctx *gin.Context) {
 			m := model.IdpClient(*subject.Client)
 			r.Client.With(&m)
 		}
+		if subject.IsTask() {
+			id := subject.Task.ID
+			db := h.DB(ctx)
+			m := &model.Task{}
+			err = db.First(m, id).Error
+			if err != nil {
+				_ = ctx.Error(err)
+				return
+			}
+			r.Task = &Task{}
+			r.Task.With(m)
+		}
 
 		r.Scopes = subject.Scopes
 	} else {
@@ -1199,6 +1211,7 @@ type AuthSelf struct {
 	User     *User        `json:"user,omitempty" yaml:",omitempty"`
 	Identity *IdpIdentity `json:"identity,omitempty" yaml:",omitempty"`
 	Client   *IdpClient   `json:"client,omitempty" yaml:",omitempty"`
+	Task     *Task        `json:"task,omitempty" yaml:",omitempty"`
 	Scopes   []string     `json:"scopes"`
 }
 

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -1109,6 +1109,10 @@ func (h AuthHandler) GetSelf(ctx *gin.Context) {
 	s := h.CurrentSubject(ctx)
 	subject, err := auth.IdP.Cache().FindSubject(s)
 	if err == nil {
+		r.Login = h.CurrentUser(ctx)
+		r.Subject = h.CurrentSubject(ctx)
+		r.Scopes = subject.Scopes
+		//
 		if subject.IsUser() {
 			r.User = &User{}
 			m := model.User(*subject.User)
@@ -1136,8 +1140,6 @@ func (h AuthHandler) GetSelf(ctx *gin.Context) {
 			r.Task = &Task{}
 			r.Task.With(m)
 		}
-
-		r.Scopes = subject.Scopes
 	} else {
 		if !errors.Is(err, &auth.NotFound{}) {
 			_ = ctx.Error(err)
@@ -1208,11 +1210,13 @@ type PAT api.PAT
 
 // AuthSelf REST resource.
 type AuthSelf struct {
+	Login    string       `json:"login"`
+	Subject  string       `json:"subject"`
+	Scopes   []string     `json:"scopes"`
 	User     *User        `json:"user,omitempty" yaml:",omitempty"`
 	Identity *IdpIdentity `json:"identity,omitempty" yaml:",omitempty"`
 	Client   *IdpClient   `json:"client,omitempty" yaml:",omitempty"`
 	Task     *Task        `json:"task,omitempty" yaml:",omitempty"`
-	Scopes   []string     `json:"scopes"`
 }
 
 // Authenticate the user.

--- a/internal/auth/builtin.go
+++ b/internal/auth/builtin.go
@@ -196,14 +196,13 @@ func (p *Builtin) NewToken(subject string, lifespan time.Duration) (m Token, err
 
 // TaskGrant creates a new task api-key.
 func (p *Builtin) TaskGrant(task *Task) (m Token, err error) {
-	m = p.newToken("", 0)
+	m = p.newToken(task.Subject(), 0)
 	m.TaskID = &task.ID
 	err = p.db.Create(&m).Error
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
 	}
-	p.cache.TaskGranted(task)
 	p.cache.TokenSaved(&m)
 	return
 }

--- a/internal/auth/builtin.go
+++ b/internal/auth/builtin.go
@@ -195,14 +195,15 @@ func (p *Builtin) NewToken(subject string, lifespan time.Duration) (m Token, err
 }
 
 // TaskGrant creates a new task api-key.
-func (p *Builtin) TaskGrant(taskId uint) (m Token, err error) {
+func (p *Builtin) TaskGrant(task *Task) (m Token, err error) {
 	m = p.newToken("", 0)
-	m.TaskID = &taskId
+	m.TaskID = &task.ID
 	err = p.db.Create(&m).Error
 	if err != nil {
 		err = liberr.Wrap(err)
 		return
 	}
+	p.cache.TaskGranted(task)
 	p.cache.TokenSaved(&m)
 	return
 }

--- a/internal/auth/cache/cache.go
+++ b/internal/auth/cache/cache.go
@@ -9,9 +9,7 @@ import (
 
 	liberr "github.com/jortel/go-utils/error"
 	"github.com/jortel/go-utils/logr"
-	"github.com/konveyor/tackle2-hub/internal/model"
 	"github.com/konveyor/tackle2-hub/internal/secret"
-	taskapi "github.com/konveyor/tackle2-hub/shared/task"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
@@ -99,14 +97,6 @@ func (r *Cache) UserSaved(m *User) {
 func (r *Cache) UserDeleted(id uint) {
 	_ = r.Transaction(func(tx *Tx) (_ error) {
 		tx.UserDeleted(id)
-		return
-	})
-}
-
-// TaskGranted updates the cache when a task grant created.
-func (r *Cache) TaskGranted(m *Task) {
-	_ = r.Transaction(func(tx *Tx) (_ error) {
-		tx.TaskGranted(m)
 		return
 	})
 }
@@ -241,6 +231,9 @@ func (r *Cache) FindToken(token string) (m *Token, err error) {
 }
 
 // FindSubject returns a subject.
+// Tasks are not stored for performance reasons. They are found
+// by matching the encoded task subject. There is nothing to be
+// gained by storing them.
 func (r *Cache) FindSubject(subject string) (s *Subject, err error) {
 	defer r.ensureRefreshed()
 	d := r.data.Load()
@@ -262,8 +255,9 @@ func (r *Cache) FindSubject(subject string) (s *Subject, err error) {
 		s.WithClient(client, r)
 		return
 	}
-	task, found := d.taskBySubject[subject]
-	if found {
+	task := &Task{}
+	matched := task.With(subject)
+	if matched {
 		s = &Subject{}
 		s.WithTask(task)
 		return
@@ -389,8 +383,6 @@ type Data struct {
 	identByLogin    map[string]*Identity
 	clientById      map[uint]*IdpClient
 	clientBySubject map[string]*IdpClient
-	taskById        map[uint]*Task
-	taskBySubject   map[string]*Task
 	tokenById       map[uint]*Token
 	tokenByDigest   map[string]*Token
 }
@@ -408,8 +400,6 @@ func (d *Data) reset() {
 	d.identByLogin = make(map[string]*Identity)
 	d.clientById = make(map[uint]*IdpClient)
 	d.clientBySubject = make(map[string]*IdpClient)
-	d.taskById = make(map[uint]*Task)
-	d.taskBySubject = make(map[string]*Task)
 	d.tokenById = make(map[uint]*Token)
 	d.tokenByDigest = make(map[string]*Token)
 }
@@ -432,8 +422,6 @@ func (d *Data) clone() *Data {
 		identByLogin:    cloneMap(d.identByLogin),
 		clientById:      cloneMap(d.clientById),
 		clientBySubject: cloneMap(d.clientBySubject),
-		taskById:        cloneMap(d.taskById),
-		taskBySubject:   cloneMap(d.taskBySubject),
 		tokenById:       cloneMap(d.tokenById),
 		tokenByDigest:   cloneMap(d.tokenByDigest),
 	}
@@ -459,10 +447,6 @@ func (d *Data) refresh(db *gorm.DB) (err error) {
 		return
 	}
 	err = d.getClients(db)
-	if err != nil {
-		return
-	}
-	err = d.getTasks(db)
 	if err != nil {
 		return
 	}
@@ -553,28 +537,6 @@ func (d *Data) getClients(db *gorm.DB) (err error) {
 	for _, m := range list {
 		d.clientById[m.ID] = m
 		d.clientBySubject[m.Subject] = m
-	}
-	return
-}
-
-// getTasks fetches tasks from the DB and populates.
-func (d *Data) getTasks(db *gorm.DB) (err error) {
-	list := make([]*model.Task, 0)
-	db = db.Where(
-		"state in (?)",
-		[]string{
-			taskapi.Pending,
-			taskapi.Running,
-		})
-	err = db.Find(&list).Error
-	if err != nil {
-		err = liberr.Wrap(err)
-		return
-	}
-	for _, m := range list {
-		task := &Task{ID: m.ID}
-		d.taskById[task.ID] = task
-		d.taskBySubject[task.Subject()] = task
 	}
 	return
 }

--- a/internal/auth/cache/cache.go
+++ b/internal/auth/cache/cache.go
@@ -9,7 +9,9 @@ import (
 
 	liberr "github.com/jortel/go-utils/error"
 	"github.com/jortel/go-utils/logr"
+	"github.com/konveyor/tackle2-hub/internal/model"
 	"github.com/konveyor/tackle2-hub/internal/secret"
+	taskapi "github.com/konveyor/tackle2-hub/shared/task"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
@@ -97,6 +99,14 @@ func (r *Cache) UserSaved(m *User) {
 func (r *Cache) UserDeleted(id uint) {
 	_ = r.Transaction(func(tx *Tx) (_ error) {
 		tx.UserDeleted(id)
+		return
+	})
+}
+
+// TaskGranted updates the cache when a task grant created.
+func (r *Cache) TaskGranted(m *Task) {
+	_ = r.Transaction(func(tx *Tx) (_ error) {
+		tx.TaskGranted(m)
 		return
 	})
 }
@@ -195,7 +205,7 @@ func (r *Cache) FindToken(token string) (m *Token, err error) {
 	}
 	// task binding.
 	if m.TaskID != nil {
-		m.Subject = "task:" + strconv.Itoa(int(*m.TaskID))
+		m.Subject = Task{ID: *m.TaskID}.Subject()
 		m.Scopes = AddonScopes
 		return
 	}
@@ -250,6 +260,12 @@ func (r *Cache) FindSubject(subject string) (s *Subject, err error) {
 	if found {
 		s = &Subject{}
 		s.WithClient(client, r)
+		return
+	}
+	task, found := d.taskBySubject[subject]
+	if found {
+		s = &Subject{}
+		s.WithTask(task)
 		return
 	}
 	err = &NotFound{
@@ -373,6 +389,8 @@ type Data struct {
 	identByLogin    map[string]*Identity
 	clientById      map[uint]*IdpClient
 	clientBySubject map[string]*IdpClient
+	taskById        map[uint]*Task
+	taskBySubject   map[string]*Task
 	tokenById       map[uint]*Token
 	tokenByDigest   map[string]*Token
 }
@@ -385,12 +403,14 @@ func (d *Data) reset() {
 	d.userById = make(map[uint]*User)
 	d.userBySubject = make(map[string]*User)
 	d.userByLogin = make(map[string]*User)
-	d.tokenById = make(map[uint]*Token)
 	d.identById = make(map[uint]*Identity)
 	d.identBySubject = make(map[string]*Identity)
 	d.identByLogin = make(map[string]*Identity)
 	d.clientById = make(map[uint]*IdpClient)
 	d.clientBySubject = make(map[string]*IdpClient)
+	d.taskById = make(map[uint]*Task)
+	d.taskBySubject = make(map[string]*Task)
+	d.tokenById = make(map[uint]*Token)
 	d.tokenByDigest = make(map[string]*Token)
 }
 
@@ -407,12 +427,14 @@ func (d *Data) clone() *Data {
 		userById:        cloneMap(d.userById),
 		userBySubject:   cloneMap(d.userBySubject),
 		userByLogin:     cloneMap(d.userByLogin),
-		tokenById:       cloneMap(d.tokenById),
 		identById:       cloneMap(d.identById),
 		identBySubject:  cloneMap(d.identBySubject),
 		identByLogin:    cloneMap(d.identByLogin),
 		clientById:      cloneMap(d.clientById),
 		clientBySubject: cloneMap(d.clientBySubject),
+		taskById:        cloneMap(d.taskById),
+		taskBySubject:   cloneMap(d.taskBySubject),
+		tokenById:       cloneMap(d.tokenById),
 		tokenByDigest:   cloneMap(d.tokenByDigest),
 	}
 }
@@ -437,6 +459,10 @@ func (d *Data) refresh(db *gorm.DB) (err error) {
 		return
 	}
 	err = d.getClients(db)
+	if err != nil {
+		return
+	}
+	err = d.getTasks(db)
 	if err != nil {
 		return
 	}
@@ -527,6 +553,28 @@ func (d *Data) getClients(db *gorm.DB) (err error) {
 	for _, m := range list {
 		d.clientById[m.ID] = m
 		d.clientBySubject[m.Subject] = m
+	}
+	return
+}
+
+// getTasks fetches tasks from the DB and populates.
+func (d *Data) getTasks(db *gorm.DB) (err error) {
+	list := make([]*model.Task, 0)
+	db = db.Where(
+		"state in (?)",
+		[]string{
+			taskapi.Pending,
+			taskapi.Running,
+		})
+	err = db.Find(&list).Error
+	if err != nil {
+		err = liberr.Wrap(err)
+		return
+	}
+	for _, m := range list {
+		task := &Task{ID: m.ID}
+		d.taskById[task.ID] = task
+		d.taskBySubject[task.Subject()] = task
 	}
 	return
 }

--- a/internal/auth/cache/pkg.go
+++ b/internal/auth/cache/pkg.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"sort"
 	"strconv"
+	"strings"
 
 	as "github.com/konveyor/tackle2-hub/internal/auth/settings"
 	"github.com/konveyor/tackle2-hub/internal/model"
@@ -71,6 +72,23 @@ type Task struct {
 func (m Task) Subject() (s string) {
 	id := strconv.Itoa(int(m.ID))
 	s = "task." + id
+	return
+}
+
+// With populates the task.
+// matched indicates the encoded subject is a task.
+func (m *Task) With(subject string) (matched bool) {
+	part := strings.Split(subject, ".")
+	if len(part) != 2 {
+		return
+	}
+	if part[0] == "task" {
+		id, err := strconv.Atoi(part[1])
+		if err == nil {
+			m.ID = uint(id)
+			matched = true
+		}
+	}
 	return
 }
 

--- a/internal/auth/cache/pkg.go
+++ b/internal/auth/cache/pkg.go
@@ -69,32 +69,32 @@ type Task struct {
 }
 
 // Login returns the (simulated) login.
+// Format: task.{id}
 func (m Task) Login() (s string) {
-	id := strconv.Itoa(int(m.ID))
+	id := strconv.FormatUint(uint64(m.ID), 10)
 	s = "task." + id
 	return
 }
 
 // Subject returns the task (encoded) subject.
+// Format: task.0x{id}.
 func (m Task) Subject() (s string) {
-	id := strconv.Itoa(int(m.ID))
-	s = "task." + id
+	id := strconv.FormatUint(uint64(m.ID), 16)
+	s = "task.0x" + id
 	return
 }
 
 // With populates the task.
 // matched indicates the encoded subject is a task.
 func (m *Task) With(subject string) (matched bool) {
-	part := strings.Split(subject, ".")
-	if len(part) != 2 {
+	if !strings.HasPrefix(subject, "task.0x") {
 		return
 	}
-	if part[0] == "task" {
-		id, err := strconv.Atoi(part[1])
-		if err == nil {
-			m.ID = uint(id)
-			matched = true
-		}
+	id := subject[7:]
+	uintId, err := strconv.ParseUint(id, 16, 64)
+	if err == nil {
+		m.ID = uint(uintId)
+		matched = true
 	}
 	return
 }

--- a/internal/auth/cache/pkg.go
+++ b/internal/auth/cache/pkg.go
@@ -68,6 +68,13 @@ type Task struct {
 	ID uint
 }
 
+// Login returns the (simulated) login.
+func (m Task) Login() (s string) {
+	id := strconv.Itoa(int(m.ID))
+	s = "task." + id
+	return
+}
+
 // Subject returns the task (encoded) subject.
 func (m Task) Subject() (s string) {
 	id := strconv.Itoa(int(m.ID))

--- a/internal/auth/cache/pkg.go
+++ b/internal/auth/cache/pkg.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"sort"
+	"strconv"
 
 	as "github.com/konveyor/tackle2-hub/internal/auth/settings"
 	"github.com/konveyor/tackle2-hub/internal/model"
@@ -61,8 +62,23 @@ func (m *Role) GetScopes() (scopes []string) {
 // Permission alias.
 type Permission = model.Permission
 
-// Task alias.
-type Task = model.Task
+// Task (lightweight) model.
+type Task struct {
+	ID uint
+}
+
+// Subject returns the task (encoded) subject.
+func (m Task) Subject() (s string) {
+	id := strconv.Itoa(int(m.ID))
+	s = "task." + id
+	return
+}
+
+// GetScopes returns the task scopes.
+func (m Task) GetScopes() (scopes []string) {
+	scopes = AddonScopes
+	return
+}
 
 // Identity alias.
 type Identity = model.IdpIdentity

--- a/internal/auth/cache/pkg_test.go
+++ b/internal/auth/cache/pkg_test.go
@@ -360,8 +360,8 @@ func TestTaskRevokedTransaction(t *testing.T) {
 	g.Expect(err).To(BeNil())
 }
 
-// TestTaskGrantedAddsToCache tests that TaskGranted adds task to cache.
-func TestTaskGrantedAddsToCache(t *testing.T) {
+// TestTaskSubjectParsing tests that task subjects are parsed on-demand.
+func TestTaskSubjectParsing(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	db, err := setupTestDB()
@@ -371,16 +371,9 @@ func TestTaskGrantedAddsToCache(t *testing.T) {
 	err = cache.Refresh()
 	g.Expect(err).To(BeNil())
 
-	// Task not in cache initially
+	// Task subject is always parseable (not cached)
 	task := &Task{ID: 800}
 	expectedSubject := task.Subject()
-	_, err = cache.FindSubject(expectedSubject)
-	g.Expect(err).NotTo(BeNil())
-
-	// Grant task token
-	cache.TaskGranted(task)
-
-	// Task now in cache
 	subject, err := cache.FindSubject(expectedSubject)
 	g.Expect(err).To(BeNil())
 	g.Expect(subject).NotTo(BeNil())
@@ -506,7 +499,7 @@ func TestSubjectLogin(t *testing.T) {
 	g.Expect(emptySubject.Login()).To(BeEmpty())
 }
 
-// TestCacheFindSubjectTask tests finding task subjects.
+// TestCacheFindSubjectTask tests finding task subjects via parsing.
 func TestCacheFindSubjectTask(t *testing.T) {
 	g := NewGomegaWithT(t)
 
@@ -517,11 +510,8 @@ func TestCacheFindSubjectTask(t *testing.T) {
 	err = cache.Refresh()
 	g.Expect(err).To(BeNil())
 
-	// Add task to cache
+	// Task subject is parsed on-demand (not cached)
 	task := &Task{ID: 999}
-	cache.TaskGranted(task)
-
-	// Find task subject
 	expectedSubject := task.Subject()
 	subject, err := cache.FindSubject(expectedSubject)
 	g.Expect(err).To(BeNil())
@@ -548,7 +538,7 @@ func TestCacheFindSubjectTaskNotFound(t *testing.T) {
 	g.Expect(err).To(BeNil())
 
 	// Try to find non-existent task subject
-	nonExistentSubject := Task{ID: 9999}.Subject()
+	nonExistentSubject := "1234"
 	_, err = cache.FindSubject(nonExistentSubject)
 	g.Expect(err).NotTo(BeNil())
 
@@ -558,8 +548,8 @@ func TestCacheFindSubjectTaskNotFound(t *testing.T) {
 	g.Expect(notFound.Id).To(Equal(nonExistentSubject))
 }
 
-// TestTaskRevokedRemovesTaskSubject tests that TaskRevoked removes task from subject cache.
-func TestTaskRevokedRemovesTaskSubject(t *testing.T) {
+// TestTaskSubjectAlwaysParseable tests that task subjects are always parseable.
+func TestTaskSubjectAlwaysParseable(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	db, err := setupTestDB()
@@ -569,26 +559,24 @@ func TestTaskRevokedRemovesTaskSubject(t *testing.T) {
 	err = cache.Refresh()
 	g.Expect(err).To(BeNil())
 
-	// Add task
+	// Task subject is always parseable
 	task := &Task{ID: 1111}
-	cache.TaskGranted(task)
-
-	// Verify task in cache
 	expectedSubject := task.Subject()
 	subject, err := cache.FindSubject(expectedSubject)
 	g.Expect(err).To(BeNil())
 	g.Expect(subject.IsTask()).To(BeTrue())
 
-	// Revoke task
+	// TaskRevoked only removes tokens, not the parsing capability
 	cache.TaskRevoked(1111)
 
-	// Verify task removed from subject cache
-	_, err = cache.FindSubject(expectedSubject)
-	g.Expect(err).NotTo(BeNil())
+	// Task subject still parseable
+	subject, err = cache.FindSubject(expectedSubject)
+	g.Expect(err).To(BeNil())
+	g.Expect(subject.IsTask()).To(BeTrue())
 }
 
-// TestCacheTaskLifecycle tests full task lifecycle in cache.
-func TestCacheTaskLifecycle(t *testing.T) {
+// TestTaskSubjectParsing tests task subject parsing behavior.
+func TestTaskSubjectParsingBehavior(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	db, err := setupTestDB()
@@ -598,31 +586,25 @@ func TestCacheTaskLifecycle(t *testing.T) {
 	err = cache.Refresh()
 	g.Expect(err).To(BeNil())
 
-	// Initially not in cache
+	// Task subject always parseable (not cached)
 	task := &Task{ID: 2222}
 	expectedSubject := task.Subject()
-	_, err = cache.FindSubject(expectedSubject)
-	g.Expect(err).NotTo(BeNil())
-
-	// Grant adds to cache
-	cache.TaskGranted(task)
-
-	// Now in cache
 	subject, err := cache.FindSubject(expectedSubject)
 	g.Expect(err).To(BeNil())
 	g.Expect(subject.IsTask()).To(BeTrue())
 	g.Expect(subject.Login()).To(Equal(expectedSubject))
 
-	// Revoke removes from cache
+	// TaskRevoked doesn't affect parsing
 	cache.TaskRevoked(2222)
 
-	// No longer in cache
-	_, err = cache.FindSubject(expectedSubject)
-	g.Expect(err).NotTo(BeNil())
+	// Still parseable
+	subject, err = cache.FindSubject(expectedSubject)
+	g.Expect(err).To(BeNil())
+	g.Expect(subject.IsTask()).To(BeTrue())
 }
 
-// TestMultipleTasksInCache tests multiple tasks can coexist in cache.
-func TestMultipleTasksInCache(t *testing.T) {
+// TestMultipleTaskSubjectsParseable tests multiple task subjects are parseable.
+func TestMultipleTaskSubjectsParseable(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	db, err := setupTestDB()
@@ -632,7 +614,7 @@ func TestMultipleTasksInCache(t *testing.T) {
 	err = cache.Refresh()
 	g.Expect(err).To(BeNil())
 
-	// Add multiple tasks
+	// All task subjects are parseable (not cached)
 	tasks := []*Task{
 		{ID: 1},
 		{ID: 2},
@@ -641,11 +623,7 @@ func TestMultipleTasksInCache(t *testing.T) {
 		{ID: 999},
 	}
 
-	for _, task := range tasks {
-		cache.TaskGranted(task)
-	}
-
-	// All tasks should be findable
+	// All tasks should be parseable
 	for _, task := range tasks {
 		expectedSubject := task.Subject()
 		subject, err := cache.FindSubject(expectedSubject)
@@ -654,25 +632,20 @@ func TestMultipleTasksInCache(t *testing.T) {
 		g.Expect(subject.Login()).To(Equal(expectedSubject))
 	}
 
-	// Revoke one task
+	// TaskRevoked only removes tokens
 	cache.TaskRevoked(2)
 
-	// Task 2 should be gone
-	task2Subject := Task{ID: 2}.Subject()
-	_, err = cache.FindSubject(task2Subject)
-	g.Expect(err).NotTo(BeNil())
-
-	// Others still present
-	for _, taskID := range []uint{1, 3, 100, 999} {
-		expectedSubject := Task{ID: taskID}.Subject()
+	// All task subjects still parseable
+	for _, task := range tasks {
+		expectedSubject := task.Subject()
 		subject, err := cache.FindSubject(expectedSubject)
 		g.Expect(err).To(BeNil())
 		g.Expect(subject.IsTask()).To(BeTrue())
 	}
 }
 
-// TestCacheConcurrentTaskOperations tests concurrent task operations on cache.
-func TestCacheConcurrentTaskOperations(t *testing.T) {
+// TestConcurrentTaskSubjectParsing tests concurrent task subject parsing.
+func TestConcurrentTaskSubjectParsing(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	db, err := setupTestDB()
@@ -685,19 +658,7 @@ func TestCacheConcurrentTaskOperations(t *testing.T) {
 	var wg sync.WaitGroup
 	iterations := 100
 
-	// Concurrent TaskGranted
-	for i := 0; i < 10; i++ {
-		wg.Add(1)
-		go func(id int) {
-			defer wg.Done()
-			for j := 0; j < iterations; j++ {
-				task := &Task{ID: uint(id*1000 + j)}
-				cache.TaskGranted(task)
-			}
-		}(i)
-	}
-
-	// Concurrent TaskRevoked
+	// Concurrent TaskRevoked (only removes tokens)
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func(id int) {
@@ -708,14 +669,18 @@ func TestCacheConcurrentTaskOperations(t *testing.T) {
 		}(i)
 	}
 
-	// Concurrent FindSubject (task)
+	// Concurrent FindSubject (parsing)
 	for i := 0; i < 20; i++ {
 		wg.Add(1)
 		go func(id int) {
 			defer wg.Done()
 			for j := 0; j < iterations; j++ {
 				taskID := j % 100
-				cache.FindSubject(Task{ID: uint(taskID)}.Subject())
+				subject, parseErr := cache.FindSubject(Task{ID: uint(taskID)}.Subject())
+				// Parsing should always succeed
+				if parseErr == nil {
+					g.Expect(subject.IsTask()).To(BeTrue())
+				}
 			}
 		}(i)
 	}
@@ -725,35 +690,33 @@ func TestCacheConcurrentTaskOperations(t *testing.T) {
 	// Verify cache is still consistent
 	d := cache.data.Load()
 	g.Expect(d).NotTo(BeNil())
-	// Some tasks may remain (race between grant/revoke)
-	g.Expect(len(d.taskById)).To(BeNumerically(">=", 0))
 }
 
-// TestTaskRefresh tests that task cache is properly loaded on refresh.
-func TestTaskRefresh(t *testing.T) {
+// TestTaskSubjectWithoutCache tests that tasks don't need cache refresh.
+func TestTaskSubjectWithoutCache(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	db, err := setupTestDB()
 	g.Expect(err).To(BeNil())
 
-	// Create tasks in database (no cache yet)
-	task1 := &Task{ID: 100}
-	task2 := &Task{ID: 200}
-	err = db.Create(task1).Error
-	g.Expect(err).To(BeNil())
-	err = db.Create(task2).Error
-	g.Expect(err).To(BeNil())
-
-	// Create cache and refresh
+	// Create cache and refresh (tasks not loaded from DB)
 	cache := New(db)
 	err = cache.Refresh()
 	g.Expect(err).To(BeNil())
 
-	// Tasks should be loaded into cache if they exist in DB
-	// (Current implementation may not load tasks on refresh - only on TaskGranted)
-	// This test documents current behavior
-	d := cache.data.Load()
-	g.Expect(d).NotTo(BeNil())
+	// Task subjects are parsed on-demand, no DB/cache needed
+	task1 := &Task{ID: 100}
+	task2 := &Task{ID: 200}
+
+	subject1, err := cache.FindSubject(task1.Subject())
+	g.Expect(err).To(BeNil())
+	g.Expect(subject1.IsTask()).To(BeTrue())
+	g.Expect(subject1.Task.ID).To(Equal(uint(100)))
+
+	subject2, err := cache.FindSubject(task2.Subject())
+	g.Expect(err).To(BeNil())
+	g.Expect(subject2.IsTask()).To(BeTrue())
+	g.Expect(subject2.Task.ID).To(Equal(uint(200)))
 }
 
 // TestCacheMixedSubjectTypes tests that different subject types (User, Identity, Client, Task) coexist.
@@ -792,9 +755,8 @@ func TestCacheMixedSubjectTypes(t *testing.T) {
 	}
 	cache.ClientSaved(client)
 
-	// Add task
+	// Task subject parseable (not cached)
 	task := &Task{ID: 1}
-	cache.TaskGranted(task)
 
 	// All should be findable
 	userSubj, err := cache.FindSubject("user-subject-1")
@@ -894,29 +856,30 @@ func TestCacheConcurrentMixedOperations(t *testing.T) {
 		}(i)
 	}
 
-	// Concurrent TaskGranted/TaskRevoked
+	// Concurrent TaskRevoked
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func(id int) {
 			defer wg.Done()
 			for j := 0; j < iterations; j++ {
-				task := &Task{ID: uint(id*1000 + j)}
-				cache.TaskGranted(task)
-				if j%3 == 0 {
-					cache.TaskRevoked(task.ID)
-				}
+				taskID := uint(id*1000 + j)
+				cache.TaskRevoked(taskID)
 			}
 		}(i)
 	}
 
-	// Concurrent FindSubject (task)
+	// Concurrent FindSubject (task parsing)
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func(id int) {
 			defer wg.Done()
 			for j := 0; j < iterations; j++ {
 				taskID := j % 100
-				cache.FindSubject(Task{ID: uint(taskID)}.Subject())
+				subject, parseErr := cache.FindSubject(Task{ID: uint(taskID)}.Subject())
+				// Parsing always succeeds
+				if parseErr == nil {
+					g.Expect(subject.IsTask()).To(BeTrue())
+				}
 			}
 		}(i)
 	}
@@ -927,6 +890,4 @@ func TestCacheConcurrentMixedOperations(t *testing.T) {
 	d := cache.data.Load()
 	// Should have some users (not all, some deleted/not found)
 	g.Expect(len(d.userById)).To(BeNumerically(">", 0))
-	// Should have some tasks (some granted, some revoked)
-	g.Expect(len(d.taskById)).To(BeNumerically(">=", 0))
 }

--- a/internal/auth/cache/pkg_test.go
+++ b/internal/auth/cache/pkg_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	as "github.com/konveyor/tackle2-hub/internal/auth/settings"
 	"github.com/konveyor/tackle2-hub/internal/database"
 	"github.com/konveyor/tackle2-hub/internal/model"
 	"github.com/konveyor/tackle2-hub/internal/secret"
@@ -25,7 +24,7 @@ func setupTestDB() (db *gorm.DB, err error) {
 	// Auto-migrate test models
 	err = db.AutoMigrate(
 		&User{},
-		&Task{},
+		&model.Task{},
 		&Role{},
 		&Permission{},
 		&Token{},
@@ -190,127 +189,6 @@ func TestCacheTransaction(t *testing.T) {
 	g.Expect(foundUser2).To(BeFalse())
 }
 
-// TestCacheDoubleCheckRefresh tests that concurrent ensureFresh calls don't cause issues.
-func TestCacheDoubleCheckRefresh(t *testing.T) {
-	g := NewGomegaWithT(t)
-
-	db, err := setupTestDB()
-	g.Expect(err).To(BeNil())
-
-	// Create test data
-	user := &User{
-		Subject:  "double-check-user",
-		Login:    "doublecheckuser",
-		Password: secret.HashPassword("password"),
-		Email:    "doublecheck@example.com",
-	}
-	err = db.Create(user).Error
-	g.Expect(err).To(BeNil())
-
-	cache := New(db)
-	err = cache.Refresh()
-	g.Expect(err).To(BeNil())
-
-	// Force cache to be stale - not needed with new design
-	// (background refresh runs independently)
-
-	// Launch multiple concurrent calls to FindUserByLogin (which calls ensureFresh)
-	var wg sync.WaitGroup
-	errors := make([]error, 10)
-
-	for i := 0; i < 10; i++ {
-		wg.Add(1)
-		go func(idx int) {
-			defer wg.Done()
-			_, err := cache.FindUserByLogin("doublecheckuser")
-			errors[idx] = err
-		}(i)
-	}
-
-	wg.Wait()
-
-	// All calls should succeed without error
-	for i, err := range errors {
-		g.Expect(err).To(BeNil(), fmt.Sprintf("goroutine %d failed", i))
-	}
-
-	// Cache should have refreshed and found the user
-	found, err := cache.FindUserByLogin("doublecheckuser")
-	g.Expect(err).To(BeNil())
-	g.Expect(found).NotTo(BeNil())
-}
-
-// TestCacheInconsistency tests error paths when referenced entities are missing.
-func TestCacheInconsistency(t *testing.T) {
-	g := NewGomegaWithT(t)
-
-	db, err := setupTestDB()
-	g.Expect(err).To(BeNil())
-
-	cache := New(db)
-	err = cache.Refresh()
-	g.Expect(err).To(BeNil())
-
-	// Create token referencing non-existent user
-	userID := uint(9999)
-	userTokenSecret := "inconsistent-user-token"
-	userTokenDigest := secret.Hash(userTokenSecret)
-	userToken := &Token{
-		Token: model.Token{
-			Model:  Model{ID: 1},
-			UserID: &userID,
-			Digest: userTokenDigest,
-		},
-	}
-	d := cache.data.Load()
-	d.tokenByDigest[userTokenDigest] = userToken
-	d.tokenById[1] = userToken
-
-	_, err = cache.FindToken(userTokenSecret)
-	g.Expect(err).NotTo(BeNil())
-	var notFound *NotFound
-	g.Expect(errors.As(err, &notFound)).To(BeTrue())
-	g.Expect(notFound.Resource).To(Equal("user"))
-
-	// Create token referencing non-existent identity
-	identityID := uint(7777)
-	identityTokenSecret := "inconsistent-identity-token"
-	identityTokenDigest := secret.Hash(identityTokenSecret)
-	identityToken := &Token{
-		Token: model.Token{
-			Model:         Model{ID: 3},
-			IdpIdentityID: &identityID,
-			Digest:        identityTokenDigest,
-		},
-	}
-	d.tokenByDigest[identityTokenDigest] = identityToken
-	d.tokenById[3] = identityToken
-
-	_, err = cache.FindToken(identityTokenSecret)
-	g.Expect(err).NotTo(BeNil())
-	g.Expect(errors.As(err, &notFound)).To(BeTrue())
-	g.Expect(notFound.Resource).To(Equal("identity"))
-
-	// Create token referencing non-existent client
-	clientID := uint(6666)
-	clientTokenSecret := "inconsistent-client-token"
-	clientTokenDigest := secret.Hash(clientTokenSecret)
-	clientToken := &Token{
-		Token: model.Token{
-			Model:       Model{ID: 4},
-			IdpClientID: &clientID,
-			Digest:      clientTokenDigest,
-		},
-	}
-	d.tokenByDigest[clientTokenDigest] = clientToken
-	d.tokenById[4] = clientToken
-
-	_, err = cache.FindToken(clientTokenSecret)
-	g.Expect(err).NotTo(BeNil())
-	g.Expect(errors.As(err, &notFound)).To(BeTrue())
-	g.Expect(notFound.Resource).To(Equal("client"))
-}
-
 // TestTaskRevokedRemovesTokens tests that TaskRevoked removes tokens from token cache.
 func TestTaskRevokedRemovesTokens(t *testing.T) {
 	g := NewGomegaWithT(t)
@@ -322,36 +200,44 @@ func TestTaskRevokedRemovesTokens(t *testing.T) {
 	err = cache.Refresh()
 	g.Expect(err).To(BeNil())
 
-	// Create task token
+	// Add task tokens
 	taskID := uint(500)
-	tokenSecret := "task-token-secret"
-	token := &Token{
+	token1 := &Token{
 		Token: model.Token{
-			Model:      Model{ID: 100},
+			Model:      Model{ID: 501},
 			TaskID:     &taskID,
-			Digest:     secret.Hash(tokenSecret),
+			Digest:     secret.Hash("task-token-501"),
 			Expiration: time.Now().Add(24 * time.Hour),
 		},
-		Secret: tokenSecret,
+		Secret: "task-token-501",
+	}
+	token2 := &Token{
+		Token: model.Token{
+			Model:      Model{ID: 502},
+			TaskID:     &taskID,
+			Digest:     secret.Hash("task-token-502"),
+			Expiration: time.Now().Add(24 * time.Hour),
+		},
+		Secret: "task-token-502",
 	}
 
-	// Add token to cache
-	cache.TokenSaved(token)
+	cache.TokenSaved(token1)
+	cache.TokenSaved(token2)
 
-	// Verify token is in cache
-	found, err := cache.FindToken(tokenSecret)
+	// Verify tokens are in cache
+	_, err = cache.FindToken("task-token-501")
 	g.Expect(err).To(BeNil())
-	g.Expect(found.ID).To(Equal(uint(100)))
+	_, err = cache.FindToken("task-token-502")
+	g.Expect(err).To(BeNil())
 
-	// Revoke task
+	// Revoke task - should remove both tokens
 	cache.TaskRevoked(taskID)
 
-	// Verify token removed from cache
-	_, err = cache.FindToken(tokenSecret)
+	// Verify tokens are removed
+	_, err = cache.FindToken("task-token-501")
 	g.Expect(err).NotTo(BeNil())
-	var notFound *NotFound
-	g.Expect(errors.As(err, &notFound)).To(BeTrue())
-	g.Expect(notFound.Resource).To(Equal("token"))
+	_, err = cache.FindToken("task-token-502")
+	g.Expect(err).NotTo(BeNil())
 }
 
 // TestTaskRevokedMultipleTokens tests that TaskRevoked removes only tokens for specified task.
@@ -365,54 +251,46 @@ func TestTaskRevokedMultipleTokens(t *testing.T) {
 	err = cache.Refresh()
 	g.Expect(err).To(BeNil())
 
-	// Create two tasks
-	task1ID := uint(501)
-	task2ID := uint(502)
+	// Add tokens for two different tasks
+	task1ID := uint(600)
+	task2ID := uint(601)
 
-	// Create tokens for each task
-	token1Secret := "task1-token"
 	token1 := &Token{
 		Token: model.Token{
-			Model:      Model{ID: 101},
+			Model:      Model{ID: 600},
 			TaskID:     &task1ID,
-			Digest:     secret.Hash(token1Secret),
+			Digest:     secret.Hash("task1-token"),
 			Expiration: time.Now().Add(24 * time.Hour),
 		},
-		Secret: token1Secret,
+		Secret: "task1-token",
 	}
-
-	token2Secret := "task2-token"
 	token2 := &Token{
 		Token: model.Token{
-			Model:      Model{ID: 102},
+			Model:      Model{ID: 601},
 			TaskID:     &task2ID,
-			Digest:     secret.Hash(token2Secret),
+			Digest:     secret.Hash("task2-token"),
 			Expiration: time.Now().Add(24 * time.Hour),
 		},
-		Secret: token2Secret,
+		Secret: "task2-token",
 	}
 
-	// Add tokens to cache
 	cache.TokenSaved(token1)
 	cache.TokenSaved(token2)
 
 	// Verify both tokens are in cache
-	_, err = cache.FindToken(token1Secret)
+	_, err = cache.FindToken("task1-token")
 	g.Expect(err).To(BeNil())
-	_, err = cache.FindToken(token2Secret)
+	_, err = cache.FindToken("task2-token")
 	g.Expect(err).To(BeNil())
 
-	// Revoke only task1
+	// Revoke task1 only
 	cache.TaskRevoked(task1ID)
 
-	// Verify task1 token removed
-	_, err = cache.FindToken(token1Secret)
+	// Task1 token removed, task2 token still present
+	_, err = cache.FindToken("task1-token")
 	g.Expect(err).NotTo(BeNil())
-
-	// Verify task2 token still exists
-	found, err := cache.FindToken(token2Secret)
+	_, err = cache.FindToken("task2-token")
 	g.Expect(err).To(BeNil())
-	g.Expect(found.ID).To(Equal(uint(102)))
 }
 
 // TestTaskRevokedTransaction tests TaskRevoked within a transaction.
@@ -426,65 +304,64 @@ func TestTaskRevokedTransaction(t *testing.T) {
 	err = cache.Refresh()
 	g.Expect(err).To(BeNil())
 
-	taskID := uint(503)
-	tokenSecret := "tx-task-token"
+	// Add task token
+	taskID := uint(700)
 	token := &Token{
 		Token: model.Token{
-			Model:      Model{ID: 103},
+			Model:      Model{ID: 700},
 			TaskID:     &taskID,
-			Digest:     secret.Hash(tokenSecret),
+			Digest:     secret.Hash("tx-task-token"),
 			Expiration: time.Now().Add(24 * time.Hour),
 		},
-		Secret: tokenSecret,
+		Secret: "tx-task-token",
 	}
-
-	// Add token
 	cache.TokenSaved(token)
 
-	// Verify in cache
-	_, err = cache.FindToken(tokenSecret)
+	// Verify token is in cache
+	_, err = cache.FindToken("tx-task-token")
 	g.Expect(err).To(BeNil())
 
-	// Revoke within successful transaction
+	// Revoke in transaction
 	err = cache.Transaction(func(tx *Tx) error {
 		tx.TaskRevoked(taskID)
 		return nil
 	})
 	g.Expect(err).To(BeNil())
 
-	// Verify token removed
-	_, err = cache.FindToken(tokenSecret)
+	// Verify token is removed
+	_, err = cache.FindToken("tx-task-token")
 	g.Expect(err).NotTo(BeNil())
 
-	// Test rollback
-	task2ID := uint(504)
-	token2Secret := "tx-task2-token"
+	// Test rollback - add token back, then rollback revoke
+	cache.TokenSaved(token)
+	_, err = cache.FindToken("tx-task-token")
+	g.Expect(err).To(BeNil())
+
+	task2ID := uint(701)
 	token2 := &Token{
 		Token: model.Token{
-			Model:      Model{ID: 104},
+			Model:      Model{ID: 701},
 			TaskID:     &task2ID,
-			Digest:     secret.Hash(token2Secret),
+			Digest:     secret.Hash("tx-task-token-2"),
 			Expiration: time.Now().Add(24 * time.Hour),
 		},
-		Secret: token2Secret,
+		Secret: "tx-task-token-2",
 	}
-
 	cache.TokenSaved(token2)
 
-	// Rollback transaction
 	err = cache.Transaction(func(tx *Tx) error {
 		tx.TaskRevoked(task2ID)
-		return fmt.Errorf("rollback test")
+		return fmt.Errorf("rollback")
 	})
 	g.Expect(err).NotTo(BeNil())
 
-	// Verify token still exists (rollback successful)
-	_, err = cache.FindToken(token2Secret)
+	// Token2 should still be in cache (rolled back)
+	_, err = cache.FindToken("tx-task-token-2")
 	g.Expect(err).To(BeNil())
 }
 
-// TestCacheUserSavedBySubject tests that UserSaved updates bySubject map.
-func TestCacheUserSavedBySubject(t *testing.T) {
+// TestTaskGrantedAddsToCache tests that TaskGranted adds task to cache.
+func TestTaskGrantedAddsToCache(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	db, err := setupTestDB()
@@ -494,439 +371,143 @@ func TestCacheUserSavedBySubject(t *testing.T) {
 	err = cache.Refresh()
 	g.Expect(err).To(BeNil())
 
-	// Create user not in DB (just for cache testing)
-	user := &User{
-		Model:    Model{ID: 999},
-		Subject:  "cached-user-subject",
-		Login:    "cacheduser",
-		Email:    "cached@example.com",
-		Password: secret.HashPassword("password"),
-	}
-
-	// Save to cache
-	cache.UserSaved(user)
-
-	// Verify it's in both maps
-	d := cache.data.Load()
-	userById, foundById := d.userById[999]
-	userBySubject, foundBySubject := d.userBySubject["cached-user-subject"]
-
-	g.Expect(foundById).To(BeTrue())
-	g.Expect(foundBySubject).To(BeTrue())
-	g.Expect(userById.Login).To(Equal("cacheduser"))
-	g.Expect(userBySubject.Login).To(Equal("cacheduser"))
-
-	// Verify FindSubject works without DB query
-	subject, err := cache.FindSubject("cached-user-subject")
-	g.Expect(err).To(BeNil())
-	g.Expect(subject.Key).To(Equal("cached-user-subject"))
-	g.Expect(subject.User.Login).To(Equal("cacheduser"))
-}
-
-// TestCacheIdentitySavedBySubject tests that IdentitySaved updates bySubject map.
-func TestCacheIdentitySavedBySubject(t *testing.T) {
-	g := NewGomegaWithT(t)
-
-	db, err := setupTestDB()
-	g.Expect(err).To(BeNil())
-
-	cache := New(db)
-	err = cache.Refresh()
-	g.Expect(err).To(BeNil())
-
-	// Create identity not in DB (just for cache testing)
-	identity := &Identity{
-		Model:   Model{ID: 888},
-		Issuer:  "https://test.idp.com",
-		Subject: "cached-identity-subject",
-		Login:   "cachedidentity",
-		Email:   "cachedidentity@example.com",
-		Scopes:  "openid profile",
-	}
-
-	// Save to cache
-	cache.IdentitySaved(identity)
-
-	// Verify it's in both maps
-	d := cache.data.Load()
-	identById, foundById := d.identById[888]
-	identBySubject, foundBySubject := d.identBySubject["cached-identity-subject"]
-
-	g.Expect(foundById).To(BeTrue())
-	g.Expect(foundBySubject).To(BeTrue())
-	g.Expect(identById.Login).To(Equal("cachedidentity"))
-	g.Expect(identBySubject.Login).To(Equal("cachedidentity"))
-
-	// Verify FindSubject works without DB query
-	subject, err := cache.FindSubject("cached-identity-subject")
-	g.Expect(err).To(BeNil())
-	g.Expect(subject.Key).To(Equal("cached-identity-subject"))
-	g.Expect(subject.Identity.Login).To(Equal("cachedidentity"))
-}
-
-// TestCacheUserDeletedBySubject tests that UserDeleted removes from bySubject map.
-func TestCacheUserDeletedBySubject(t *testing.T) {
-	g := NewGomegaWithT(t)
-
-	db, err := setupTestDB()
-	g.Expect(err).To(BeNil())
-
-	cache := New(db)
-	err = cache.Refresh()
-	g.Expect(err).To(BeNil())
-
-	user := &User{
-		Model:   Model{ID: 777},
-		Subject: "delete-user-subject",
-		Login:   "deleteuser",
-	}
-
-	cache.UserSaved(user)
-
-	// Verify it's in both maps
-	d := cache.data.Load()
-	_, foundById := d.userById[777]
-	_, foundBySubject := d.userBySubject["delete-user-subject"]
-	g.Expect(foundById).To(BeTrue())
-	g.Expect(foundBySubject).To(BeTrue())
-
-	// Delete user
-	cache.UserDeleted(777)
-
-	// Verify removed from both maps
-	d = cache.data.Load()
-	_, foundById = d.userById[777]
-	_, foundBySubject = d.userBySubject["delete-user-subject"]
-	g.Expect(foundById).To(BeFalse())
-	g.Expect(foundBySubject).To(BeFalse())
-
-	// Verify FindSubject returns NotFound
-	_, err = cache.FindSubject("delete-user-subject")
-	g.Expect(err).NotTo(BeNil())
-}
-
-// TestCacheIdentityDeletedBySubject tests that IdentityDeleted removes from bySubject map.
-func TestCacheIdentityDeletedBySubject(t *testing.T) {
-	g := NewGomegaWithT(t)
-
-	db, err := setupTestDB()
-	g.Expect(err).To(BeNil())
-
-	cache := New(db)
-	err = cache.Refresh()
-	g.Expect(err).To(BeNil())
-
-	identity := &Identity{
-		Model:   Model{ID: 666},
-		Subject: "delete-identity-subject",
-		Login:   "deleteidentity",
-	}
-
-	cache.IdentitySaved(identity)
-
-	// Verify it's in both maps
-	d := cache.data.Load()
-	_, foundById := d.identById[666]
-	_, foundBySubject := d.identBySubject["delete-identity-subject"]
-	g.Expect(foundById).To(BeTrue())
-	g.Expect(foundBySubject).To(BeTrue())
-
-	// Delete identity
-	cache.IdentityDeleted(666)
-
-	// Verify removed from both maps
-	d = cache.data.Load()
-	_, foundById = d.identById[666]
-	_, foundBySubject = d.identBySubject["delete-identity-subject"]
-	g.Expect(foundById).To(BeFalse())
-	g.Expect(foundBySubject).To(BeFalse())
-
-	// Verify FindSubject returns NotFound
-	_, err = cache.FindSubject("delete-identity-subject")
-	g.Expect(err).NotTo(BeNil())
-}
-
-// TestCacheUserByUseridMaps tests that user is in all three maps.
-func TestCacheUserByUseridMaps(t *testing.T) {
-	g := NewGomegaWithT(t)
-
-	db, err := setupTestDB()
-	g.Expect(err).To(BeNil())
-
-	cache := New(db)
-	err = cache.Refresh()
-	g.Expect(err).To(BeNil())
-
-	// Create user
-	user := &User{
-		Model:    Model{ID: 555},
-		Subject:  "map-test-subject",
-		Login:    "maptestuser",
-		Email:    "maptest@example.com",
-		Password: secret.HashPassword("password"),
-	}
-
-	// Save to cache
-	cache.UserSaved(user)
-
-	// Verify it's in all three maps
-	d := cache.data.Load()
-	userById, foundById := d.userById[555]
-	userBySubject, foundBySubject := d.userBySubject["map-test-subject"]
-	userByLogin, foundByLogin := d.userByLogin["maptestuser"]
-
-	g.Expect(foundById).To(BeTrue())
-	g.Expect(foundBySubject).To(BeTrue())
-	g.Expect(foundByLogin).To(BeTrue())
-	g.Expect(userById.Login).To(Equal("maptestuser"))
-	g.Expect(userBySubject.Login).To(Equal("maptestuser"))
-	g.Expect(userByLogin.Subject).To(Equal("map-test-subject"))
-
-	// Delete user
-	cache.UserDeleted(555)
-
-	// Verify removed from all three maps
-	d = cache.data.Load()
-	_, foundById = d.userById[555]
-	_, foundBySubject = d.userBySubject["map-test-subject"]
-	_, foundByLogin = d.userByLogin["maptestuser"]
-
-	g.Expect(foundById).To(BeFalse())
-	g.Expect(foundBySubject).To(BeFalse())
-	g.Expect(foundByLogin).To(BeFalse())
-}
-
-// TestCacheConcurrency tests concurrent access to the cache.
-func TestCacheConcurrency(t *testing.T) {
-	g := NewGomegaWithT(t)
-
-	db, err := setupTestDB()
-	g.Expect(err).To(BeNil())
-
-	// Create multiple users in DB
-	users := make([]*User, 10)
-	for i := 0; i < 10; i++ {
-		users[i] = &User{
-			Subject:  fmt.Sprintf("concurrent-user-%d", i),
-			Login:    fmt.Sprintf("concurrentuser%d", i),
-			Password: secret.HashPassword("password"),
-			Email:    fmt.Sprintf("concurrent%d@example.com", i),
-		}
-		err = db.Create(users[i]).Error
-		g.Expect(err).To(BeNil())
-	}
-
-	cache := New(db)
-	err = cache.Refresh()
-	g.Expect(err).To(BeNil())
-
-	// Launch concurrent FindUserByLogin operations
-	var wg sync.WaitGroup
-	for i := 0; i < 50; i++ {
-		wg.Add(1)
-		go func(idx int) {
-			defer wg.Done()
-			userIdx := idx % 10
-			_, err := cache.FindUserByLogin(fmt.Sprintf("concurrentuser%d", userIdx))
-			g.Expect(err).To(BeNil())
-		}(i)
-	}
-
-	// Launch concurrent UserSaved operations
-	for i := 0; i < 5; i++ {
-		wg.Add(1)
-		go func(idx int) {
-			defer wg.Done()
-			userIdx := idx % 10
-			cache.UserSaved((*User)(users[userIdx]))
-		}(i)
-	}
-
-	wg.Wait()
-}
-
-// TestManualCacheRefresh tests Reset and Refresh operations.
-func TestManualCacheRefresh(t *testing.T) {
-	g := NewGomegaWithT(t)
-
-	db, err := setupTestDB()
-	g.Expect(err).To(BeNil())
-
-	user := &User{
-		Subject:  "manual-refresh-user",
-		Login:    "manualrefreshuser",
-		Password: secret.HashPassword("password"),
-		Email:    "manualrefresh@example.com",
-	}
-	err = db.Create(user).Error
-	g.Expect(err).To(BeNil())
-
-	cache := New(db)
-	err = cache.Refresh()
-	g.Expect(err).To(BeNil())
-
-	// Verify user is in cache
-	found, err := cache.FindUserByLogin("manualrefreshuser")
-	g.Expect(err).To(BeNil())
-	g.Expect(found).NotTo(BeNil())
-
-	// Call Reset - should clear cache
-	cache.Reset()
-
-	// Cache is now empty, user not found
-	_, err = cache.FindUserByLogin("manualrefreshuser")
+	// Task not in cache initially
+	task := &Task{ID: 800}
+	expectedSubject := task.Subject()
+	_, err = cache.FindSubject(expectedSubject)
 	g.Expect(err).NotTo(BeNil())
 
-	// Call manual Refresh to reload
-	err = cache.Refresh()
-	g.Expect(err).To(BeNil())
+	// Grant task token
+	cache.TaskGranted(task)
 
-	// User should still be found
-	found, err = cache.FindUserByLogin("manualrefreshuser")
+	// Task now in cache
+	subject, err := cache.FindSubject(expectedSubject)
 	g.Expect(err).To(BeNil())
-	g.Expect(found).NotTo(BeNil())
+	g.Expect(subject).NotTo(BeNil())
+	g.Expect(subject.IsTask()).To(BeTrue())
+	g.Expect(subject.Task).NotTo(BeNil())
+	g.Expect(subject.Task.ID).To(Equal(uint(800)))
+	g.Expect(subject.Key).To(Equal(expectedSubject))
+	g.Expect(subject.Login()).To(Equal(expectedSubject))
 }
 
-// TestFindRoleByName tests finding roles by name.
-func TestFindRoleByName(t *testing.T) {
+// TestTaskSubject tests Task.Subject() method.
+func TestTaskSubject(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	db, err := setupTestDB()
-	g.Expect(err).To(BeNil())
-
-	// Create test roles
-	perm1 := &Permission{
-		Name:  "Read Apps",
-		Scope: "applications:get",
+	tests := []struct {
+		taskID   uint
+		expected string
+	}{
+		{1, "task.1"},
+		{42, "task.42"},
+		{999, "task.999"},
+		{12345, "task.12345"},
 	}
-	err = db.Create(perm1).Error
-	g.Expect(err).To(BeNil())
 
-	perm2 := &Permission{
-		Name:  "Write Apps",
-		Scope: "applications:post",
+	for _, tt := range tests {
+		task := &Task{ID: tt.taskID}
+		g.Expect(task.Subject()).To(Equal(tt.expected))
 	}
-	err = db.Create(perm2).Error
-	g.Expect(err).To(BeNil())
-
-	role1 := &Role{
-		Name:        "AppReader",
-		Permissions: []Permission{*perm1},
-	}
-	err = db.Create(role1).Error
-	g.Expect(err).To(BeNil())
-
-	role2 := &Role{
-		Name:        "AppWriter",
-		Permissions: []Permission{*perm2},
-	}
-	err = db.Create(role2).Error
-	g.Expect(err).To(BeNil())
-
-	cache := New(db)
-	err = cache.Refresh()
-	g.Expect(err).To(BeNil())
-
-	// Test finding existing roles by name
-	found1, err := cache.FindRoleByName("AppReader")
-	g.Expect(err).To(BeNil())
-	g.Expect(found1).NotTo(BeNil())
-	g.Expect(found1.Name).To(Equal("AppReader"))
-	g.Expect(found1.GetScopes()).To(ContainElement("applications:get"))
-
-	found2, err := cache.FindRoleByName("AppWriter")
-	g.Expect(err).To(BeNil())
-	g.Expect(found2).NotTo(BeNil())
-	g.Expect(found2.Name).To(Equal("AppWriter"))
-	g.Expect(found2.GetScopes()).To(ContainElement("applications:post"))
-
-	// Test finding non-existent role
-	_, err = cache.FindRoleByName("NonExistentRole")
-	g.Expect(err).NotTo(BeNil())
-	var notFound *NotFound
-	g.Expect(errors.As(err, &notFound)).To(BeTrue())
-	g.Expect(notFound.Resource).To(Equal("Role"))
-	g.Expect(notFound.Id).To(Equal("NonExistentRole"))
 }
 
-// TestFindRoleById tests finding roles by ID.
-func TestFindRoleById(t *testing.T) {
+// TestTaskGetScopes tests Task.GetScopes() returns AddonScopes.
+func TestTaskGetScopes(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	db, err := setupTestDB()
-	g.Expect(err).To(BeNil())
+	task := &Task{ID: 100}
+	scopes := task.GetScopes()
 
-	perm := &Permission{
-		Name:  "Read Tasks",
-		Scope: "tasks:get",
-	}
-	err = db.Create(perm).Error
-	g.Expect(err).To(BeNil())
-
-	role := &Role{
-		Name:        "TaskReader",
-		Permissions: []Permission{*perm},
-	}
-	err = db.Create(role).Error
-	g.Expect(err).To(BeNil())
-
-	cache := New(db)
-	err = cache.Refresh()
-	g.Expect(err).To(BeNil())
-
-	// Test finding existing role by ID
-	found, err := cache.FindRoleById(role.ID)
-	g.Expect(err).To(BeNil())
-	g.Expect(found).NotTo(BeNil())
-	g.Expect(found.Name).To(Equal("TaskReader"))
-	g.Expect(found.GetScopes()).To(ContainElement("tasks:get"))
-
-	// Test finding non-existent role
-	_, err = cache.FindRoleById(9999)
-	g.Expect(err).NotTo(BeNil())
-	var notFound *NotFound
-	g.Expect(errors.As(err, &notFound)).To(BeTrue())
-	g.Expect(notFound.Resource).To(Equal("Role"))
+	g.Expect(scopes).NotTo(BeEmpty())
+	g.Expect(scopes).To(ContainElement("addons:get"))
+	g.Expect(scopes).To(ContainElement("applications:get"))
+	g.Expect(scopes).To(ContainElement("applications:post"))
+	g.Expect(scopes).To(ContainElement("applications.facts:*"))
 }
 
-// TestFindIdentityByLogin tests finding identities by userid.
-func TestFindIdentityByLogin(t *testing.T) {
+// TestSubjectWithTask tests Subject.WithTask() population.
+func TestSubjectWithTask(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	db, err := setupTestDB()
-	g.Expect(err).To(BeNil())
+	task := &Task{ID: 555}
+	subject := &Subject{}
+	subject.WithTask(task)
 
-	identity := &Identity{
-		Issuer:  "https://idp.example.com",
-		Subject: "idp-subject-123",
-		Login:   "idpuser123",
-		Email:   "idp@example.com",
-		Scopes:  "openid profile email",
-	}
-	err = db.Create(identity).Error
-	g.Expect(err).To(BeNil())
-
-	cache := New(db)
-	err = cache.Refresh()
-	g.Expect(err).To(BeNil())
-
-	// Test finding existing identity by userid
-	found, err := cache.FindIdentityByLogin("idpuser123")
-	g.Expect(err).To(BeNil())
-	g.Expect(found).NotTo(BeNil())
-	g.Expect(found.Subject).To(Equal("idp-subject-123"))
-	g.Expect(found.Email).To(Equal("idp@example.com"))
-
-	// Test finding non-existent identity
-	_, err = cache.FindIdentityByLogin("nonexistent")
-	g.Expect(err).NotTo(BeNil())
-	var notFound *NotFound
-	g.Expect(errors.As(err, &notFound)).To(BeTrue())
-	g.Expect(notFound.Resource).To(Equal("identity"))
+	expectedSubject := task.Subject()
+	g.Expect(subject.Task).To(Equal(task))
+	g.Expect(subject.Key).To(Equal(expectedSubject))
+	g.Expect(subject.Scopes).NotTo(BeEmpty())
+	g.Expect(subject.Scopes).To(ContainElement("addons:get"))
 }
 
-// TestFindTokenEdgeCases tests edge cases in token finding.
-func TestFindTokenEdgeCases(t *testing.T) {
+// TestSubjectIsTask tests Subject.IsTask() method.
+func TestSubjectIsTask(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	// Task subject
+	taskSubject := &Subject{Task: &Task{ID: 1}}
+	g.Expect(taskSubject.IsTask()).To(BeTrue())
+	g.Expect(taskSubject.IsUser()).To(BeFalse())
+	g.Expect(taskSubject.IsIdentity()).To(BeFalse())
+	g.Expect(taskSubject.IsClient()).To(BeFalse())
+
+	// User subject
+	userID := uint(1)
+	userSubject := &Subject{UserId: &userID, User: &User{}}
+	g.Expect(userSubject.IsUser()).To(BeTrue())
+	g.Expect(userSubject.IsTask()).To(BeFalse())
+
+	// Identity subject
+	identID := uint(1)
+	identSubject := &Subject{IdentityId: &identID, Identity: &Identity{}}
+	g.Expect(identSubject.IsIdentity()).To(BeTrue())
+	g.Expect(identSubject.IsTask()).To(BeFalse())
+
+	// Client subject
+	clientID := uint(1)
+	clientSubject := &Subject{ClientId: &clientID, Client: &IdpClient{}}
+	g.Expect(clientSubject.IsClient()).To(BeTrue())
+	g.Expect(clientSubject.IsTask()).To(BeFalse())
+
+	// Empty subject
+	emptySubject := &Subject{}
+	g.Expect(emptySubject.IsTask()).To(BeFalse())
+	g.Expect(emptySubject.IsUser()).To(BeFalse())
+	g.Expect(emptySubject.IsIdentity()).To(BeFalse())
+	g.Expect(emptySubject.IsClient()).To(BeFalse())
+}
+
+// TestSubjectLogin tests Subject.Login() for different subject types.
+func TestSubjectLogin(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	// Task login
+	task := &Task{ID: 445}
+	taskSubject := &Subject{Task: task}
+	g.Expect(taskSubject.Login()).To(Equal(task.Subject()))
+
+	// User login
+	userID := uint(1)
+	userSubject := &Subject{UserId: &userID, User: &User{Login: "jsmith"}}
+	g.Expect(userSubject.Login()).To(Equal("jsmith"))
+
+	// Identity login
+	identID := uint(1)
+	identSubject := &Subject{IdentityId: &identID, Identity: &Identity{Login: "idpuser"}}
+	g.Expect(identSubject.Login()).To(Equal("idpuser"))
+
+	// Client login
+	clientID := uint(1)
+	clientSubject := &Subject{ClientId: &clientID, Client: &IdpClient{ClientId: "client-123"}}
+	g.Expect(clientSubject.Login()).To(Equal("client-123"))
+
+	// Empty subject
+	emptySubject := &Subject{}
+	g.Expect(emptySubject.Login()).To(BeEmpty())
+}
+
+// TestCacheFindSubjectTask tests finding task subjects.
+func TestCacheFindSubjectTask(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	db, err := setupTestDB()
@@ -936,61 +517,27 @@ func TestFindTokenEdgeCases(t *testing.T) {
 	err = cache.Refresh()
 	g.Expect(err).To(BeNil())
 
-	// Test finding non-existent token
-	_, err = cache.FindToken("nonexistent-token")
-	g.Expect(err).NotTo(BeNil())
-	var notFound *NotFound
-	g.Expect(errors.As(err, &notFound)).To(BeTrue())
-	g.Expect(notFound.Resource).To(Equal("token"))
+	// Add task to cache
+	task := &Task{ID: 999}
+	cache.TaskGranted(task)
 
-	// Test token with no bindings (all foreign keys nil)
-	unboundToken := &Token{
-		Token: model.Token{
-			Kind:          KindAPIKey,
-			AuthId:        "unbound-auth-id",
-			Digest:        secret.Hash("unbound-secret"),
-			Expiration:    time.Now().Add(24 * time.Hour),
-			UserID:        nil,
-			TaskID:        nil,
-			IdpIdentityID: nil,
-		},
-		Secret: "unbound-secret",
-	}
-	err = db.Create(&unboundToken.Token).Error
+	// Find task subject
+	expectedSubject := task.Subject()
+	subject, err := cache.FindSubject(expectedSubject)
 	g.Expect(err).To(BeNil())
+	g.Expect(subject).NotTo(BeNil())
+	g.Expect(subject.IsTask()).To(BeTrue())
+	g.Expect(subject.Task.ID).To(Equal(uint(999)))
+	g.Expect(subject.Key).To(Equal(expectedSubject))
+	g.Expect(subject.Login()).To(Equal(expectedSubject))
 
-	cache.TokenSaved(unboundToken)
-
-	found, err := cache.FindToken("unbound-secret")
-	g.Expect(err).To(BeNil())
-	g.Expect(found).NotTo(BeNil())
-	g.Expect(found.Subject).To(BeEmpty())
-	g.Expect(found.Scopes).To(BeEmpty())
-
-	// Test expired token is not cached
-	expiredToken := &Token{
-		Token: model.Token{
-			Kind:       KindAPIKey,
-			AuthId:     "expired-auth-id",
-			Digest:     secret.Hash("expired-secret"),
-			Expiration: time.Now().Add(-1 * time.Hour), // Expired
-		},
-		Secret: "expired-secret",
-	}
-	err = db.Create(&expiredToken.Token).Error
-	g.Expect(err).To(BeNil())
-
-	// Refresh cache - expired tokens should not be loaded
-	err = cache.Refresh()
-	g.Expect(err).To(BeNil())
-
-	_, err = cache.FindToken("expired-secret")
-	g.Expect(err).NotTo(BeNil())
-	g.Expect(errors.As(err, &notFound)).To(BeTrue())
+	// Verify scopes
+	g.Expect(subject.Scopes).NotTo(BeEmpty())
+	g.Expect(subject.Scopes).To(ContainElement("addons:get"))
 }
 
-// TestFindSubjectEdgeCases tests edge cases in subject finding.
-func TestFindSubjectEdgeCases(t *testing.T) {
+// TestCacheFindSubjectTaskNotFound tests NotFound error for non-existent task.
+func TestCacheFindSubjectTaskNotFound(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	db, err := setupTestDB()
@@ -1000,179 +547,19 @@ func TestFindSubjectEdgeCases(t *testing.T) {
 	err = cache.Refresh()
 	g.Expect(err).To(BeNil())
 
-	// Test finding non-existent subject
-	_, err = cache.FindSubject("nonexistent-subject")
+	// Try to find non-existent task subject
+	nonExistentSubject := Task{ID: 9999}.Subject()
+	_, err = cache.FindSubject(nonExistentSubject)
 	g.Expect(err).NotTo(BeNil())
+
 	var notFound *NotFound
 	g.Expect(errors.As(err, &notFound)).To(BeTrue())
 	g.Expect(notFound.Resource).To(Equal("subject"))
-	g.Expect(notFound.Id).To(Equal("nonexistent-subject"))
+	g.Expect(notFound.Id).To(Equal(nonExistentSubject))
 }
 
-// TestRoleGetScopes tests Role.GetScopes method.
-func TestRoleGetScopes(t *testing.T) {
-	g := NewGomegaWithT(t)
-
-	// Test role with multiple permissions
-	role := &Role{
-		Model: Model{ID: 1},
-		Name:  "TestRole",
-		Permissions: []Permission{
-			{Scope: "applications:get"},
-			{Scope: "applications:post"},
-			{Scope: "tasks:get"},
-		},
-	}
-
-	scopes := role.GetScopes()
-	g.Expect(scopes).To(HaveLen(3))
-	g.Expect(scopes).To(ContainElement("applications:get"))
-	g.Expect(scopes).To(ContainElement("applications:post"))
-	g.Expect(scopes).To(ContainElement("tasks:get"))
-
-	// Test role with duplicate scopes
-	roleWithDupes := &Role{
-		Model: Model{ID: 2},
-		Name:  "RoleWithDupes",
-		Permissions: []Permission{
-			{Scope: "tasks:get"},
-			{Scope: "applications:get"},
-			{Scope: "tasks:get"}, // Duplicate
-		},
-	}
-
-	scopes = roleWithDupes.GetScopes()
-	g.Expect(scopes).To(HaveLen(2)) // Duplicates removed
-	g.Expect(scopes).To(ContainElement("tasks:get"))
-	g.Expect(scopes).To(ContainElement("applications:get"))
-
-	// Test role with no permissions
-	emptyRole := &Role{
-		Model:       Model{ID: 3},
-		Name:        "EmptyRole",
-		Permissions: []Permission{},
-	}
-
-	scopes = emptyRole.GetScopes()
-	g.Expect(scopes).To(BeEmpty())
-}
-
-// TestUserGetScopes tests User.GetScopes method.
-func TestUserGetScopes(t *testing.T) {
-	g := NewGomegaWithT(t)
-
-	db, err := setupTestDB()
-	g.Expect(err).To(BeNil())
-
-	// Create permissions
-	perm1 := &Permission{Name: "Perm1", Scope: "apps:get"}
-	perm2 := &Permission{Name: "Perm2", Scope: "apps:post"}
-	perm3 := &Permission{Name: "Perm3", Scope: "tasks:get"}
-	err = db.Create(perm1).Error
-	g.Expect(err).To(BeNil())
-	err = db.Create(perm2).Error
-	g.Expect(err).To(BeNil())
-	err = db.Create(perm3).Error
-	g.Expect(err).To(BeNil())
-
-	// Create roles
-	role1 := &Role{
-		Name:        "Role1",
-		Permissions: []Permission{*perm1, *perm2},
-	}
-	role2 := &Role{
-		Name:        "Role2",
-		Permissions: []Permission{*perm2, *perm3}, // perm2 is duplicate
-	}
-	err = db.Create(role1).Error
-	g.Expect(err).To(BeNil())
-	err = db.Create(role2).Error
-	g.Expect(err).To(BeNil())
-
-	// Create user with both roles
-	user := &User{
-		Subject: "test-user",
-		Login:   "testuser",
-		Roles:   []model.Role{model.Role(*role1), model.Role(*role2)},
-	}
-	err = db.Create(user).Error
-	g.Expect(err).To(BeNil())
-
-	cache := New(db)
-	err = cache.Refresh()
-	g.Expect(err).To(BeNil())
-
-	cachedUser, err := cache.FindUserByLogin("testuser")
-	g.Expect(err).To(BeNil())
-
-	scopes := cachedUser.GetScopes(cache)
-	g.Expect(scopes).To(HaveLen(3)) // Should have 3 unique scopes
-	g.Expect(scopes).To(ContainElement("apps:get"))
-	g.Expect(scopes).To(ContainElement("apps:post"))
-	g.Expect(scopes).To(ContainElement("tasks:get"))
-
-	// Test user with no roles
-	userNoRoles := &User{
-		Model:   Model{ID: 999},
-		Subject: "noroles",
-		Login:   "noroles",
-	}
-	scopes = userNoRoles.GetScopes(cache)
-	g.Expect(scopes).To(BeEmpty())
-}
-
-// TestIdpClientWith tests IdpClient.With() method.
-func TestIdpClientWith(t *testing.T) {
-	g := NewGomegaWithT(t)
-
-	// Test with all fields populated
-	settingsClient := &as.IdpClient{
-		ID:              1,
-		ClientId:        "test-client",
-		Secret:          "test-secret",
-		ApplicationType: "web",
-		Grants:          []string{"authorization_code", "refresh_token"},
-		RedirectURIs:    []string{"http://localhost/callback"},
-		Scopes:          []string{"openid", "profile"},
-	}
-
-	cacheClient := &IdpClient{}
-	cacheClient.With(settingsClient)
-
-	g.Expect(cacheClient.ID).To(Equal(uint(1)))
-	g.Expect(cacheClient.ClientId).To(Equal("test-client"))
-	g.Expect(cacheClient.Secret).To(Equal("test-secret"))
-	g.Expect(cacheClient.ApplicationType).To(Equal("web"))
-	g.Expect(cacheClient.Grants).To(HaveLen(2))
-	g.Expect(cacheClient.Grants).To(ContainElement("authorization_code"))
-	g.Expect(cacheClient.Grants).To(ContainElement("refresh_token"))
-	g.Expect(cacheClient.RedirectURIs).To(HaveLen(1))
-	g.Expect(cacheClient.RedirectURIs[0]).To(Equal("http://localhost/callback"))
-	g.Expect(cacheClient.Scopes).To(HaveLen(2))
-	g.Expect(cacheClient.Scopes).To(ContainElement("openid"))
-	g.Expect(cacheClient.Scopes).To(ContainElement("profile"))
-
-	// Test with empty secret (public client)
-	publicClient := &as.IdpClient{
-		ID:              2,
-		ClientId:        "public-client",
-		Secret:          "",
-		ApplicationType: "native",
-		Grants:          []string{"device_code"},
-		Scopes:          []string{"openid"},
-	}
-
-	cachePublic := &IdpClient{}
-	cachePublic.With(publicClient)
-
-	g.Expect(cachePublic.ID).To(Equal(uint(2)))
-	g.Expect(cachePublic.ClientId).To(Equal("public-client"))
-	g.Expect(cachePublic.Secret).To(BeEmpty())
-	g.Expect(cachePublic.ApplicationType).To(Equal("native"))
-}
-
-// TestCopyOnWriteCommit verifies Commit clones Data instead of mutating.
-func TestCopyOnWriteCommit(t *testing.T) {
+// TestTaskRevokedRemovesTaskSubject tests that TaskRevoked removes task from subject cache.
+func TestTaskRevokedRemovesTaskSubject(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	db, err := setupTestDB()
@@ -1182,34 +569,26 @@ func TestCopyOnWriteCommit(t *testing.T) {
 	err = cache.Refresh()
 	g.Expect(err).To(BeNil())
 
-	// Load Data before Tx
-	oldData := cache.data.Load()
+	// Add task
+	task := &Task{ID: 1111}
+	cache.TaskGranted(task)
 
-	// Execute transaction
-	user := &User{
-		Model:   Model{ID: 100},
-		Subject: "cow-test",
-		Login:   "cowtest",
-	}
-	cache.UserSaved(user)
+	// Verify task in cache
+	expectedSubject := task.Subject()
+	subject, err := cache.FindSubject(expectedSubject)
+	g.Expect(err).To(BeNil())
+	g.Expect(subject.IsTask()).To(BeTrue())
 
-	// Load Data after Tx
-	newData := cache.data.Load()
+	// Revoke task
+	cache.TaskRevoked(1111)
 
-	// Verify Data pointer changed (copy-on-write)
-	g.Expect(oldData).NotTo(Equal(newData))
-
-	// Verify old Data unchanged
-	_, found := oldData.userById[100]
-	g.Expect(found).To(BeFalse())
-
-	// Verify new Data has change
-	_, found = newData.userById[100]
-	g.Expect(found).To(BeTrue())
+	// Verify task removed from subject cache
+	_, err = cache.FindSubject(expectedSubject)
+	g.Expect(err).NotTo(BeNil())
 }
 
-// TestConcurrentCommitsNoLostUpdates verifies mutex prevents lost updates.
-func TestConcurrentCommitsNoLostUpdates(t *testing.T) {
+// TestCacheTaskLifecycle tests full task lifecycle in cache.
+func TestCacheTaskLifecycle(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	db, err := setupTestDB()
@@ -1219,71 +598,31 @@ func TestConcurrentCommitsNoLostUpdates(t *testing.T) {
 	err = cache.Refresh()
 	g.Expect(err).To(BeNil())
 
-	// Spawn 10 concurrent UserSaved operations
-	var wg sync.WaitGroup
-	for i := 0; i < 10; i++ {
-		wg.Add(1)
-		go func(id int) {
-			defer wg.Done()
-			user := &User{
-				Model:   Model{ID: uint(id + 100)},
-				Subject: fmt.Sprintf("concurrent-%d", id),
-				Login:   fmt.Sprintf("concurrent%d", id),
-			}
-			cache.UserSaved(user)
-		}(i)
-	}
+	// Initially not in cache
+	task := &Task{ID: 2222}
+	expectedSubject := task.Subject()
+	_, err = cache.FindSubject(expectedSubject)
+	g.Expect(err).NotTo(BeNil())
 
-	wg.Wait()
+	// Grant adds to cache
+	cache.TaskGranted(task)
 
-	// Verify ALL 10 users are in cache (no lost updates)
-	d := cache.data.Load()
-	for i := 0; i < 10; i++ {
-		_, found := d.userById[uint(i+100)]
-		g.Expect(found).To(BeTrue(), fmt.Sprintf("user %d not found", i))
-	}
+	// Now in cache
+	subject, err := cache.FindSubject(expectedSubject)
+	g.Expect(err).To(BeNil())
+	g.Expect(subject.IsTask()).To(BeTrue())
+	g.Expect(subject.Login()).To(Equal(expectedSubject))
+
+	// Revoke removes from cache
+	cache.TaskRevoked(2222)
+
+	// No longer in cache
+	_, err = cache.FindSubject(expectedSubject)
+	g.Expect(err).NotTo(BeNil())
 }
 
-// TestDataClone verifies clone creates independent copy.
-func TestDataClone(t *testing.T) {
-	g := NewGomegaWithT(t)
-
-	// Create original Data with content
-	original := &Data{}
-	original.reset()
-	original.userById[1] = &User{Model: Model{ID: 1}, Login: "user1"}
-	original.roleById[2] = &Role{Model: Model{ID: 2}, Name: "role1"}
-	original.refreshed = time.Now().Add(-5 * time.Minute)
-
-	// Clone it
-	clone := original.clone()
-
-	// Verify refreshed timestamp copied
-	g.Expect(clone.refreshed).To(Equal(original.refreshed))
-
-	// Verify maps copied (share same objects)
-	g.Expect(clone.userById[1]).To(Equal(original.userById[1]))
-	g.Expect(clone.roleById[2]).To(Equal(original.roleById[2]))
-
-	// Mutate clone - should NOT affect original
-	clone.userById[3] = &User{Model: Model{ID: 3}, Login: "user3"}
-	delete(clone.roleById, 2)
-
-	// Verify original unchanged
-	_, found := original.userById[3]
-	g.Expect(found).To(BeFalse())
-	_, found = original.roleById[2]
-	g.Expect(found).To(BeTrue())
-
-	// Verify clone has mutations
-	_, found = clone.userById[3]
-	g.Expect(found).To(BeTrue())
-	_, found = clone.roleById[2]
-	g.Expect(found).To(BeFalse())
-}
-
-// TestOnDemandRefresh verifies ensureRefreshed triggers when stale.
-func TestOnDemandRefresh(t *testing.T) {
+// TestMultipleTasksInCache tests multiple tasks can coexist in cache.
+func TestMultipleTasksInCache(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	db, err := setupTestDB()
@@ -1293,102 +632,47 @@ func TestOnDemandRefresh(t *testing.T) {
 	err = cache.Refresh()
 	g.Expect(err).To(BeNil())
 
-	// Get original Data and manually age it
-	d := cache.data.Load()
-	oldRefreshed := d.refreshed
-
-	// Create a new stale Data and swap it in
-	staleData := d.clone()
-	staleData.refreshed = time.Now().Add(-10 * time.Minute) // Stale
-	cache.data.Store(staleData)
-
-	// Create new user in DB (bypassing cache notifications)
-	user := &User{
-		Subject:  "on-demand-user",
-		Login:    "ondemanduser",
-		Password: secret.HashPassword("password"),
-		Email:    "ondemand@example.com",
+	// Add multiple tasks
+	tasks := []*Task{
+		{ID: 1},
+		{ID: 2},
+		{ID: 3},
+		{ID: 100},
+		{ID: 999},
 	}
-	err = db.Create(user).Error
-	g.Expect(err).To(BeNil())
 
-	// First FindXXX should trigger refresh
-	cache.FindUserByLogin("ondemanduser")
-
-	// Poll until refresh completes (max 2 seconds)
-	refreshed := false
-	for i := 0; i < 20; i++ {
-		time.Sleep(100 * time.Millisecond)
-		d = cache.data.Load()
-		if d.refreshed.After(oldRefreshed) {
-			refreshed = true
-			break
-		}
+	for _, task := range tasks {
+		cache.TaskGranted(task)
 	}
-	g.Expect(refreshed).To(BeTrue(), "refresh should complete within 2 seconds")
 
-	// Verify new user now in cache
-	found, err := cache.FindUserByLogin("ondemanduser")
-	g.Expect(err).To(BeNil())
-	g.Expect(found).NotTo(BeNil())
-}
-
-// TestAuthStorm tests lock-free reads under concurrent load.
-func TestAuthStorm(t *testing.T) {
-	g := NewGomegaWithT(t)
-
-	db, err := setupTestDB()
-	g.Expect(err).To(BeNil())
-
-	// Create test tokens
-	for i := 0; i < 10; i++ {
-		token := &Token{
-			Token: model.Token{
-				Kind:       KindAPIKey,
-				AuthId:     fmt.Sprintf("storm-auth-%d", i),
-				Digest:     secret.Hash(fmt.Sprintf("storm-token-%d", i)),
-				Expiration: time.Now().Add(24 * time.Hour),
-			},
-			Secret: fmt.Sprintf("storm-token-%d", i),
-		}
-		err = db.Create(&token.Token).Error
+	// All tasks should be findable
+	for _, task := range tasks {
+		expectedSubject := task.Subject()
+		subject, err := cache.FindSubject(expectedSubject)
 		g.Expect(err).To(BeNil())
+		g.Expect(subject.IsTask()).To(BeTrue())
+		g.Expect(subject.Login()).To(Equal(expectedSubject))
 	}
 
-	cache := New(db)
-	err = cache.Refresh()
-	g.Expect(err).To(BeNil())
+	// Revoke one task
+	cache.TaskRevoked(2)
 
-	// 100 goroutines each doing 10 FindToken calls
-	var wg sync.WaitGroup
-	successCount := make([]int, 100)
+	// Task 2 should be gone
+	task2Subject := Task{ID: 2}.Subject()
+	_, err = cache.FindSubject(task2Subject)
+	g.Expect(err).NotTo(BeNil())
 
-	for i := 0; i < 100; i++ {
-		wg.Add(1)
-		go func(idx int) {
-			defer wg.Done()
-			for j := 0; j < 10; j++ {
-				tokenIdx := j % 10
-				_, err := cache.FindToken(fmt.Sprintf("storm-token-%d", tokenIdx))
-				if err == nil {
-					successCount[idx]++
-				}
-			}
-		}(i)
+	// Others still present
+	for _, taskID := range []uint{1, 3, 100, 999} {
+		expectedSubject := Task{ID: taskID}.Subject()
+		subject, err := cache.FindSubject(expectedSubject)
+		g.Expect(err).To(BeNil())
+		g.Expect(subject.IsTask()).To(BeTrue())
 	}
-
-	wg.Wait()
-
-	// All reads should succeed
-	totalSuccess := 0
-	for _, count := range successCount {
-		totalSuccess += count
-	}
-	g.Expect(totalSuccess).To(Equal(1000))
 }
 
-// TestTaskChurnUnderLoad tests copy-on-write under write load.
-func TestTaskChurnUnderLoad(t *testing.T) {
+// TestCacheConcurrentTaskOperations tests concurrent task operations on cache.
+func TestCacheConcurrentTaskOperations(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	db, err := setupTestDB()
@@ -1399,140 +683,167 @@ func TestTaskChurnUnderLoad(t *testing.T) {
 	g.Expect(err).To(BeNil())
 
 	var wg sync.WaitGroup
-	doneChan := make(chan struct{})
+	iterations := 100
 
-	// 10 writers: create/revoke task tokens
-	for i := 0; i < 10; i++ {
-		wg.Add(1)
-		go func(id int) {
-			defer wg.Done()
-			taskID := uint(1000 + id)
-			tokenSecret := fmt.Sprintf("churn-token-%d", id)
-
-			for j := 0; j < 10; j++ {
-				select {
-				case <-doneChan:
-					return
-				default:
-				}
-
-				// Add token
-				token := &Token{
-					Token: model.Token{
-						Model:      Model{ID: uint(id*100 + j)},
-						TaskID:     &taskID,
-						Digest:     secret.Hash(tokenSecret),
-						Expiration: time.Now().Add(24 * time.Hour),
-					},
-					Secret: tokenSecret,
-				}
-				cache.TokenSaved(token)
-
-				// Revoke it
-				cache.TaskRevoked(taskID)
-			}
-		}(i)
-	}
-
-	// 50 readers: continuously try to find tokens
-	readErrors := make([]int, 50)
-	for i := 0; i < 50; i++ {
-		wg.Add(1)
-		go func(idx int) {
-			defer wg.Done()
-			for j := 0; j < 20; j++ {
-				select {
-				case <-doneChan:
-					return
-				default:
-				}
-				tokenIdx := j % 10
-				_, err := cache.FindToken(fmt.Sprintf("churn-token-%d", tokenIdx))
-				// Token may or may not exist (being churned)
-				// Just verify no panic/crash
-				if err != nil {
-					readErrors[idx]++
-				}
-			}
-		}(i)
-	}
-
-	wg.Wait()
-	close(doneChan)
-
-	// Test passes if no panics occurred
-	// Read errors are expected due to churn
-}
-
-// TestRefreshRace tests that Data.refreshOnce prevents stampede.
-func TestRefreshRace(t *testing.T) {
-	g := NewGomegaWithT(t)
-
-	db, err := setupTestDB()
-	g.Expect(err).To(BeNil())
-
-	cache := New(db)
-	err = cache.Refresh()
-	g.Expect(err).To(BeNil())
-
-	// Make cache stale
-	d := cache.data.Load()
-	staleData := d.clone()
-	staleData.refreshed = time.Now().Add(-10 * time.Minute)
-	cache.data.Store(staleData)
-
-	// 50 goroutines all detect staleness simultaneously
-	var wg sync.WaitGroup
-	for i := 0; i < 50; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			// This triggers ensureRefreshed
-			cache.FindUserByLogin("nonexistent")
-		}()
-	}
-
-	wg.Wait()
-
-	// Give refresh time to complete
-	time.Sleep(100 * time.Millisecond)
-
-	// Verify cache refreshed (exactly once via sync.Once)
-	d = cache.data.Load()
-	g.Expect(d.refreshed).To(BeTemporally(">", staleData.refreshed))
-}
-
-// TestMixedConcurrentOperations tests all operations work concurrently.
-func TestMixedConcurrentOperations(t *testing.T) {
-	g := NewGomegaWithT(t)
-
-	db, err := setupTestDB()
-	g.Expect(err).To(BeNil())
-
-	cache := New(db)
-	err = cache.Refresh()
-	g.Expect(err).To(BeNil())
-
-	var wg sync.WaitGroup
-	iterations := 20
-
-	// Concurrent UserSaved
+	// Concurrent TaskGranted
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func(id int) {
 			defer wg.Done()
 			for j := 0; j < iterations; j++ {
-				user := &User{
-					Model:   Model{ID: uint(id*1000 + j)},
-					Subject: fmt.Sprintf("mixed-user-%d-%d", id, j),
-					Login:   fmt.Sprintf("mixeduser%d-%d", id, j),
-				}
-				cache.UserSaved(user)
+				task := &Task{ID: uint(id*1000 + j)}
+				cache.TaskGranted(task)
 			}
 		}(i)
 	}
 
-	// Concurrent RoleSaved/Deleted
+	// Concurrent TaskRevoked
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				cache.TaskRevoked(uint(id*1000 + j))
+			}
+		}(i)
+	}
+
+	// Concurrent FindSubject (task)
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				taskID := j % 100
+				cache.FindSubject(Task{ID: uint(taskID)}.Subject())
+			}
+		}(i)
+	}
+
+	wg.Wait()
+
+	// Verify cache is still consistent
+	d := cache.data.Load()
+	g.Expect(d).NotTo(BeNil())
+	// Some tasks may remain (race between grant/revoke)
+	g.Expect(len(d.taskById)).To(BeNumerically(">=", 0))
+}
+
+// TestTaskRefresh tests that task cache is properly loaded on refresh.
+func TestTaskRefresh(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	db, err := setupTestDB()
+	g.Expect(err).To(BeNil())
+
+	// Create tasks in database (no cache yet)
+	task1 := &Task{ID: 100}
+	task2 := &Task{ID: 200}
+	err = db.Create(task1).Error
+	g.Expect(err).To(BeNil())
+	err = db.Create(task2).Error
+	g.Expect(err).To(BeNil())
+
+	// Create cache and refresh
+	cache := New(db)
+	err = cache.Refresh()
+	g.Expect(err).To(BeNil())
+
+	// Tasks should be loaded into cache if they exist in DB
+	// (Current implementation may not load tasks on refresh - only on TaskGranted)
+	// This test documents current behavior
+	d := cache.data.Load()
+	g.Expect(d).NotTo(BeNil())
+}
+
+// TestCacheMixedSubjectTypes tests that different subject types (User, Identity, Client, Task) coexist.
+func TestCacheMixedSubjectTypes(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	db, err := setupTestDB()
+	g.Expect(err).To(BeNil())
+
+	cache := New(db)
+	err = cache.Refresh()
+	g.Expect(err).To(BeNil())
+
+	// Add user
+	user := &User{
+		Model:   Model{ID: 1},
+		Subject: "user-subject-1",
+		Login:   "user1",
+	}
+	cache.UserSaved(user)
+
+	// Add identity
+	identity := &Identity{
+		Model:   Model{ID: 1},
+		Issuer:  "https://idp.example.com",
+		Subject: "identity-subject-1",
+		Login:   "identity1",
+	}
+	cache.IdentitySaved(identity)
+
+	// Add client
+	client := &IdpClient{
+		Model:    Model{ID: 1},
+		Subject:  "client-subject-1",
+		ClientId: "client1",
+	}
+	cache.ClientSaved(client)
+
+	// Add task
+	task := &Task{ID: 1}
+	cache.TaskGranted(task)
+
+	// All should be findable
+	userSubj, err := cache.FindSubject("user-subject-1")
+	g.Expect(err).To(BeNil())
+	g.Expect(userSubj.IsUser()).To(BeTrue())
+	g.Expect(userSubj.Login()).To(Equal("user1"))
+
+	identSubj, err := cache.FindSubject("identity-subject-1")
+	g.Expect(err).To(BeNil())
+	g.Expect(identSubj.IsIdentity()).To(BeTrue())
+	g.Expect(identSubj.Login()).To(Equal("identity1"))
+
+	clientSubj, err := cache.FindSubject("client-subject-1")
+	g.Expect(err).To(BeNil())
+	g.Expect(clientSubj.IsClient()).To(BeTrue())
+	g.Expect(clientSubj.Login()).To(Equal("client1"))
+
+	taskSubject := task.Subject()
+	taskSubj, err := cache.FindSubject(taskSubject)
+	g.Expect(err).To(BeNil())
+	g.Expect(taskSubj.IsTask()).To(BeTrue())
+	g.Expect(taskSubj.Login()).To(Equal(taskSubject))
+}
+
+// TestCacheConcurrentMixedOperations tests mixed concurrent operations.
+func TestCacheConcurrentMixedOperations(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	db, err := setupTestDB()
+	g.Expect(err).To(BeNil())
+
+	cache := New(db)
+	err = cache.Refresh()
+	g.Expect(err).To(BeNil())
+
+	// Seed some initial data
+	for i := 0; i < 10; i++ {
+		user := &User{
+			Model:   Model{ID: uint(i)},
+			Subject: fmt.Sprintf("mixeduser%d", i),
+			Login:   fmt.Sprintf("mixeduser%d", i),
+		}
+		cache.UserSaved(user)
+	}
+
+	var wg sync.WaitGroup
+	iterations := 50
+
+	// Concurrent RoleSaved/RoleDeleted
 	for i := 0; i < 10; i++ {
 		wg.Add(1)
 		go func(id int) {
@@ -1578,7 +889,34 @@ func TestMixedConcurrentOperations(t *testing.T) {
 			defer wg.Done()
 			for j := 0; j < iterations; j++ {
 				userIdx := j % 10
-				cache.FindUserByLogin(fmt.Sprintf("mixeduser%d-%d", userIdx, j))
+				cache.FindUserByLogin(fmt.Sprintf("mixeduser%d", userIdx))
+			}
+		}(i)
+	}
+
+	// Concurrent TaskGranted/TaskRevoked
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				task := &Task{ID: uint(id*1000 + j)}
+				cache.TaskGranted(task)
+				if j%3 == 0 {
+					cache.TaskRevoked(task.ID)
+				}
+			}
+		}(i)
+	}
+
+	// Concurrent FindSubject (task)
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				taskID := j % 100
+				cache.FindSubject(Task{ID: uint(taskID)}.Subject())
 			}
 		}(i)
 	}
@@ -1589,4 +927,6 @@ func TestMixedConcurrentOperations(t *testing.T) {
 	d := cache.data.Load()
 	// Should have some users (not all, some deleted/not found)
 	g.Expect(len(d.userById)).To(BeNumerically(">", 0))
+	// Should have some tasks (some granted, some revoked)
+	g.Expect(len(d.taskById)).To(BeNumerically(">=", 0))
 }

--- a/internal/auth/cache/pkg_test.go
+++ b/internal/auth/cache/pkg_test.go
@@ -381,11 +381,32 @@ func TestTaskSubjectParsing(t *testing.T) {
 	g.Expect(subject.Task).NotTo(BeNil())
 	g.Expect(subject.Task.ID).To(Equal(uint(800)))
 	g.Expect(subject.Key).To(Equal(expectedSubject))
-	g.Expect(subject.Login()).To(Equal(expectedSubject))
+	g.Expect(subject.Login()).To(Equal(task.Login()))
 }
 
-// TestTaskSubject tests Task.Subject() method.
+// TestTaskSubject tests Task.Subject() method returns hex format.
 func TestTaskSubject(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	tests := []struct {
+		taskID   uint
+		expected string
+	}{
+		{1, "task.0x1"},
+		{42, "task.0x2a"},
+		{999, "task.0x3e7"},
+		{12345, "task.0x3039"},
+		{445, "task.0x1bd"},
+	}
+
+	for _, tt := range tests {
+		task := &Task{ID: tt.taskID}
+		g.Expect(task.Subject()).To(Equal(tt.expected))
+	}
+}
+
+// TestTaskLogin tests Task.Login() method returns decimal format.
+func TestTaskLogin(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	tests := []struct {
@@ -396,11 +417,46 @@ func TestTaskSubject(t *testing.T) {
 		{42, "task.42"},
 		{999, "task.999"},
 		{12345, "task.12345"},
+		{445, "task.445"},
 	}
 
 	for _, tt := range tests {
 		task := &Task{ID: tt.taskID}
-		g.Expect(task.Subject()).To(Equal(tt.expected))
+		g.Expect(task.Login()).To(Equal(tt.expected))
+	}
+}
+
+// TestTaskWith tests Task.With() parser for hex format.
+func TestTaskWith(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	tests := []struct {
+		subject     string
+		shouldMatch bool
+		expectedID  uint
+	}{
+		{"task.0x1", true, 1},
+		{"task.0x2a", true, 42},
+		{"task.0x3e7", true, 999},
+		{"task.0x3039", true, 12345},
+		{"task.0x1bd", true, 445},
+		{"task.0xff", true, 255},
+		{"task.0xFFFF", true, 65535},
+		{"task.123", false, 0},   // decimal format should not match
+		{"task.0x", false, 0},    // invalid hex
+		{"task.0xGHI", false, 0}, // invalid hex chars
+		{"user.0x1", false, 0},   // wrong prefix
+		{"task.1", false, 0},     // missing 0x
+		{"", false, 0},           // empty string
+	}
+
+	for _, tt := range tests {
+		task := &Task{}
+		matched := task.With(tt.subject)
+		g.Expect(matched).To(Equal(tt.shouldMatch), "subject: %s", tt.subject)
+		if tt.shouldMatch {
+			g.Expect(task.ID).To(Equal(tt.expectedID), "subject: %s", tt.subject)
+		}
 	}
 }
 
@@ -474,10 +530,10 @@ func TestSubjectIsTask(t *testing.T) {
 func TestSubjectLogin(t *testing.T) {
 	g := NewGomegaWithT(t)
 
-	// Task login
+	// Task login (decimal format)
 	task := &Task{ID: 445}
 	taskSubject := &Subject{Task: task}
-	g.Expect(taskSubject.Login()).To(Equal(task.Subject()))
+	g.Expect(taskSubject.Login()).To(Equal("task.445"))
 
 	// User login
 	userID := uint(1)
@@ -519,7 +575,7 @@ func TestCacheFindSubjectTask(t *testing.T) {
 	g.Expect(subject.IsTask()).To(BeTrue())
 	g.Expect(subject.Task.ID).To(Equal(uint(999)))
 	g.Expect(subject.Key).To(Equal(expectedSubject))
-	g.Expect(subject.Login()).To(Equal(expectedSubject))
+	g.Expect(subject.Login()).To(Equal(task.Login()))
 
 	// Verify scopes
 	g.Expect(subject.Scopes).NotTo(BeEmpty())
@@ -592,7 +648,7 @@ func TestTaskSubjectParsingBehavior(t *testing.T) {
 	subject, err := cache.FindSubject(expectedSubject)
 	g.Expect(err).To(BeNil())
 	g.Expect(subject.IsTask()).To(BeTrue())
-	g.Expect(subject.Login()).To(Equal(expectedSubject))
+	g.Expect(subject.Login()).To(Equal(task.Login()))
 
 	// TaskRevoked doesn't affect parsing
 	cache.TaskRevoked(2222)
@@ -629,7 +685,7 @@ func TestMultipleTaskSubjectsParseable(t *testing.T) {
 		subject, err := cache.FindSubject(expectedSubject)
 		g.Expect(err).To(BeNil())
 		g.Expect(subject.IsTask()).To(BeTrue())
-		g.Expect(subject.Login()).To(Equal(expectedSubject))
+		g.Expect(subject.Login()).To(Equal(task.Login()))
 	}
 
 	// TaskRevoked only removes tokens
@@ -778,7 +834,7 @@ func TestCacheMixedSubjectTypes(t *testing.T) {
 	taskSubj, err := cache.FindSubject(taskSubject)
 	g.Expect(err).To(BeNil())
 	g.Expect(taskSubj.IsTask()).To(BeTrue())
-	g.Expect(taskSubj.Login()).To(Equal(taskSubject))
+	g.Expect(taskSubj.Login()).To(Equal(task.Login()))
 }
 
 // TestCacheConcurrentMixedOperations tests mixed concurrent operations.

--- a/internal/auth/cache/subject.go
+++ b/internal/auth/cache/subject.go
@@ -17,6 +17,7 @@ type Subject struct {
 	User       *User
 	Identity   *Identity
 	Client     *IdpClient
+	Task       *Task
 }
 
 // WithUser populates Subject from a User model.
@@ -56,6 +57,13 @@ func (r *Subject) WithClient(client *IdpClient, cache *Cache) {
 	r.Scopes = client.GetScopes()
 }
 
+// WithTask populates with the task.
+func (r *Subject) WithTask(task *Task) {
+	r.Task = task
+	r.Key = task.Subject()
+	r.Scopes = task.GetScopes()
+}
+
 // Login returns the user (login) name (Eg: jsmith).
 func (r *Subject) Login() (login string) {
 	if r.IsUser() {
@@ -65,6 +73,13 @@ func (r *Subject) Login() (login string) {
 	if r.IsIdentity() {
 		login = r.Identity.Login
 		return
+	}
+	if r.IsClient() {
+		login = r.Client.ClientId
+		return
+	}
+	if r.IsTask() {
+		login = r.Task.Subject()
 	}
 	return
 }
@@ -82,4 +97,9 @@ func (r *Subject) IsIdentity() bool {
 // IsClient returns true if this subject is an IdpClient.
 func (r *Subject) IsClient() bool {
 	return r.ClientId != nil
+}
+
+// IsTask returns true if the subject is a Task.
+func (r *Subject) IsTask() bool {
+	return r.Task != nil
 }

--- a/internal/auth/cache/subject.go
+++ b/internal/auth/cache/subject.go
@@ -79,7 +79,7 @@ func (r *Subject) Login() (login string) {
 		return
 	}
 	if r.IsTask() {
-		login = r.Task.Subject()
+		login = r.Task.Login()
 	}
 	return
 }

--- a/internal/auth/cache/tx.go
+++ b/internal/auth/cache/tx.go
@@ -60,24 +60,10 @@ func (r *Tx) UserDeleted(id uint) {
 		})
 }
 
-// TaskGranted task token has been created.
-func (r *Tx) TaskGranted(m *Task) {
-	r.changes = append(
-		r.changes, func(d *Data) {
-			d.taskById[m.ID] = m
-			d.taskBySubject[m.Subject()] = m
-		})
-}
-
 // TaskRevoked task token revoked.
 func (r *Tx) TaskRevoked(id uint) {
 	r.changes = append(
 		r.changes, func(d *Data) {
-			m, found := d.taskById[id]
-			if found {
-				delete(d.taskById, id)
-				delete(d.taskBySubject, m.Subject())
-			}
 			for _, m := range d.tokenById {
 				if m.TaskID != nil && *m.TaskID == id {
 					delete(d.tokenByDigest, m.Digest)

--- a/internal/auth/cache/tx.go
+++ b/internal/auth/cache/tx.go
@@ -60,10 +60,24 @@ func (r *Tx) UserDeleted(id uint) {
 		})
 }
 
+// TaskGranted task token has been created.
+func (r *Tx) TaskGranted(m *Task) {
+	r.changes = append(
+		r.changes, func(d *Data) {
+			d.taskById[m.ID] = m
+			d.taskBySubject[m.Subject()] = m
+		})
+}
+
 // TaskRevoked task token revoked.
 func (r *Tx) TaskRevoked(id uint) {
 	r.changes = append(
 		r.changes, func(d *Data) {
+			m, found := d.taskById[id]
+			if found {
+				delete(d.taskById, id)
+				delete(d.taskBySubject, m.Subject())
+			}
 			for _, m := range d.tokenById {
 				if m.TaskID != nil && *m.TaskID == id {
 					delete(d.tokenByDigest, m.Digest)

--- a/internal/auth/pkg.go
+++ b/internal/auth/pkg.go
@@ -73,7 +73,7 @@ type Provider interface {
 	// NewToken creates a new personal access token.
 	NewToken(subject string, lifespan time.Duration) (token Token, err error)
 	// TaskGrant creates a new api-key.
-	TaskGrant(taskId uint) (token Token, err error)
+	TaskGrant(task *Task) (token Token, err error)
 	// TaskRevoke revokes task tokens.
 	TaskRevoke(taskId uint)
 	// Revoke a token.

--- a/internal/auth/pkg_test.go
+++ b/internal/auth/pkg_test.go
@@ -123,9 +123,8 @@ func TestTaskGrant(t *testing.T) {
 	g.Expect(err).To(BeNil())
 
 	// Create test task in Running state (required for cache to load it)
-	task := &model.Task{
-		Name:  "test-task",
-		State: "Running",
+	task := &Task{
+		ID: 445,
 	}
 	err = db.Create(task).Error
 	g.Expect(err).To(BeNil())
@@ -135,9 +134,11 @@ func TestTaskGrant(t *testing.T) {
 	g.Expect(err).To(BeNil())
 
 	// Test creating task token
-	token, err := provider.TaskGrant(task.ID)
+	token, err := provider.TaskGrant(task)
 	g.Expect(err).To(BeNil())
 	g.Expect(token.Secret).NotTo(BeEmpty())
+	g.Expect(token.TaskID).NotTo(BeNil())
+	g.Expect(*token.TaskID).To(Equal(uint(445)))
 
 	// Test authenticating with the task token
 	request := newTestRequest()
@@ -146,13 +147,288 @@ func TestTaskGrant(t *testing.T) {
 	g.Expect(err).To(BeNil())
 	g.Expect(jwToken).NotTo(BeNil())
 
-	// Verify the digest in the database matches
-	err = db.First(&token).Error
+	// Verify token claims contain task subject
+	claims := jwToken.Claims.(jwt.MapClaims)
+	subject := claims[ClaimSub].(string)
+	expectedSubject := Task{ID: 445}.Subject()
+	g.Expect(subject).To(Equal(expectedSubject))
+
+	// Verify User() returns task subject
+	user := provider.User(jwToken)
+	g.Expect(user).To(Equal(expectedSubject))
+
+	// Verify scopes are AddonScopes
+	scopes := provider.Scopes(jwToken)
+	g.Expect(scopes).NotTo(BeEmpty())
+	scopeStrings := make([]string, len(scopes))
+	for i, s := range scopes {
+		scopeStrings[i] = s.String()
+	}
+	g.Expect(scopeStrings).To(ContainElement("addons:get"))
+	g.Expect(scopeStrings).To(ContainElement("applications:get"))
+
+	// Verify the token was created in the database
+	var dbToken model.Token
+	err = db.First(&dbToken, token.ID).Error
+	g.Expect(err).To(BeNil())
+	g.Expect(dbToken.TaskID).NotTo(BeNil())
+	g.Expect(*dbToken.TaskID).To(Equal(uint(445)))
+}
+
+// TestTaskSubjectFormat tests that task subjects are formatted correctly.
+func TestTaskSubjectFormat(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	db, err := setupTestDB()
 	g.Expect(err).To(BeNil())
 
-	// Test creating key for non-existent task
-	_, err = provider.TaskGrant(9999)
+	// Create tasks with different IDs
+	task1 := &Task{ID: 1}
+	task2 := &Task{ID: 999}
+	task3 := &Task{ID: 12345}
+
+	err = db.Create(task1).Error
+	g.Expect(err).To(BeNil())
+	err = db.Create(task2).Error
+	g.Expect(err).To(BeNil())
+	err = db.Create(task3).Error
+	g.Expect(err).To(BeNil())
+
+	provider, err := NewBuiltin(db)
+	g.Expect(err).To(BeNil())
+
+	// Test task.1
+	token1, err := provider.TaskGrant(task1)
+	g.Expect(err).To(BeNil())
+	request := newTestRequest()
+	request.With("Bearer " + token1.Secret)
+	jwToken1, err := provider.Authenticate(request)
+	g.Expect(err).To(BeNil())
+	claims := jwToken1.Claims.(jwt.MapClaims)
+	expectedSubject1 := Task{ID: 1}.Subject()
+	g.Expect(claims[ClaimSub]).To(Equal(expectedSubject1))
+	g.Expect(provider.User(jwToken1)).To(Equal(expectedSubject1))
+
+	// Test task.999
+	token2, err := provider.TaskGrant(task2)
+	g.Expect(err).To(BeNil())
+	request = newTestRequest()
+	request.With("Bearer " + token2.Secret)
+	jwToken2, err := provider.Authenticate(request)
+	g.Expect(err).To(BeNil())
+	claims = jwToken2.Claims.(jwt.MapClaims)
+	expectedSubject2 := Task{ID: 999}.Subject()
+	g.Expect(claims[ClaimSub]).To(Equal(expectedSubject2))
+	g.Expect(provider.User(jwToken2)).To(Equal(expectedSubject2))
+
+	// Test task.12345
+	token3, err := provider.TaskGrant(task3)
+	g.Expect(err).To(BeNil())
+	request = newTestRequest()
+	request.With("Bearer " + token3.Secret)
+	jwToken3, err := provider.Authenticate(request)
+	g.Expect(err).To(BeNil())
+	claims = jwToken3.Claims.(jwt.MapClaims)
+	expectedSubject3 := Task{ID: 12345}.Subject()
+	g.Expect(claims[ClaimSub]).To(Equal(expectedSubject3))
+	g.Expect(provider.User(jwToken3)).To(Equal(expectedSubject3))
+}
+
+// TestTaskGrantedCacheUpdate tests that TaskGranted updates the cache.
+func TestTaskGrantedCacheUpdate(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	db, err := setupTestDB()
+	g.Expect(err).To(BeNil())
+
+	provider, err := NewBuiltin(db)
+	g.Expect(err).To(BeNil())
+
+	// Create task
+	task := &Task{ID: 100}
+	err = db.Create(task).Error
+	g.Expect(err).To(BeNil())
+
+	// Grant token - should add task to cache
+	token, err := provider.TaskGrant(task)
+	g.Expect(err).To(BeNil())
+
+	// Verify task is in cache by finding its subject
+	expectedSubject := task.Subject()
+	subject, err := provider.cache.FindSubject(expectedSubject)
+	g.Expect(err).To(BeNil())
+	g.Expect(subject).NotTo(BeNil())
+	g.Expect(subject.IsTask()).To(BeTrue())
+	g.Expect(subject.Task).NotTo(BeNil())
+	g.Expect(subject.Task.ID).To(Equal(uint(100)))
+	g.Expect(subject.Login()).To(Equal(expectedSubject))
+
+	// Verify authentication works
+	request := newTestRequest()
+	request.With("Bearer " + token.Secret)
+	_, err = provider.Authenticate(request)
+	g.Expect(err).To(BeNil())
+}
+
+// TestTaskSubjectScopes tests that task subjects get AddonScopes.
+func TestTaskSubjectScopes(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	db, err := setupTestDB()
+	g.Expect(err).To(BeNil())
+
+	task := &Task{ID: 200}
+	err = db.Create(task).Error
+	g.Expect(err).To(BeNil())
+
+	provider, err := NewBuiltin(db)
+	g.Expect(err).To(BeNil())
+
+	token, err := provider.TaskGrant(task)
+	g.Expect(err).To(BeNil())
+
+	request := newTestRequest()
+	request.With("Bearer " + token.Secret)
+	jwToken, err := provider.Authenticate(request)
+	g.Expect(err).To(BeNil())
+
+	// Verify scopes match AddonScopes
+	scopes := provider.Scopes(jwToken)
+	scopeStrings := make([]string, len(scopes))
+	for i, s := range scopes {
+		scopeStrings[i] = s.String()
+	}
+
+	// Check some key addon scopes
+	g.Expect(scopeStrings).To(ContainElement("addons:get"))
+	g.Expect(scopeStrings).To(ContainElement("applications:get"))
+	g.Expect(scopeStrings).To(ContainElement("applications:post"))
+	g.Expect(scopeStrings).To(ContainElement("applications:put"))
+	g.Expect(scopeStrings).To(ContainElement("applications.facts:*"))
+	g.Expect(scopeStrings).To(ContainElement("tasks:get"))
+	g.Expect(scopeStrings).To(ContainElement("identities:get"))
+}
+
+// TestTaskSubjectCacheLifecycle tests the full lifecycle of task subjects in cache.
+func TestTaskSubjectCacheLifecycle(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	db, err := setupTestDB()
+	g.Expect(err).To(BeNil())
+
+	provider, err := NewBuiltin(db)
+	g.Expect(err).To(BeNil())
+
+	// Create task
+	task := &Task{ID: 300}
+	err = db.Create(task).Error
+	g.Expect(err).To(BeNil())
+
+	// Task not in cache initially
+	expectedSubject := task.Subject()
+	_, err = provider.cache.FindSubject(expectedSubject)
 	g.Expect(err).NotTo(BeNil())
+
+	// Grant token - adds task to cache
+	token, err := provider.TaskGrant(task)
+	g.Expect(err).To(BeNil())
+
+	// Task now in cache
+	subject, err := provider.cache.FindSubject(expectedSubject)
+	g.Expect(err).To(BeNil())
+	g.Expect(subject.IsTask()).To(BeTrue())
+
+	// Authentication works
+	request := newTestRequest()
+	request.With("Bearer " + token.Secret)
+	_, err = provider.Authenticate(request)
+	g.Expect(err).To(BeNil())
+
+	// Revoke task - removes from cache
+	provider.TaskRevoke(300)
+
+	// Task removed from cache
+	_, err = provider.cache.FindSubject(expectedSubject)
+	g.Expect(err).NotTo(BeNil())
+
+	// Authentication fails
+	request = newTestRequest()
+	request.With("Bearer " + token.Secret)
+	_, err = provider.Authenticate(request)
+	g.Expect(err).NotTo(BeNil())
+}
+
+// TestMultipleTasksWithTokens tests multiple tasks can have tokens simultaneously.
+func TestMultipleTasksWithTokens(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	db, err := setupTestDB()
+	g.Expect(err).To(BeNil())
+
+	provider, err := NewBuiltin(db)
+	g.Expect(err).To(BeNil())
+
+	// Create multiple tasks
+	tasks := []*Task{
+		{ID: 1},
+		{ID: 2},
+		{ID: 3},
+	}
+	for _, task := range tasks {
+		err = db.Create(task).Error
+		g.Expect(err).To(BeNil())
+	}
+
+	// Grant tokens for all tasks
+	tokens := make([]Token, len(tasks))
+	for i, task := range tasks {
+		tokens[i], err = provider.TaskGrant(task)
+		g.Expect(err).To(BeNil())
+	}
+
+	// All tasks should be in cache and authenticate
+	for i, task := range tasks {
+		expectedSubject := task.Subject()
+
+		// Check cache
+		subject, err := provider.cache.FindSubject(expectedSubject)
+		g.Expect(err).To(BeNil())
+		g.Expect(subject.IsTask()).To(BeTrue())
+		g.Expect(subject.Login()).To(Equal(expectedSubject))
+
+		// Check authentication
+		request := newTestRequest()
+		request.With("Bearer " + tokens[i].Secret)
+		jwToken, err := provider.Authenticate(request)
+		g.Expect(err).To(BeNil())
+		claims := jwToken.Claims.(jwt.MapClaims)
+		g.Expect(claims[ClaimSub]).To(Equal(expectedSubject))
+		g.Expect(provider.User(jwToken)).To(Equal(expectedSubject))
+	}
+
+	// Revoke one task - others still work
+	provider.TaskRevoke(2)
+
+	// Task 2 should be gone
+	task2Subject := Task{ID: 2}.Subject()
+	_, err = provider.cache.FindSubject(task2Subject)
+	g.Expect(err).NotTo(BeNil())
+
+	request := newTestRequest()
+	request.With("Bearer " + tokens[1].Secret)
+	_, err = provider.Authenticate(request)
+	g.Expect(err).NotTo(BeNil())
+
+	// Task 1 and 3 still work
+	request = newTestRequest()
+	request.With("Bearer " + tokens[0].Secret)
+	_, err = provider.Authenticate(request)
+	g.Expect(err).To(BeNil())
+
+	request = newTestRequest()
+	request.With("Bearer " + tokens[2].Secret)
+	_, err = provider.Authenticate(request)
+	g.Expect(err).To(BeNil())
 }
 
 // TestJWTAuthentication tests authenticating with JWT tokens using HMAC signing.
@@ -487,7 +763,8 @@ func TestKeyCacheWithTaskStates(t *testing.T) {
 	g.Expect(err).To(BeNil())
 
 	// Create token for running task - should work
-	key, err := provider.TaskGrant(task.ID)
+	taskRef := &Task{ID: task.ID}
+	key, err := provider.TaskGrant(taskRef)
 	g.Expect(err).To(BeNil())
 
 	// Authenticate with key - should work
@@ -578,7 +855,8 @@ func TestNoAuthProvider(t *testing.T) {
 		db.Delete(task)
 	})
 
-	key, err = provider.TaskGrant(task.ID)
+	taskRef := &Task{ID: task.ID}
+	key, err = provider.TaskGrant(taskRef)
 	g.Expect(err).To(BeNil())
 	g.Expect(key.Secret).ToNot(BeEmpty())
 }
@@ -681,7 +959,8 @@ func TestTaskRevoke(t *testing.T) {
 	g.Expect(err).To(BeNil())
 
 	// Create task token
-	token, err := provider.TaskGrant(task.ID)
+	taskRef := &Task{ID: task.ID}
+	token, err := provider.TaskGrant(taskRef)
 	g.Expect(err).To(BeNil())
 
 	// Verify token works
@@ -729,7 +1008,8 @@ func TestTaskRevokeMultipleTokens(t *testing.T) {
 	g.Expect(err).To(BeNil())
 
 	// Create first token
-	token1, err := provider.TaskGrant(task.ID)
+	taskRef := &Task{ID: task.ID}
+	token1, err := provider.TaskGrant(taskRef)
 	g.Expect(err).To(BeNil())
 
 	// Manually create second token for same task (shouldn't normally happen)
@@ -876,7 +1156,8 @@ func TestCascadeDeleteTask(t *testing.T) {
 	g.Expect(err).To(BeNil())
 
 	// Create token for task
-	token, err := provider.TaskGrant(task.ID)
+	taskRef := &Task{ID: task.ID}
+	token, err := provider.TaskGrant(taskRef)
 	g.Expect(err).To(BeNil())
 
 	// Verify token exists
@@ -1773,7 +2054,8 @@ func TestTokenBindingEdgeCases(t *testing.T) {
 	err = cache.Refresh()
 	g.Expect(err).To(BeNil())
 
-	token, err := provider.TaskGrant(pendingTask.ID)
+	taskRef := &Task{ID: pendingTask.ID}
+	token, err := provider.TaskGrant(taskRef)
 	g.Expect(err).To(BeNil())
 
 	request := newTestRequest()
@@ -2896,7 +3178,7 @@ func setupTestDB() (db *gorm.DB, err error) {
 	err = db.AutoMigrate(
 		&IdpClient{},
 		&User{},
-		&Task{},
+		&model.Task{},
 		&model.Bucket{},
 		&Role{},
 		&Permission{},

--- a/internal/auth/pkg_test.go
+++ b/internal/auth/pkg_test.go
@@ -147,15 +147,15 @@ func TestTaskGrant(t *testing.T) {
 	g.Expect(err).To(BeNil())
 	g.Expect(jwToken).NotTo(BeNil())
 
-	// Verify token claims contain task subject
+	// Verify token claims contain task subject (hex format)
 	claims := jwToken.Claims.(jwt.MapClaims)
 	subject := claims[ClaimSub].(string)
 	expectedSubject := Task{ID: 445}.Subject()
 	g.Expect(subject).To(Equal(expectedSubject))
 
-	// Verify User() returns task subject
+	// Verify User() returns task login (decimal format)
 	user := provider.User(jwToken)
-	g.Expect(user).To(Equal(expectedSubject))
+	g.Expect(user).To(Equal(Task{ID: 445}.Login()))
 
 	// Verify scopes are AddonScopes
 	scopes := provider.Scopes(jwToken)
@@ -197,7 +197,7 @@ func TestTaskSubjectFormat(t *testing.T) {
 	provider, err := NewBuiltin(db)
 	g.Expect(err).To(BeNil())
 
-	// Test task.1
+	// Test task.1 - Subject() returns hex format, User() returns login (decimal)
 	token1, err := provider.TaskGrant(task1)
 	g.Expect(err).To(BeNil())
 	request := newTestRequest()
@@ -207,7 +207,7 @@ func TestTaskSubjectFormat(t *testing.T) {
 	claims := jwToken1.Claims.(jwt.MapClaims)
 	expectedSubject1 := Task{ID: 1}.Subject()
 	g.Expect(claims[ClaimSub]).To(Equal(expectedSubject1))
-	g.Expect(provider.User(jwToken1)).To(Equal(expectedSubject1))
+	g.Expect(provider.User(jwToken1)).To(Equal(Task{ID: 1}.Login()))
 
 	// Test task.999
 	token2, err := provider.TaskGrant(task2)
@@ -219,7 +219,7 @@ func TestTaskSubjectFormat(t *testing.T) {
 	claims = jwToken2.Claims.(jwt.MapClaims)
 	expectedSubject2 := Task{ID: 999}.Subject()
 	g.Expect(claims[ClaimSub]).To(Equal(expectedSubject2))
-	g.Expect(provider.User(jwToken2)).To(Equal(expectedSubject2))
+	g.Expect(provider.User(jwToken2)).To(Equal(Task{ID: 999}.Login()))
 
 	// Test task.12345
 	token3, err := provider.TaskGrant(task3)
@@ -231,7 +231,7 @@ func TestTaskSubjectFormat(t *testing.T) {
 	claims = jwToken3.Claims.(jwt.MapClaims)
 	expectedSubject3 := Task{ID: 12345}.Subject()
 	g.Expect(claims[ClaimSub]).To(Equal(expectedSubject3))
-	g.Expect(provider.User(jwToken3)).To(Equal(expectedSubject3))
+	g.Expect(provider.User(jwToken3)).To(Equal(Task{ID: 12345}.Login()))
 }
 
 // TestTaskSubjectParsing tests that task subjects are parsed on-demand.
@@ -261,7 +261,7 @@ func TestTaskSubjectParsing(t *testing.T) {
 	g.Expect(subject.IsTask()).To(BeTrue())
 	g.Expect(subject.Task).NotTo(BeNil())
 	g.Expect(subject.Task.ID).To(Equal(uint(100)))
-	g.Expect(subject.Login()).To(Equal(expectedSubject))
+	g.Expect(subject.Login()).To(Equal(task.Login()))
 
 	// Verify authentication works
 	request := newTestRequest()
@@ -392,7 +392,7 @@ func TestMultipleTasksWithTokens(t *testing.T) {
 		subject, err := provider.cache.FindSubject(expectedSubject)
 		g.Expect(err).To(BeNil())
 		g.Expect(subject.IsTask()).To(BeTrue())
-		g.Expect(subject.Login()).To(Equal(expectedSubject))
+		g.Expect(subject.Login()).To(Equal(task.Login()))
 
 		// Check authentication
 		request := newTestRequest()
@@ -401,7 +401,7 @@ func TestMultipleTasksWithTokens(t *testing.T) {
 		g.Expect(err).To(BeNil())
 		claims := jwToken.Claims.(jwt.MapClaims)
 		g.Expect(claims[ClaimSub]).To(Equal(expectedSubject))
-		g.Expect(provider.User(jwToken)).To(Equal(expectedSubject))
+		g.Expect(provider.User(jwToken)).To(Equal(task.Login()))
 	}
 
 	// Revoke one task - others still work

--- a/internal/auth/pkg_test.go
+++ b/internal/auth/pkg_test.go
@@ -234,8 +234,8 @@ func TestTaskSubjectFormat(t *testing.T) {
 	g.Expect(provider.User(jwToken3)).To(Equal(expectedSubject3))
 }
 
-// TestTaskGrantedCacheUpdate tests that TaskGranted updates the cache.
-func TestTaskGrantedCacheUpdate(t *testing.T) {
+// TestTaskSubjectParsing tests that task subjects are parsed on-demand.
+func TestTaskSubjectParsing(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	db, err := setupTestDB()
@@ -249,11 +249,11 @@ func TestTaskGrantedCacheUpdate(t *testing.T) {
 	err = db.Create(task).Error
 	g.Expect(err).To(BeNil())
 
-	// Grant token - should add task to cache
+	// Grant token
 	token, err := provider.TaskGrant(task)
 	g.Expect(err).To(BeNil())
 
-	// Verify task is in cache by finding its subject
+	// Verify task subject is parsed on-demand (not cached)
 	expectedSubject := task.Subject()
 	subject, err := provider.cache.FindSubject(expectedSubject)
 	g.Expect(err).To(BeNil())
@@ -309,8 +309,8 @@ func TestTaskSubjectScopes(t *testing.T) {
 	g.Expect(scopeStrings).To(ContainElement("identities:get"))
 }
 
-// TestTaskSubjectCacheLifecycle tests the full lifecycle of task subjects in cache.
-func TestTaskSubjectCacheLifecycle(t *testing.T) {
+// TestTaskTokenLifecycle tests the full lifecycle of task tokens.
+func TestTaskTokenLifecycle(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	db, err := setupTestDB()
@@ -324,34 +324,32 @@ func TestTaskSubjectCacheLifecycle(t *testing.T) {
 	err = db.Create(task).Error
 	g.Expect(err).To(BeNil())
 
-	// Task not in cache initially
+	// Task subject is always parseable (not cached)
 	expectedSubject := task.Subject()
-	_, err = provider.cache.FindSubject(expectedSubject)
-	g.Expect(err).NotTo(BeNil())
-
-	// Grant token - adds task to cache
-	token, err := provider.TaskGrant(task)
-	g.Expect(err).To(BeNil())
-
-	// Task now in cache
 	subject, err := provider.cache.FindSubject(expectedSubject)
 	g.Expect(err).To(BeNil())
 	g.Expect(subject.IsTask()).To(BeTrue())
+	g.Expect(subject.Task.ID).To(Equal(uint(300)))
 
-	// Authentication works
+	// Grant token
+	token, err := provider.TaskGrant(task)
+	g.Expect(err).To(BeNil())
+
+	// Authentication works with token
 	request := newTestRequest()
 	request.With("Bearer " + token.Secret)
 	_, err = provider.Authenticate(request)
 	g.Expect(err).To(BeNil())
 
-	// Revoke task - removes from cache
+	// Revoke task - removes tokens (but subject still parseable)
 	provider.TaskRevoke(300)
 
-	// Task removed from cache
-	_, err = provider.cache.FindSubject(expectedSubject)
-	g.Expect(err).NotTo(BeNil())
+	// Subject still parseable
+	subject, err = provider.cache.FindSubject(expectedSubject)
+	g.Expect(err).To(BeNil())
+	g.Expect(subject.IsTask()).To(BeTrue())
 
-	// Authentication fails
+	// Authentication fails (token removed)
 	request = newTestRequest()
 	request.With("Bearer " + token.Secret)
 	_, err = provider.Authenticate(request)
@@ -386,11 +384,11 @@ func TestMultipleTasksWithTokens(t *testing.T) {
 		g.Expect(err).To(BeNil())
 	}
 
-	// All tasks should be in cache and authenticate
+	// All task subjects are parseable and authenticate with tokens
 	for i, task := range tasks {
 		expectedSubject := task.Subject()
 
-		// Check cache
+		// Subject is always parseable (not cached)
 		subject, err := provider.cache.FindSubject(expectedSubject)
 		g.Expect(err).To(BeNil())
 		g.Expect(subject.IsTask()).To(BeTrue())
@@ -409,11 +407,13 @@ func TestMultipleTasksWithTokens(t *testing.T) {
 	// Revoke one task - others still work
 	provider.TaskRevoke(2)
 
-	// Task 2 should be gone
+	// Task 2 subject still parseable
 	task2Subject := Task{ID: 2}.Subject()
-	_, err = provider.cache.FindSubject(task2Subject)
-	g.Expect(err).NotTo(BeNil())
+	subject, err := provider.cache.FindSubject(task2Subject)
+	g.Expect(err).To(BeNil())
+	g.Expect(subject.IsTask()).To(BeTrue())
 
+	// Task 2 token authentication fails (token removed)
 	request := newTestRequest()
 	request.With("Bearer " + tokens[1].Secret)
 	_, err = provider.Authenticate(request)
@@ -2067,7 +2067,7 @@ func TestTokenBindingEdgeCases(t *testing.T) {
 	// Verify task subject format
 	claims := jwToken.Claims.(jwt.MapClaims)
 	subject := claims[ClaimSub].(string)
-	g.Expect(subject).To(ContainSubstring("task:"))
+	g.Expect(subject).To(Equal(taskRef.Subject()))
 }
 
 // TestCacheFindSubject tests finding subjects (users and identities) by subject string.

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -684,7 +684,10 @@ func (r *Task) propagateEnv(addon, extension *core.Container) {
 
 // secret builds the pod secret.
 func (r *Task) secret() (secret core.Secret, err error) {
-	token, err := auth.IdP.TaskGrant(r.ID)
+	owner := &auth.Task{
+		ID: r.ID,
+	}
+	token, err := auth.IdP.TaskGrant(owner)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Better task subject support.  More wholistic.  Ensures that when an api-key (PAT) generated for a task is presented by an addon (for auth in the REST api), the current _subject_ and _login_ properties in the request `Context` are complete.  The same as for user PAT or JWT.

Changes made by addons now associated with the task.  For example, an analysis created by an addon has: `CreateUser: task.44`.

Better support in the /auth/self endpoint:

```
$ TOKEN=417d245464ea295dc9b725feebe06fd5 hub /auth/self
login: task.3
subject: task.0x3
scopes:
    - addons:get
    - analysis.profiles:get
    - applications:get
    - applications:post
    - applications:put
    - applications.facts:*
    - applications.bucket:*
    - applications.analyses:*
    - applications.manifests:*
    - archetypes:get
    - generators:get
    - identities:get
    - identities:decrypt
    - manifests:*
    - platforms:get
    - proxies:get
    - schemas:get
    - settings:get
    - tags:*
    - tagcategories:*
    - tasks:get
    - tasks.report:*
    - tasks.bucket:get
    - files:*
    - rulesets:get
    - targets:get
task:
    id: 3
    createUser: admin
    createTime: 2026-06-17T12:36:32.217471282Z
    name: Test2.1.analyzer
    kind: analyzer
    addon: analyzer
    extensions:
        - java
    state: Running
    priority: 10
    data:
        mode:
            artifact: ""
            binary: false
            withDeps: true
        rules:
            labels:
                excluded: []
                included:
                    - konveyor.io/target=eap8
                    - konveyor.io/target=cloud-readiness
                    - konveyor.io/target=spring6
            path: ""
        scope:
            packages:
                excluded: []
                included: []
            withKnownLibs: false
        sources: []
        tagger:
            enabled: true
        targets: []
        verbosity: 0
    application:
        id: 1
        name: ""
    bucket:
        id: 5
        name: ""
    pod: konveyor-tackle/task-3-p9sk4
    started: 2026-06-17T12:36:33.050134507Z
    events:
        - kind: AddonSelected
          count: 1
          last: 2026-06-17T12:36:33.041467178Z
        - kind: ExtensionSelected
          count: 1
          reason: java
          last: 2026-06-17T12:36:33.042358447Z
        - kind: PodCreated
          count: 1
          reason: konveyor-tackle/task-3-p9sk4
          last: 2026-06-17T12:36:33.076259432Z
        - kind: PodPending
          count: 4
          reason: ContainerCreating
          last: 2026-06-17T12:36:35.122761791Z
        - kind: PodRunning
          count: 21
          last: 2026-06-17T12:36:56.618855625Z
    attached:
        - id: 501
          name: addon.log
        - id: 502
          name: java.log
200
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Added task details to the self-auth response when the session is authenticated as a task.

* **Refactor**
  * Improved task-based authentication handling, including how task subjects are generated, parsed, and used for login/scopes.

* **Bug Fixes**
  * Strengthened task token revocation behavior to reliably remove the correct tokens without breaking subject parsing consistency.

* **Tests**
  * Expanded coverage for task subject parsing, lifecycle, concurrency, and revocation edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->