### PR TITLE
:sparkles: Add scopes to PAT tokens returned by the API.

### DIFF
--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -521,7 +521,7 @@ func (h AuthHandler) UserCreate(ctx *gin.Context) {
 		return
 	}
 
-	auth.IdP.Cache().UserSaved((*auth.User)(m))
+	auth.IdP.Cache().UserSaved(m)
 
 	r.With(m)
 
@@ -596,7 +596,7 @@ func (h AuthHandler) UserUpdate(ctx *gin.Context) {
 		return
 	}
 
-	auth.IdP.Cache().UserSaved((*auth.User)(updated))
+	auth.IdP.Cache().UserSaved(updated)
 
 	h.Status(ctx, http.StatusNoContent)
 }

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -1022,6 +1022,12 @@ func (h AuthHandler) TokenGet(ctx *gin.Context) {
 
 	r := Token{}
 	r.With(m)
+	err = h.addScopes(&r)
+	if err != nil {
+		_ = ctx.Error(err)
+		return
+	}
+
 	h.Respond(ctx, http.StatusOK, r)
 }
 
@@ -1047,6 +1053,11 @@ func (h AuthHandler) TokenList(ctx *gin.Context) {
 	for i := range list {
 		r := Token{}
 		r.With(&list[i])
+		err = h.addScopes(&r)
+		if err != nil {
+			_ = ctx.Error(err)
+			return
+		}
 		resources = append(resources, r)
 	}
 
@@ -1196,6 +1207,19 @@ func (h AuthHandler) OIDC() func(*gin.Context) {
 			strippedHandler.ServeHTTP(ctx.Writer, ctx.Request)
 		}
 	}
+}
+
+// addScopes adds PAT scopes.
+func (h *AuthHandler) addScopes(m *Token) (err error) {
+	if m.Kind != auth.KindAPIKey {
+		return
+	}
+	token, err := auth.IdP.Cache().FindTokenById(m.ID)
+	if err != nil {
+		return
+	}
+	m.Scopes = token.Scopes
+	return
 }
 
 // Auth REST Resources.

--- a/internal/auth/builtin.go
+++ b/internal/auth/builtin.go
@@ -4,7 +4,6 @@ import (
 	"crypto/rsa"
 	"errors"
 	"net/http"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -551,19 +550,14 @@ func (p *Builtin) authUser(req *Request) (jwToken *jwt.Token, err error) {
 		}
 		return
 	}
-	scopes := make([]string, 0)
-	for _, ref := range user.Roles {
-		role, nErr := p.cache.FindRoleById(ref.ID)
-		if nErr != nil {
-			// not found.
-			continue
+	scopes, err := p.cache.FindUserScopes(user.ID)
+	if err != nil {
+		err = &NotAuthenticated{
+			Reason: "scopes not found",
+			Token:  login,
 		}
-		for _, scope := range role.GetScopes() {
-			scopes = append(scopes, scope)
-		}
+		return
 	}
-	scopes = uniqueStrings(scopes)
-	sort.Strings(scopes)
 	jwToken = jwt.New(jwt.SigningMethodRS256)
 	jwtClaims := jwToken.Claims.(jwt.MapClaims)
 	jwtClaims[ClaimId] = user.Login

--- a/internal/auth/cache/cache.go
+++ b/internal/auth/cache/cache.go
@@ -545,7 +545,7 @@ func (d *Data) getTokens(db *gorm.DB) (err error) {
 	return
 }
 
-// addTokenScopes determine token scopes and update the map.
+// addTokenScopes determine token scopes and update the data.
 func (d *Data) addTokenScopes(m *Token) {
 	if m.Kind != KindAPIKey {
 		return
@@ -603,7 +603,7 @@ func (d *Data) addTokenScopes(m *Token) {
 	return
 }
 
-// addUserScopes determine user scopes and add to the map.
+// addUserScopes determine user scopes and add to the data.
 func (d *Data) addUserScopes(m *User) {
 	scopes := []string{}
 	for _, r := range m.Roles {

--- a/internal/auth/cache/cache.go
+++ b/internal/auth/cache/cache.go
@@ -165,11 +165,27 @@ func (r *Cache) GrantDeleted(id uint) {
 	})
 }
 
+// FindTokenById returns a PAT.
+func (r *Cache) FindTokenById(id uint) (m *Token, err error) {
+	defer r.ensureRefreshed()
+	d := r.data.Load()
+	m, found := d.tokenById[id]
+	if !found {
+		err = &NotFound{
+			Resource: "token",
+			Id:       strconv.Itoa(int(id)),
+		}
+		return
+	}
+	m, err = r.addScopes(m)
+	return
+}
+
 // FindToken returns a PAT.
 func (r *Cache) FindToken(token string) (m *Token, err error) {
 	defer r.ensureRefreshed()
 	d := r.data.Load()
-	cached, found := d.tokenByDigest[secret.Hash(token)]
+	m, found := d.tokenByDigest[secret.Hash(token)]
 	if !found {
 		err = &NotFound{
 			Resource: "token",
@@ -177,56 +193,7 @@ func (r *Cache) FindToken(token string) (m *Token, err error) {
 		}
 		return
 	}
-	// Create a copy to avoid modifying cached instance
-	m = &Token{Token: cached.Token}
-	// user binding.
-	if m.UserID != nil {
-		user, found := d.userById[*m.UserID]
-		if !found {
-			err = &NotFound{
-				Resource: "user",
-				Id:       strconv.Itoa(int(*m.UserID)),
-			}
-			return
-		}
-		m.Subject = user.Subject
-		m.Scopes = user.GetScopes(r)
-		return
-	}
-	// task binding.
-	if m.TaskID != nil {
-		m.Subject = Task{ID: *m.TaskID}.Subject()
-		m.Scopes = AddonScopes
-		return
-	}
-	// IdP identity binding.
-	if m.IdpIdentityID != nil {
-		identity, found := d.identById[*m.IdpIdentityID]
-		if !found {
-			err = &NotFound{
-				Resource: "identity",
-				Id:       strconv.Itoa(int(*m.IdpIdentityID)),
-			}
-			return
-		}
-		m.Subject = identity.Subject
-		m.Scopes = strings.Fields(identity.Scopes)
-		return
-	}
-	// IdP client binding.
-	if m.IdpClientID != nil {
-		client, found := d.clientById[*m.IdpClientID]
-		if !found {
-			err = &NotFound{
-				Resource: "client",
-				Id:       strconv.Itoa(int(*m.IdpClientID)),
-			}
-			return
-		}
-		m.Subject = client.Subject
-		m.Scopes = client.GetScopes()
-		return
-	}
+	m, err = r.addScopes(m)
 	return
 }
 
@@ -365,6 +332,66 @@ func (r *Cache) ensureRefreshed() {
 			}
 		}()
 	})
+}
+
+// addScopes returns a new (copied) token with scopes added as needed.
+// Tokens already having scopes are not altered.
+func (r *Cache) addScopes(in *Token) (m *Token, err error) {
+	m = &Token{Token: in.Token}
+	if len(in.Scopes) > 0 {
+		m.Scopes = in.Scopes
+		return
+	}
+	d := r.data.Load()
+	// user binding.
+	if m.UserID != nil {
+		user, found := d.userById[*m.UserID]
+		if !found {
+			err = &NotFound{
+				Resource: "user",
+				Id:       strconv.Itoa(int(*m.UserID)),
+			}
+			return
+		}
+		m.Subject = user.Subject
+		m.Scopes = user.GetScopes(r)
+		return
+	}
+	// task binding.
+	if m.TaskID != nil {
+		m.Subject = Task{ID: *m.TaskID}.Subject()
+		m.Scopes = AddonScopes
+		return
+	}
+	// IdP identity binding.
+	if m.IdpIdentityID != nil {
+		identity, found := d.identById[*m.IdpIdentityID]
+		if !found {
+			err = &NotFound{
+				Resource: "identity",
+				Id:       strconv.Itoa(int(*m.IdpIdentityID)),
+			}
+			return
+		}
+		m.Subject = identity.Subject
+		m.Scopes = strings.Fields(identity.Scopes)
+		return
+	}
+	// IdP client binding.
+	if m.IdpClientID != nil {
+		client, found := d.clientById[*m.IdpClientID]
+		if !found {
+			err = &NotFound{
+				Resource: "client",
+				Id:       strconv.Itoa(int(*m.IdpClientID)),
+			}
+			return
+		}
+		m.Subject = client.Subject
+		m.Scopes = client.GetScopes()
+		return
+	}
+	return
 }
 
 // Data contains cached maps.

--- a/internal/auth/cache/cache.go
+++ b/internal/auth/cache/cache.go
@@ -545,7 +545,7 @@ func (d *Data) getTokens(db *gorm.DB) (err error) {
 	return
 }
 
-// addTokenScopes
+// addTokenScopes determine token scopes and update the map.
 func (d *Data) addTokenScopes(m *Token) {
 	if m.Kind != KindAPIKey {
 		return
@@ -603,7 +603,7 @@ func (d *Data) addTokenScopes(m *Token) {
 	return
 }
 
-// addUserScopes
+// addUserScopes determine user scopes and add to the map.
 func (d *Data) addUserScopes(m *User) {
 	scopes := []string{}
 	for _, r := range m.Roles {

--- a/internal/auth/cache/cache.go
+++ b/internal/auth/cache/cache.go
@@ -291,6 +291,19 @@ func (r *Cache) FindUserByLogin(login string) (m *User, err error) {
 	return
 }
 
+func (r *Cache) FindUserScopes(id uint) (scopes []string, err error) {
+	defer r.ensureRefreshed()
+	d := r.data.Load()
+	scopes, found := d.userScopes[id]
+	if !found {
+		err = &NotFound{
+			Resource: "user",
+			Id:       strconv.Itoa(int(id)),
+		}
+	}
+	return
+}
+
 // Begin returns a cache transaction.
 // The transaction holds a changelog of cache operations.
 // Changes are applied atomically on Commit().
@@ -344,6 +357,7 @@ type Data struct {
 	userById        map[uint]*User
 	userBySubject   map[string]*User
 	userByLogin     map[string]*User
+	userScopes      map[uint][]string
 	identById       map[uint]*Identity
 	identBySubject  map[string]*Identity
 	identByLogin    map[string]*Identity
@@ -361,6 +375,7 @@ func (d *Data) reset() {
 	d.userById = make(map[uint]*User)
 	d.userBySubject = make(map[string]*User)
 	d.userByLogin = make(map[string]*User)
+	d.userScopes = make(map[uint][]string)
 	d.identById = make(map[uint]*Identity)
 	d.identBySubject = make(map[string]*Identity)
 	d.identByLogin = make(map[string]*Identity)
@@ -383,6 +398,7 @@ func (d *Data) clone() *Data {
 		userById:        cloneMap(d.userById),
 		userBySubject:   cloneMap(d.userBySubject),
 		userByLogin:     cloneMap(d.userByLogin),
+		userScopes:      cloneMap(d.userScopes),
 		identById:       cloneMap(d.identById),
 		identBySubject:  cloneMap(d.identBySubject),
 		identByLogin:    cloneMap(d.identByLogin),
@@ -420,7 +436,11 @@ func (d *Data) refresh(db *gorm.DB) (err error) {
 	if err != nil {
 		return
 	}
+
+	d.updateScopes()
+
 	d.refreshed = time.Now()
+
 	return
 }
 
@@ -519,15 +539,14 @@ func (d *Data) getTokens(db *gorm.DB) (err error) {
 		return
 	}
 	for _, m := range list {
-		d.assignScopes(m)
 		d.tokenById[m.ID] = m
 		d.tokenByDigest[m.Digest] = m
 	}
 	return
 }
 
-// assignScopes determines scopes for PAT and assigns them.
-func (d *Data) assignScopes(m *Token) {
+// addTokenScopes
+func (d *Data) addTokenScopes(m *Token) {
 	if m.Kind != KindAPIKey {
 		return
 	}
@@ -537,37 +556,21 @@ func (d *Data) assignScopes(m *Token) {
 			Log.Info(err.Error())
 		}
 	}()
-	m.Scopes = []string{}
 	// user binding.
 	if m.UserID != nil {
-		user, found := d.userById[*m.UserID]
+		scopes, found := d.userScopes[*m.UserID]
 		if !found {
 			err = &NotFound{
-				Resource: "user",
+				Resource: "user.scopes",
 				Id:       strconv.Itoa(int(*m.UserID)),
 			}
 			return
 		}
-		m.Subject = user.Subject
-		for _, r := range user.Roles {
-			var role *Role
-			role, found = d.roleById[r.ID]
-			if !found {
-				continue
-			}
-			for _, scope := range role.GetScopes() {
-				m.Scopes = append(
-					m.Scopes,
-					scope)
-			}
-		}
-		m.Scopes = uniqueStrings(m.Scopes)
-		sort.Strings(m.Scopes)
+		m.Scopes = scopes
 		return
 	}
 	// task binding.
 	if m.TaskID != nil {
-		m.Subject = Task{ID: *m.TaskID}.Subject()
 		m.Scopes = AddonScopes
 		return
 	}
@@ -581,7 +584,6 @@ func (d *Data) assignScopes(m *Token) {
 			}
 			return
 		}
-		m.Subject = identity.Subject
 		m.Scopes = strings.Fields(identity.Scopes)
 		return
 	}
@@ -595,11 +597,42 @@ func (d *Data) assignScopes(m *Token) {
 			}
 			return
 		}
-		m.Subject = client.Subject
 		m.Scopes = client.GetScopes()
 		return
 	}
 	return
+}
+
+// addUserScopes
+func (d *Data) addUserScopes(m *User) {
+	scopes := []string{}
+	for _, r := range m.Roles {
+		r, found := d.roleById[r.ID]
+		if !found {
+			err := &NotFound{
+				Resource: "role",
+				Id:       strconv.Itoa(int(r.ID)),
+			}
+			Log.Info(err.Error())
+		}
+		for _, p := range r.Permissions {
+			scopes = append(scopes, p.Scope)
+		}
+	}
+	scopes = uniqueStrings(scopes)
+	sort.Strings(scopes)
+	d.userScopes[m.ID] = scopes
+}
+
+// updateScopes
+func (d *Data) updateScopes() {
+	d.userScopes = make(map[uint][]string)
+	for _, m := range d.userById {
+		d.addUserScopes(m)
+	}
+	for _, m := range d.tokenById {
+		d.addTokenScopes(m)
+	}
 }
 
 // cloneMap returns a shallow clone.

--- a/internal/auth/cache/cache.go
+++ b/internal/auth/cache/cache.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -177,7 +178,6 @@ func (r *Cache) FindTokenById(id uint) (m *Token, err error) {
 		}
 		return
 	}
-	m, err = r.addScopes(m)
 	return
 }
 
@@ -193,7 +193,6 @@ func (r *Cache) FindToken(token string) (m *Token, err error) {
 		}
 		return
 	}
-	m, err = r.addScopes(m)
 	return
 }
 
@@ -332,66 +331,6 @@ func (r *Cache) ensureRefreshed() {
 			}
 		}()
 	})
-}
-
-// addScopes returns a new (copied) token with scopes added as needed.
-// Tokens already having scopes are not altered.
-func (r *Cache) addScopes(in *Token) (m *Token, err error) {
-	m = &Token{Token: in.Token}
-	if len(in.Scopes) > 0 {
-		m.Scopes = in.Scopes
-		return
-	}
-	d := r.data.Load()
-	// user binding.
-	if m.UserID != nil {
-		user, found := d.userById[*m.UserID]
-		if !found {
-			err = &NotFound{
-				Resource: "user",
-				Id:       strconv.Itoa(int(*m.UserID)),
-			}
-			return
-		}
-		m.Subject = user.Subject
-		m.Scopes = user.GetScopes(r)
-		return
-	}
-	// task binding.
-	if m.TaskID != nil {
-		m.Subject = Task{ID: *m.TaskID}.Subject()
-		m.Scopes = AddonScopes
-		return
-	}
-	// IdP identity binding.
-	if m.IdpIdentityID != nil {
-		identity, found := d.identById[*m.IdpIdentityID]
-		if !found {
-			err = &NotFound{
-				Resource: "identity",
-				Id:       strconv.Itoa(int(*m.IdpIdentityID)),
-			}
-			return
-		}
-		m.Subject = identity.Subject
-		m.Scopes = strings.Fields(identity.Scopes)
-		return
-	}
-	// IdP client binding.
-	if m.IdpClientID != nil {
-		client, found := d.clientById[*m.IdpClientID]
-		if !found {
-			err = &NotFound{
-				Resource: "client",
-				Id:       strconv.Itoa(int(*m.IdpClientID)),
-			}
-			return
-		}
-		m.Subject = client.Subject
-		m.Scopes = client.GetScopes()
-		return
-	}
-	return
 }
 
 // Data contains cached maps.
@@ -580,8 +519,85 @@ func (d *Data) getTokens(db *gorm.DB) (err error) {
 		return
 	}
 	for _, m := range list {
+		d.assignScopes(m)
 		d.tokenById[m.ID] = m
 		d.tokenByDigest[m.Digest] = m
+	}
+	return
+}
+
+// assignScopes determines scopes for PAT and assigns them.
+func (d *Data) assignScopes(m *Token) {
+	if m.Kind != KindAPIKey {
+		return
+	}
+	var err error
+	defer func() {
+		if err != nil {
+			Log.Info(err.Error())
+		}
+	}()
+	m.Scopes = []string{}
+	// user binding.
+	if m.UserID != nil {
+		user, found := d.userById[*m.UserID]
+		if !found {
+			err = &NotFound{
+				Resource: "user",
+				Id:       strconv.Itoa(int(*m.UserID)),
+			}
+			return
+		}
+		m.Subject = user.Subject
+		for _, r := range user.Roles {
+			var role *Role
+			role, found = d.roleById[r.ID]
+			if !found {
+				continue
+			}
+			for _, scope := range role.GetScopes() {
+				m.Scopes = append(
+					m.Scopes,
+					scope)
+			}
+		}
+		m.Scopes = uniqueStrings(m.Scopes)
+		sort.Strings(m.Scopes)
+		return
+	}
+	// task binding.
+	if m.TaskID != nil {
+		m.Subject = Task{ID: *m.TaskID}.Subject()
+		m.Scopes = AddonScopes
+		return
+	}
+	// IdP identity binding.
+	if m.IdpIdentityID != nil {
+		identity, found := d.identById[*m.IdpIdentityID]
+		if !found {
+			err = &NotFound{
+				Resource: "identity",
+				Id:       strconv.Itoa(int(*m.IdpIdentityID)),
+			}
+			return
+		}
+		m.Subject = identity.Subject
+		m.Scopes = strings.Fields(identity.Scopes)
+		return
+	}
+	// IdP client binding.
+	if m.IdpClientID != nil {
+		client, found := d.clientById[*m.IdpClientID]
+		if !found {
+			err = &NotFound{
+				Resource: "client",
+				Id:       strconv.Itoa(int(*m.IdpClientID)),
+			}
+			return
+		}
+		m.Subject = client.Subject
+		m.Scopes = client.GetScopes()
+		return
 	}
 	return
 }

--- a/internal/auth/cache/cache.go
+++ b/internal/auth/cache/cache.go
@@ -615,6 +615,7 @@ func (d *Data) addUserScopes(m *User) {
 				Id:       strconv.Itoa(int(r.ID)),
 			}
 			Log.Info(err.Error())
+			continue
 		}
 		for _, p := range r.Permissions {
 			scopes = append(scopes, p.Scope)

--- a/internal/auth/cache/cache.go
+++ b/internal/auth/cache/cache.go
@@ -206,7 +206,12 @@ func (r *Cache) FindSubject(subject string) (s *Subject, err error) {
 	user, found := d.userBySubject[subject]
 	if found {
 		s = &Subject{}
-		s.WithUser(user, r)
+		var scopes []string
+		scopes, err = r.FindUserScopes(user.ID)
+		if err != nil {
+			return
+		}
+		s.WithUser(user, scopes)
 		return
 	}
 	identity, found := d.identBySubject[subject]
@@ -218,7 +223,7 @@ func (r *Cache) FindSubject(subject string) (s *Subject, err error) {
 	client, found := d.clientBySubject[subject]
 	if found {
 		s = &Subject{}
-		s.WithClient(client, r)
+		s.WithClient(client)
 		return
 	}
 	task := &Task{}

--- a/internal/auth/cache/cache.go
+++ b/internal/auth/cache/cache.go
@@ -291,6 +291,7 @@ func (r *Cache) FindUserByLogin(login string) (m *User, err error) {
 	return
 }
 
+// FindUserScopes returns the user scopes.
 func (r *Cache) FindUserScopes(id uint) (scopes []string, err error) {
 	defer r.ensureRefreshed()
 	d := r.data.Load()

--- a/internal/auth/cache/pkg.go
+++ b/internal/auth/cache/pkg.go
@@ -29,36 +29,10 @@ const (
 type Model = model.Model
 
 // User alias.
-type User model.User
-
-// GetScopes returns the user's scopes.
-func (m *User) GetScopes(cache *Cache) (scopes []string) {
-	for _, r := range m.Roles {
-		role, nErr := cache.FindRoleById(r.ID)
-		if nErr != nil {
-			continue
-		}
-		for _, scope := range role.GetScopes() {
-			scopes = append(scopes, scope)
-		}
-	}
-	scopes = uniqueStrings(scopes)
-	sort.Strings(scopes)
-	return
-}
+type User = model.User
 
 // Role alias.
-type Role model.Role
-
-// GetScopes returns the roles scopes.
-func (m *Role) GetScopes() (scopes []string) {
-	for _, p := range m.Permissions {
-		scopes = append(scopes, p.Scope)
-	}
-	scopes = uniqueStrings(scopes)
-	sort.Strings(scopes)
-	return
-}
+type Role = model.Role
 
 // Permission alias.
 type Permission = model.Permission

--- a/internal/auth/cache/pkg_test.go
+++ b/internal/auth/cache/pkg_test.go
@@ -844,24 +844,34 @@ func TestFindTokenById(t *testing.T) {
 	db, err := setupTestDB()
 	g.Expect(err).To(BeNil())
 
-	cache := New(db)
-	err = cache.Refresh()
+	// Create a task in DB first
+	task := &model.Task{
+		Model: Model{ID: 1000},
+	}
+	err = db.Create(task).Error
 	g.Expect(err).To(BeNil())
 
-	// Create a task token
+	// Create a task token in DB
 	taskID := uint(1000)
 	taskToken := &Token{
 		Token: model.Token{
 			Model:      Model{ID: 1000},
+			Kind:       KindAPIKey,
 			TaskID:     &taskID,
 			Digest:     secret.Hash("task-token-1000"),
 			Expiration: time.Now().Add(24 * time.Hour),
 		},
 		Secret: "task-token-1000",
 	}
-	cache.TokenSaved(taskToken)
+	err = db.Create(&taskToken.Token).Error
+	g.Expect(err).To(BeNil())
 
-	// Find token by ID
+	// Refresh cache to load token with scopes assigned
+	cache := New(db)
+	err = cache.Refresh()
+	g.Expect(err).To(BeNil())
+
+	// Find token by ID - should have scopes
 	foundToken, err := cache.FindTokenById(1000)
 	g.Expect(err).To(BeNil())
 	g.Expect(foundToken).NotTo(BeNil())
@@ -885,8 +895,23 @@ func TestFindTokenByIdWithUser(t *testing.T) {
 	db, err := setupTestDB()
 	g.Expect(err).To(BeNil())
 
-	cache := New(db)
-	err = cache.Refresh()
+	// Create permission
+	perm := &Permission{
+		Model: Model{ID: 1},
+		Scope: "applications:get",
+	}
+	err = db.Create(perm).Error
+	g.Expect(err).To(BeNil())
+
+	// Create role with permission
+	role := &Role{
+		Model: Model{ID: 1},
+		Name:  "Developer",
+	}
+	err = db.Create(role).Error
+	g.Expect(err).To(BeNil())
+
+	err = db.Model(role).Association("Permissions").Append(perm)
 	g.Expect(err).To(BeNil())
 
 	// Create user
@@ -895,27 +920,40 @@ func TestFindTokenByIdWithUser(t *testing.T) {
 		Subject: "user-subject",
 		Login:   "testuser",
 	}
-	cache.UserSaved(user)
+	err = db.Create(user).Error
+	g.Expect(err).To(BeNil())
 
-	// Create user token
+	// Associate user with role
+	err = db.Exec("INSERT INTO UserRole (UserID, RoleID) VALUES (?, ?)", user.ID, role.ID).Error
+	g.Expect(err).To(BeNil())
+
+	// Create user token in DB
 	userID := uint(2000)
 	userToken := &Token{
 		Token: model.Token{
 			Model:      Model{ID: 2001},
+			Kind:       KindAPIKey,
 			UserID:     &userID,
 			Digest:     secret.Hash("user-token-2001"),
 			Expiration: time.Now().Add(24 * time.Hour),
 		},
 		Secret: "user-token-2001",
 	}
-	cache.TokenSaved(userToken)
+	err = db.Create(&userToken.Token).Error
+	g.Expect(err).To(BeNil())
 
-	// Find token by ID - should have user subject populated
+	// Refresh cache to load token with scopes assigned
+	cache := New(db)
+	err = cache.Refresh()
+	g.Expect(err).To(BeNil())
+
+	// Find token by ID - should have user subject and scopes
 	foundToken, err := cache.FindTokenById(2001)
 	g.Expect(err).To(BeNil())
 	g.Expect(foundToken).NotTo(BeNil())
 	g.Expect(foundToken.Subject).To(Equal("user-subject"))
-	g.Expect(foundToken.Scopes).NotTo(BeNil())
+	g.Expect(foundToken.Scopes).NotTo(BeEmpty())
+	g.Expect(foundToken.Scopes).To(ContainElement("applications:get"))
 }
 
 // TestFindTokenWithScopes tests that FindToken returns tokens with scopes populated.
@@ -925,22 +963,32 @@ func TestFindTokenWithScopes(t *testing.T) {
 	db, err := setupTestDB()
 	g.Expect(err).To(BeNil())
 
-	cache := New(db)
-	err = cache.Refresh()
+	// Create a task in DB first
+	task := &model.Task{
+		Model: Model{ID: 3000},
+	}
+	err = db.Create(task).Error
 	g.Expect(err).To(BeNil())
 
-	// Create a task token
+	// Create a task token in DB
 	taskID := uint(3000)
 	taskToken := &Token{
 		Token: model.Token{
 			Model:      Model{ID: 3000},
+			Kind:       KindAPIKey,
 			TaskID:     &taskID,
 			Digest:     secret.Hash("task-token-3000"),
 			Expiration: time.Now().Add(24 * time.Hour),
 		},
 		Secret: "task-token-3000",
 	}
-	cache.TokenSaved(taskToken)
+	err = db.Create(&taskToken.Token).Error
+	g.Expect(err).To(BeNil())
+
+	// Refresh cache to load token with scopes assigned
+	cache := New(db)
+	err = cache.Refresh()
+	g.Expect(err).To(BeNil())
 
 	// Find token by secret - should have scopes
 	foundToken, err := cache.FindToken("task-token-3000")
@@ -958,11 +1006,7 @@ func TestFindTokenWithIdentity(t *testing.T) {
 	db, err := setupTestDB()
 	g.Expect(err).To(BeNil())
 
-	cache := New(db)
-	err = cache.Refresh()
-	g.Expect(err).To(BeNil())
-
-	// Create identity
+	// Create identity in DB
 	identity := &Identity{
 		Model:   Model{ID: 4000},
 		Issuer:  "https://idp.example.com",
@@ -970,20 +1014,28 @@ func TestFindTokenWithIdentity(t *testing.T) {
 		Login:   "identityuser",
 		Scopes:  "applications:get applications:post",
 	}
-	cache.IdentitySaved(identity)
+	err = db.Create(identity).Error
+	g.Expect(err).To(BeNil())
 
-	// Create identity token
+	// Create identity token in DB
 	identityID := uint(4000)
 	identityToken := &Token{
 		Token: model.Token{
 			Model:         Model{ID: 4001},
+			Kind:          KindAPIKey,
 			IdpIdentityID: &identityID,
 			Digest:        secret.Hash("identity-token-4001"),
 			Expiration:    time.Now().Add(24 * time.Hour),
 		},
 		Secret: "identity-token-4001",
 	}
-	cache.TokenSaved(identityToken)
+	err = db.Create(&identityToken.Token).Error
+	g.Expect(err).To(BeNil())
+
+	// Refresh cache to load token with scopes assigned
+	cache := New(db)
+	err = cache.Refresh()
+	g.Expect(err).To(BeNil())
 
 	// Find token - should have identity scopes
 	foundToken, err := cache.FindToken("identity-token-4001")
@@ -1001,31 +1053,35 @@ func TestFindTokenWithClient(t *testing.T) {
 	db, err := setupTestDB()
 	g.Expect(err).To(BeNil())
 
-	cache := New(db)
-	err = cache.Refresh()
-	g.Expect(err).To(BeNil())
-
-	// Create client
+	// Create client in DB
 	client := &IdpClient{
 		Model:    Model{ID: 5000},
 		Subject:  "client-subject-5000",
 		ClientId: "client-5000",
 		Scopes:   []string{"applications:get", "applications:post"},
 	}
-	cache.ClientSaved(client)
+	err = db.Create(client).Error
+	g.Expect(err).To(BeNil())
 
-	// Create client token
+	// Create client token in DB
 	clientID := uint(5000)
 	clientToken := &Token{
 		Token: model.Token{
 			Model:       Model{ID: 5001},
+			Kind:        KindAPIKey,
 			IdpClientID: &clientID,
 			Digest:      secret.Hash("client-token-5001"),
 			Expiration:  time.Now().Add(24 * time.Hour),
 		},
 		Secret: "client-token-5001",
 	}
-	cache.TokenSaved(clientToken)
+	err = db.Create(&clientToken.Token).Error
+	g.Expect(err).To(BeNil())
+
+	// Refresh cache to load token with scopes assigned
+	cache := New(db)
+	err = cache.Refresh()
+	g.Expect(err).To(BeNil())
 
 	// Find token - should have client scopes
 	foundToken, err := cache.FindToken("client-token-5001")

--- a/internal/auth/cache/pkg_test.go
+++ b/internal/auth/cache/pkg_test.go
@@ -947,11 +947,10 @@ func TestFindTokenByIdWithUser(t *testing.T) {
 	err = cache.Refresh()
 	g.Expect(err).To(BeNil())
 
-	// Find token by ID - should have user subject and scopes
+	// Find token by ID - should have scopes
 	foundToken, err := cache.FindTokenById(2001)
 	g.Expect(err).To(BeNil())
 	g.Expect(foundToken).NotTo(BeNil())
-	g.Expect(foundToken.Subject).To(Equal("user-subject"))
 	g.Expect(foundToken.Scopes).NotTo(BeEmpty())
 	g.Expect(foundToken.Scopes).To(ContainElement("applications:get"))
 }
@@ -996,7 +995,6 @@ func TestFindTokenWithScopes(t *testing.T) {
 	g.Expect(foundToken).NotTo(BeNil())
 	g.Expect(foundToken.Scopes).NotTo(BeEmpty())
 	g.Expect(foundToken.Scopes).To(ContainElement("addons:get"))
-	g.Expect(foundToken.Subject).To(Equal(Task{ID: taskID}.Subject()))
 }
 
 // TestFindTokenWithIdentity tests FindToken with IdP identity token.
@@ -1041,7 +1039,6 @@ func TestFindTokenWithIdentity(t *testing.T) {
 	foundToken, err := cache.FindToken("identity-token-4001")
 	g.Expect(err).To(BeNil())
 	g.Expect(foundToken).NotTo(BeNil())
-	g.Expect(foundToken.Subject).To(Equal("identity-subject-4000"))
 	g.Expect(foundToken.Scopes).To(ContainElement("applications:get"))
 	g.Expect(foundToken.Scopes).To(ContainElement("applications:post"))
 }
@@ -1087,7 +1084,6 @@ func TestFindTokenWithClient(t *testing.T) {
 	foundToken, err := cache.FindToken("client-token-5001")
 	g.Expect(err).To(BeNil())
 	g.Expect(foundToken).NotTo(BeNil())
-	g.Expect(foundToken.Subject).To(Equal("client-subject-5000"))
 	g.Expect(foundToken.Scopes).To(ContainElement("applications:get"))
 	g.Expect(foundToken.Scopes).To(ContainElement("applications:post"))
 }

--- a/internal/auth/cache/pkg_test.go
+++ b/internal/auth/cache/pkg_test.go
@@ -837,6 +837,205 @@ func TestCacheMixedSubjectTypes(t *testing.T) {
 	g.Expect(taskSubj.Login()).To(Equal(task.Login()))
 }
 
+// TestFindTokenById tests FindTokenById method.
+func TestFindTokenById(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	db, err := setupTestDB()
+	g.Expect(err).To(BeNil())
+
+	cache := New(db)
+	err = cache.Refresh()
+	g.Expect(err).To(BeNil())
+
+	// Create a task token
+	taskID := uint(1000)
+	taskToken := &Token{
+		Token: model.Token{
+			Model:      Model{ID: 1000},
+			TaskID:     &taskID,
+			Digest:     secret.Hash("task-token-1000"),
+			Expiration: time.Now().Add(24 * time.Hour),
+		},
+		Secret: "task-token-1000",
+	}
+	cache.TokenSaved(taskToken)
+
+	// Find token by ID
+	foundToken, err := cache.FindTokenById(1000)
+	g.Expect(err).To(BeNil())
+	g.Expect(foundToken).NotTo(BeNil())
+	g.Expect(foundToken.ID).To(Equal(uint(1000)))
+	g.Expect(*foundToken.TaskID).To(Equal(taskID))
+	g.Expect(foundToken.Scopes).NotTo(BeEmpty())
+	g.Expect(foundToken.Scopes).To(ContainElement("addons:get"))
+
+	// Try to find non-existent token
+	_, err = cache.FindTokenById(9999)
+	g.Expect(err).NotTo(BeNil())
+	var notFound *NotFound
+	g.Expect(errors.As(err, &notFound)).To(BeTrue())
+	g.Expect(notFound.Resource).To(Equal("token"))
+}
+
+// TestFindTokenByIdWithUser tests FindTokenById returns scopes for user tokens.
+func TestFindTokenByIdWithUser(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	db, err := setupTestDB()
+	g.Expect(err).To(BeNil())
+
+	cache := New(db)
+	err = cache.Refresh()
+	g.Expect(err).To(BeNil())
+
+	// Create user
+	user := &User{
+		Model:   Model{ID: 2000},
+		Subject: "user-subject",
+		Login:   "testuser",
+	}
+	cache.UserSaved(user)
+
+	// Create user token
+	userID := uint(2000)
+	userToken := &Token{
+		Token: model.Token{
+			Model:      Model{ID: 2001},
+			UserID:     &userID,
+			Digest:     secret.Hash("user-token-2001"),
+			Expiration: time.Now().Add(24 * time.Hour),
+		},
+		Secret: "user-token-2001",
+	}
+	cache.TokenSaved(userToken)
+
+	// Find token by ID - should have user subject populated
+	foundToken, err := cache.FindTokenById(2001)
+	g.Expect(err).To(BeNil())
+	g.Expect(foundToken).NotTo(BeNil())
+	g.Expect(foundToken.Subject).To(Equal("user-subject"))
+	g.Expect(foundToken.Scopes).NotTo(BeNil())
+}
+
+// TestFindTokenWithScopes tests that FindToken returns tokens with scopes populated.
+func TestFindTokenWithScopes(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	db, err := setupTestDB()
+	g.Expect(err).To(BeNil())
+
+	cache := New(db)
+	err = cache.Refresh()
+	g.Expect(err).To(BeNil())
+
+	// Create a task token
+	taskID := uint(3000)
+	taskToken := &Token{
+		Token: model.Token{
+			Model:      Model{ID: 3000},
+			TaskID:     &taskID,
+			Digest:     secret.Hash("task-token-3000"),
+			Expiration: time.Now().Add(24 * time.Hour),
+		},
+		Secret: "task-token-3000",
+	}
+	cache.TokenSaved(taskToken)
+
+	// Find token by secret - should have scopes
+	foundToken, err := cache.FindToken("task-token-3000")
+	g.Expect(err).To(BeNil())
+	g.Expect(foundToken).NotTo(BeNil())
+	g.Expect(foundToken.Scopes).NotTo(BeEmpty())
+	g.Expect(foundToken.Scopes).To(ContainElement("addons:get"))
+	g.Expect(foundToken.Subject).To(Equal(Task{ID: taskID}.Subject()))
+}
+
+// TestFindTokenWithIdentity tests FindToken with IdP identity token.
+func TestFindTokenWithIdentity(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	db, err := setupTestDB()
+	g.Expect(err).To(BeNil())
+
+	cache := New(db)
+	err = cache.Refresh()
+	g.Expect(err).To(BeNil())
+
+	// Create identity
+	identity := &Identity{
+		Model:   Model{ID: 4000},
+		Issuer:  "https://idp.example.com",
+		Subject: "identity-subject-4000",
+		Login:   "identityuser",
+		Scopes:  "applications:get applications:post",
+	}
+	cache.IdentitySaved(identity)
+
+	// Create identity token
+	identityID := uint(4000)
+	identityToken := &Token{
+		Token: model.Token{
+			Model:         Model{ID: 4001},
+			IdpIdentityID: &identityID,
+			Digest:        secret.Hash("identity-token-4001"),
+			Expiration:    time.Now().Add(24 * time.Hour),
+		},
+		Secret: "identity-token-4001",
+	}
+	cache.TokenSaved(identityToken)
+
+	// Find token - should have identity scopes
+	foundToken, err := cache.FindToken("identity-token-4001")
+	g.Expect(err).To(BeNil())
+	g.Expect(foundToken).NotTo(BeNil())
+	g.Expect(foundToken.Subject).To(Equal("identity-subject-4000"))
+	g.Expect(foundToken.Scopes).To(ContainElement("applications:get"))
+	g.Expect(foundToken.Scopes).To(ContainElement("applications:post"))
+}
+
+// TestFindTokenWithClient tests FindToken with IdP client token.
+func TestFindTokenWithClient(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	db, err := setupTestDB()
+	g.Expect(err).To(BeNil())
+
+	cache := New(db)
+	err = cache.Refresh()
+	g.Expect(err).To(BeNil())
+
+	// Create client
+	client := &IdpClient{
+		Model:    Model{ID: 5000},
+		Subject:  "client-subject-5000",
+		ClientId: "client-5000",
+		Scopes:   []string{"applications:get", "applications:post"},
+	}
+	cache.ClientSaved(client)
+
+	// Create client token
+	clientID := uint(5000)
+	clientToken := &Token{
+		Token: model.Token{
+			Model:       Model{ID: 5001},
+			IdpClientID: &clientID,
+			Digest:      secret.Hash("client-token-5001"),
+			Expiration:  time.Now().Add(24 * time.Hour),
+		},
+		Secret: "client-token-5001",
+	}
+	cache.TokenSaved(clientToken)
+
+	// Find token - should have client scopes
+	foundToken, err := cache.FindToken("client-token-5001")
+	g.Expect(err).To(BeNil())
+	g.Expect(foundToken).NotTo(BeNil())
+	g.Expect(foundToken.Subject).To(Equal("client-subject-5000"))
+	g.Expect(foundToken.Scopes).To(ContainElement("applications:get"))
+	g.Expect(foundToken.Scopes).To(ContainElement("applications:post"))
+}
+
 // TestCacheConcurrentMixedOperations tests mixed concurrent operations.
 func TestCacheConcurrentMixedOperations(t *testing.T) {
 	g := NewGomegaWithT(t)

--- a/internal/auth/cache/subject.go
+++ b/internal/auth/cache/subject.go
@@ -20,12 +20,12 @@ type Subject struct {
 }
 
 // WithUser populates Subject from a User model.
-func (r *Subject) WithUser(user *User, cache *Cache) {
+func (r *Subject) WithUser(user *User, scopes []string) {
 	r.UserId = &user.ID
 	r.Key = user.Subject
 	r.User = user
 	r.Email = user.Email
-	r.Scopes, _ = cache.FindUserScopes(user.ID)
+	r.Scopes = scopes
 }
 
 // WithIdentity populates Subject from an IdpIdentity model.
@@ -40,7 +40,7 @@ func (r *Subject) WithIdentity(idp *Identity) {
 }
 
 // WithClient populates Subject from an IdpClient model.
-func (r *Subject) WithClient(client *IdpClient, cache *Cache) {
+func (r *Subject) WithClient(client *IdpClient) {
 	r.ClientId = &client.ID
 	r.Client = client
 	r.Key = client.Subject

--- a/internal/auth/cache/subject.go
+++ b/internal/auth/cache/subject.go
@@ -1,7 +1,6 @@
 package cache
 
 import (
-	"sort"
 	"strings"
 )
 
@@ -26,15 +25,7 @@ func (r *Subject) WithUser(user *User, cache *Cache) {
 	r.Key = user.Subject
 	r.User = user
 	r.Email = user.Email
-	for _, ref := range user.Roles {
-		role, err := cache.FindRoleById(ref.ID)
-		if err != nil {
-			continue
-		}
-		r.Scopes = append(r.Scopes, role.GetScopes()...)
-	}
-	r.Scopes = uniqueStrings(r.Scopes)
-	sort.Strings(r.Scopes)
+	r.Scopes, _ = cache.FindUserScopes(user.ID)
 }
 
 // WithIdentity populates Subject from an IdpIdentity model.
@@ -43,7 +34,6 @@ func (r *Subject) WithIdentity(idp *Identity) {
 	r.Identity = idp
 	r.Key = idp.Subject
 	r.Email = idp.Email
-
 	if idp.Scopes != "" {
 		r.Scopes = strings.Fields(idp.Scopes)
 	}

--- a/internal/auth/cache/tx.go
+++ b/internal/auth/cache/tx.go
@@ -163,6 +163,13 @@ func (r *Tx) GrantDeleted(id uint) {
 		})
 }
 
+// changed notification that Data has changed.
+func (r *Tx) changed(d *Data) {
+	for _, m := range d.tokenById {
+		d.assignScopes(m)
+	}
+}
+
 // Commit applies all changelog operations atomically.
 func (r *Tx) Commit() {
 	r.cache.txMutex.Lock()
@@ -172,6 +179,7 @@ func (r *Tx) Commit() {
 	for _, fn := range r.changes {
 		fn(clone)
 	}
+	r.changed(clone)
 	r.cache.data.Store(clone)
 	r.changes = nil
 }

--- a/internal/auth/cache/tx.go
+++ b/internal/auth/cache/tx.go
@@ -165,9 +165,7 @@ func (r *Tx) GrantDeleted(id uint) {
 
 // changed notification that Data has changed.
 func (r *Tx) changed(d *Data) {
-	for _, m := range d.tokenById {
-		d.assignScopes(m)
-	}
+	d.updateScopes()
 }
 
 // Commit applies all changelog operations atomically.

--- a/internal/auth/domain.go
+++ b/internal/auth/domain.go
@@ -430,12 +430,11 @@ func (d *Domain) userPatch(existing map[string]User, wanted []seed.User) (patch 
 				roles: roles,
 			})
 		} else {
-			newUser := User{
-				Login:    user.Login,
-				Subject:  uuid.New().String(),
-				Password: user.Password,
-			}
+			newUser := User{}
 			newUser.ID = user.ID
+			newUser.Login = user.Login
+			newUser.Subject = uuid.New().String()
+			newUser.Password = user.Password
 			_, _ = secret.Encode(&newUser)
 			patch.toCreate = append(patch.toCreate, userWithRoles{
 				user:  newUser,

--- a/internal/auth/ldap.go
+++ b/internal/auth/ldap.go
@@ -65,7 +65,9 @@ func (h *LdapHandler) buildIdentity(ldapUser *LdapUser, password string, lifespa
 		if err != nil {
 			continue
 		}
-		scopes = append(scopes, role.GetScopes()...)
+		for _, p := range role.Permissions {
+			scopes = append(scopes, p.Scope)
+		}
 	}
 	scopes = uniqueStrings(scopes)
 	sort.Strings(scopes)

--- a/internal/auth/noauth.go
+++ b/internal/auth/noauth.go
@@ -27,6 +27,10 @@ func (r *NoAuth) Authenticate(request *Request) (jwToken *jwt.Token, err error) 
 func (r *NoAuth) NewToken(subject string, lifespan time.Duration) (token Token, err error) {
 	token = r.newToken(subject, lifespan)
 	err = r.Builtin.db.Create(&token).Error
+	if err != nil {
+		return
+	}
+	r.cache.TokenSaved(&token)
 	return
 }
 

--- a/internal/auth/pkg_test.go
+++ b/internal/auth/pkg_test.go
@@ -3390,7 +3390,8 @@ func TestCreateAccessToken_UpdatesExistingToken(t *testing.T) {
 	g.Expect(err).To(BeNil())
 
 	subject := &Subject{}
-	subject.WithUser(user, provider.cache)
+	scopes, _ := provider.cache.FindUserScopes(user.ID)
+	subject.WithUser(user, scopes)
 
 	grantId := provider.storage.genId()
 	grant := &Grant{
@@ -3476,7 +3477,8 @@ func TestCreateAccessToken_CascadeDeleteOnGrantDeletion(t *testing.T) {
 	g.Expect(err).To(BeNil())
 
 	subject := &Subject{}
-	subject.WithUser(user, provider.cache)
+	scopes, _ := provider.cache.FindUserScopes(user.ID)
+	subject.WithUser(user, scopes)
 
 	grantId := provider.storage.genId()
 	grant := &Grant{
@@ -3542,7 +3544,8 @@ func TestAuthRequest_CreatesGrantAndLinksToken(t *testing.T) {
 	g.Expect(err).To(BeNil())
 
 	subject := &Subject{}
-	subject.WithUser(user, provider.cache)
+	scopes, _ := provider.cache.FindUserScopes(user.ID)
+	subject.WithUser(user, scopes)
 
 	// Create AuthRequest
 	authReq := &AuthRequest{
@@ -3673,7 +3676,8 @@ func TestCreateAccessAndRefreshTokens_FullFlow(t *testing.T) {
 	g.Expect(err).To(BeNil())
 
 	subject := &Subject{}
-	subject.WithUser(user, provider.cache)
+	scopes, _ := provider.cache.FindUserScopes(user.ID)
+	subject.WithUser(user, scopes)
 
 	// Create AuthRequest
 	requestId := provider.storage.genId()

--- a/internal/auth/pkg_test.go
+++ b/internal/auth/pkg_test.go
@@ -3391,6 +3391,7 @@ func TestCreateAccessToken_UpdatesExistingToken(t *testing.T) {
 
 	subject := &Subject{}
 	scopes, _ := provider.cache.FindUserScopes(user.ID)
+	g.Expect(err).To(BeNil())
 	subject.WithUser(user, scopes)
 
 	grantId := provider.storage.genId()
@@ -3478,6 +3479,7 @@ func TestCreateAccessToken_CascadeDeleteOnGrantDeletion(t *testing.T) {
 
 	subject := &Subject{}
 	scopes, _ := provider.cache.FindUserScopes(user.ID)
+	g.Expect(err).To(BeNil())
 	subject.WithUser(user, scopes)
 
 	grantId := provider.storage.genId()
@@ -3545,6 +3547,7 @@ func TestAuthRequest_CreatesGrantAndLinksToken(t *testing.T) {
 
 	subject := &Subject{}
 	scopes, _ := provider.cache.FindUserScopes(user.ID)
+	g.Expect(err).To(BeNil())
 	subject.WithUser(user, scopes)
 
 	// Create AuthRequest
@@ -3677,6 +3680,7 @@ func TestCreateAccessAndRefreshTokens_FullFlow(t *testing.T) {
 
 	subject := &Subject{}
 	scopes, _ := provider.cache.FindUserScopes(user.ID)
+	g.Expect(err).To(BeNil())
 	subject.WithUser(user, scopes)
 
 	// Create AuthRequest

--- a/internal/auth/pkg_test.go
+++ b/internal/auth/pkg_test.go
@@ -3388,9 +3388,10 @@ func TestCreateAccessToken_UpdatesExistingToken(t *testing.T) {
 	user := &User{Login: "testuser"}
 	err = db.Create(user).Error
 	g.Expect(err).To(BeNil())
+	provider.cache.UserSaved(user)
 
 	subject := &Subject{}
-	scopes, _ := provider.cache.FindUserScopes(user.ID)
+	scopes, err := provider.cache.FindUserScopes(user.ID)
 	g.Expect(err).To(BeNil())
 	subject.WithUser(user, scopes)
 
@@ -3476,9 +3477,10 @@ func TestCreateAccessToken_CascadeDeleteOnGrantDeletion(t *testing.T) {
 	user := &User{Login: "testuser"}
 	err = db.Create(user).Error
 	g.Expect(err).To(BeNil())
+	provider.cache.UserSaved(user)
 
 	subject := &Subject{}
-	scopes, _ := provider.cache.FindUserScopes(user.ID)
+	scopes, err := provider.cache.FindUserScopes(user.ID)
 	g.Expect(err).To(BeNil())
 	subject.WithUser(user, scopes)
 
@@ -3544,9 +3546,10 @@ func TestAuthRequest_CreatesGrantAndLinksToken(t *testing.T) {
 	user := &User{Login: "testuser"}
 	err = db.Create(user).Error
 	g.Expect(err).To(BeNil())
+	provider.cache.UserSaved(user)
 
 	subject := &Subject{}
-	scopes, _ := provider.cache.FindUserScopes(user.ID)
+	scopes, err := provider.cache.FindUserScopes(user.ID)
 	g.Expect(err).To(BeNil())
 	subject.WithUser(user, scopes)
 
@@ -3677,9 +3680,10 @@ func TestCreateAccessAndRefreshTokens_FullFlow(t *testing.T) {
 	user := &User{Login: "testuser"}
 	err = db.Create(user).Error
 	g.Expect(err).To(BeNil())
+	provider.cache.UserSaved(user)
 
 	subject := &Subject{}
-	scopes, _ := provider.cache.FindUserScopes(user.ID)
+	scopes, err := provider.cache.FindUserScopes(user.ID)
 	g.Expect(err).To(BeNil())
 	subject.WithUser(user, scopes)
 

--- a/internal/auth/storage.go
+++ b/internal/auth/storage.go
@@ -839,16 +839,16 @@ func (r *Login) authUser() (err error) {
 	cache := r.storage.cache
 	user, err := cache.FindUserByLogin(r.login)
 	if err == nil {
-		var scopes []string
-		scopes, err = cache.FindUserScopes(user.ID)
-		if err == nil {
-			return
-		}
 		if !secret.MatchPassword(r.password, user.Password) {
 			err = &NotAuthenticated{
 				Reason: "invalid password",
 				Token:  r.login,
 			}
+			return
+		}
+		var scopes []string
+		scopes, err = cache.FindUserScopes(user.ID)
+		if err != nil {
 			return
 		}
 		subject := &Subject{}

--- a/internal/auth/storage.go
+++ b/internal/auth/storage.go
@@ -836,10 +836,14 @@ func (r *Login) authenticate() (err error) {
 
 // authUser authenticates a user.
 func (r *Login) authUser() (err error) {
-	user, err := r.storage.cache.FindUserByLogin(r.login)
+	cache := r.storage.cache
+	user, err := cache.FindUserByLogin(r.login)
 	if err == nil {
-		subject := &Subject{}
-		subject.WithUser(user, r.storage.cache)
+		var scopes []string
+		scopes, err = cache.FindUserScopes(user.ID)
+		if err == nil {
+			return
+		}
 		if !secret.MatchPassword(r.password, user.Password) {
 			err = &NotAuthenticated{
 				Reason: "invalid password",
@@ -847,6 +851,8 @@ func (r *Login) authUser() (err error) {
 			}
 			return
 		}
+		subject := &Subject{}
+		subject.WithUser(user, scopes)
 		r.subject = subject
 		return
 	}


### PR DESCRIPTION
To support better presentation of PAT/api-key tokens, the hub will add/inject scopes when returned.

related: https://github.com/konveyor/tackle2-ui/issues/3359

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * API key token retrieval now returns correctly populated scopes using cached, precomputed scope data.
  * JWT scope generation is now consistent across standard and LDAP-backed identities, derived from saved role/permission scopes.
  * Token creation without authentication no longer updates cache state if token persistence fails.
* **Tests**
  * Added and expanded tests for token lookup (by ID/secret) and scope population, including refresh, user, IdP identity, and IdP client scenarios.
* **Refactor**
  * Cache and subject scope handling now rely on precomputed per-user scopes and update derived scope state on commits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->