### PR TITLE
:sparkles: Add auth CR controllers.

### DIFF
--- a/internal/api/resource/pkg_test.go
+++ b/internal/api/resource/pkg_test.go
@@ -3657,11 +3657,11 @@ func TestPermission_Model(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 
 	r := &Permission{
-		Resource:  Resource{ID: 1},
-		Name:      "read",
-		Noun: "applications",
-		Verb:      "GET",
-		Scope:     "applications:read",
+		Resource: Resource{ID: 1},
+		Name:     "read",
+		Noun:     "applications",
+		Verb:     "GET",
+		Scope:    "applications:read",
 	}
 
 	m := r.Model()

--- a/internal/controller/addon/pkg.go
+++ b/internal/controller/addon/pkg.go
@@ -92,15 +92,14 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 	if found && addon.Reconciled() {
 		return
 	}
-	r.history[addon.Name] = 1
-	addon.Status.Conditions = nil
-	addon.Status.ObservedGeneration = addon.Generation
 	// Changed
 	migrated, err := r.addonChanged(addon)
 	if migrated || err != nil {
 		return
 	}
 	// Ready condition.
+	addon.Status.Conditions = nil
+	addon.Status.ObservedGeneration = addon.Generation
 	addon.Status.Conditions = append(
 		addon.Status.Conditions,
 		r.ready(addon))
@@ -109,6 +108,8 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 	if err != nil {
 		return
 	}
+
+	r.history[addon.Name] = 1
 
 	return
 }

--- a/internal/controller/addon/pkg.go
+++ b/internal/controller/addon/pkg.go
@@ -31,10 +31,10 @@ var Log = logr2.WithName(Name)
 // Add the controller.
 func Add(mgr manager.Manager, db *gorm.DB) (err error) {
 	reconciler := &Reconciler{
-		history: make(map[string]byte),
-		Client:  mgr.GetClient(),
-		Log:     Log,
-		DB:      db,
+		seen:   make(map[string]bool),
+		Client: mgr.GetClient(),
+		Log:    Log,
+		DB:     db,
 	}
 	cnt, err := controller.New(
 		Name,
@@ -58,14 +58,14 @@ func Add(mgr manager.Manager, db *gorm.DB) (err error) {
 }
 
 // Reconciler reconciles addon CRs.
-// The history is used to ensure resources are reconciled
-// at least once at startup.
+// The seen (map) is used to ensure resources are
+// reconciled at least once at startup.
 type Reconciler struct {
 	record.EventRecorder
 	k8s.Client
-	DB      *gorm.DB
-	Log     logr.Logger
-	history map[string]byte
+	DB   *gorm.DB
+	Log  logr.Logger
+	seen map[string]bool
 }
 
 // Reconcile a Addon CR.
@@ -88,7 +88,7 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 		}
 		return
 	}
-	_, found := r.history[addon.Name]
+	_, found := r.seen[addon.Name]
 	if found && addon.Reconciled() {
 		return
 	}
@@ -98,18 +98,19 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 		return
 	}
 	// Ready condition.
+	ready := r.ready(addon)
 	addon.Status.Conditions = nil
 	addon.Status.ObservedGeneration = addon.Generation
 	addon.Status.Conditions = append(
 		addon.Status.Conditions,
-		r.ready(addon))
+		ready)
 	// Apply changes.
 	err = r.Status().Update(context.TODO(), addon)
 	if err != nil {
 		return
 	}
 
-	r.history[addon.Name] = 1
+	r.seen[addon.Name] = true
 
 	return
 }

--- a/internal/controller/addon/pkg.go
+++ b/internal/controller/addon/pkg.go
@@ -1,0 +1,162 @@
+package addon
+
+import (
+	"context"
+	"strings"
+
+	"github.com/go-logr/logr"
+	logr2 "github.com/jortel/go-utils/logr"
+	crd "github.com/konveyor/tackle2-hub/internal/k8s/api/tackle/v1alpha1"
+	"gorm.io/gorm"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/storage/names"
+	"k8s.io/client-go/tools/record"
+	k8s "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	Name = "addon"
+)
+
+type Addon = crd.Addon
+
+var Log = logr2.WithName(Name)
+
+// Add the controller.
+func Add(mgr manager.Manager, db *gorm.DB) (err error) {
+	reconciler := &Reconciler{
+		history: make(map[string]byte),
+		Client:  mgr.GetClient(),
+		Log:     Log,
+		DB:      db,
+	}
+	cnt, err := controller.New(
+		Name,
+		mgr,
+		controller.Options{
+			Reconciler: reconciler,
+		})
+	if err != nil {
+		Log.Error(err, "")
+		return
+	}
+	err = cnt.Watch(
+		&source.Kind{Type: &Addon{}},
+		&handler.EnqueueRequestForObject{})
+	if err != nil {
+		Log.Error(err, "")
+		return
+	}
+
+	return
+}
+
+// Reconciler reconciles addon CRs.
+// The history is used to ensure resources are reconciled
+// at least once at startup.
+type Reconciler struct {
+	record.EventRecorder
+	k8s.Client
+	DB      *gorm.DB
+	Log     logr.Logger
+	history map[string]byte
+}
+
+// Reconcile a Addon CR.
+// Note: Must not be a pointer receiver to ensure that the
+// logger and other state is not shared.
+func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (result reconcile.Result, err error) {
+	r.Log = logr2.WithName(
+		names.SimpleNameGenerator.GenerateName(Name+"|"),
+		"addon",
+		request)
+
+	// Fetch the CR.
+	addon := &Addon{}
+	err = r.Get(context.TODO(), request.NamespacedName, addon)
+	if err != nil {
+		if k8serr.IsNotFound(err) {
+			r.Log.Info("Addon deleted.", "name", request)
+			_ = r.addonDeleted(request.Name)
+			err = nil
+		}
+		return
+	}
+	_, found := r.history[addon.Name]
+	if found && addon.Reconciled() {
+		return
+	}
+	r.history[addon.Name] = 1
+	addon.Status.Conditions = nil
+	addon.Status.ObservedGeneration = addon.Generation
+	// Changed
+	migrated, err := r.addonChanged(addon)
+	if migrated || err != nil {
+		return
+	}
+	// Ready condition.
+	addon.Status.Conditions = append(
+		addon.Status.Conditions,
+		r.ready(addon))
+	// Apply changes.
+	err = r.Status().Update(context.TODO(), addon)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// ready returns the ready condition.
+func (r *Reconciler) ready(addon *Addon) (ready v1.Condition) {
+	ready = crd.Ready
+	ready.LastTransitionTime = v1.Now()
+	ready.ObservedGeneration = addon.Status.ObservedGeneration
+	err := make([]string, 0)
+	for i := range addon.Status.Conditions {
+		cnd := &addon.Status.Conditions[i]
+		if cnd.Type == crd.ValidationError {
+			err = append(err, cnd.Message)
+		}
+	}
+	if len(err) == 0 {
+		ready.Status = v1.ConditionTrue
+		ready.Reason = crd.Validated
+		ready.Message = strings.Join(err, ";")
+	} else {
+		ready.Status = v1.ConditionFalse
+		ready.Reason = crd.ValidationError
+	}
+	return
+}
+
+// addonChanged an addon has been created/updated.
+func (r *Reconciler) addonChanged(addon *Addon) (migrated bool, err error) {
+	migrated = addon.Migrate()
+	if migrated {
+		err = r.Update(context.TODO(), addon)
+		if err != nil {
+			return
+		}
+	}
+	if addon.Spec.Container.Image == "" {
+		cnd := crd.ImageNotDefined
+		cnd.LastTransitionTime = v1.Now()
+		cnd.ObservedGeneration = addon.Status.ObservedGeneration
+		addon.Status.Conditions = append(
+			addon.Status.Conditions,
+			cnd)
+	}
+	return
+}
+
+// addonDeleted an addon has been deleted.
+func (r *Reconciler) addonDeleted(name string) (err error) {
+	return
+}

--- a/internal/controller/client/pkg.go
+++ b/internal/controller/client/pkg.go
@@ -32,10 +32,10 @@ type IdpClient = crd.IdpClient
 // Add the controller.
 func Add(mgr manager.Manager, db *gorm.DB) (err error) {
 	reconciler := &Reconciler{
-		history: make(map[string]byte),
-		Client:  mgr.GetClient(),
-		Log:     Log,
-		DB:      db,
+		seen:   make(map[string]bool),
+		Client: mgr.GetClient(),
+		Log:    Log,
+		DB:     db,
 	}
 	cnt, err := controller.New(
 		Name,
@@ -59,14 +59,14 @@ func Add(mgr manager.Manager, db *gorm.DB) (err error) {
 }
 
 // Reconciler reconciles idpClient CRs.
-// The history is used to ensure resources are reconciled
+// The seen (map) is used to ensure resources are reconciled
 // at least once at startup.
 type Reconciler struct {
 	record.EventRecorder
 	k8s.Client
-	DB      *gorm.DB
-	Log     logr.Logger
-	history map[string]byte
+	DB   *gorm.DB
+	Log  logr.Logger
+	seen map[string]bool
 }
 
 // Reconcile a Addon CR.
@@ -88,7 +88,7 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 		}
 		return
 	}
-	_, found := r.history[idpClient.Name]
+	_, found := r.seen[idpClient.Name]
 	if found && idpClient.Reconciled() {
 		return
 	}
@@ -98,18 +98,19 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 		return
 	}
 	// Ready condition.
+	ready := r.ready(idpClient)
 	idpClient.Status.Conditions = nil
 	idpClient.Status.ObservedGeneration = idpClient.Generation
 	idpClient.Status.Conditions = append(
 		idpClient.Status.Conditions,
-		r.ready(idpClient))
+		ready)
 	// Apply changes.
 	err = r.Status().Update(context.TODO(), idpClient)
 	if err != nil {
 		return
 	}
 
-	r.history[idpClient.Name] = 1
+	r.seen[idpClient.Name] = true
 
 	return
 }
@@ -140,7 +141,7 @@ func (r *Reconciler) ready(idpClient *IdpClient) (ready v1.Condition) {
 // changed an idpClient has been created/updated.
 // When detected, the hub is restarted.
 func (r *Reconciler) changed(p *IdpClient) (err error) {
-	if r.history[p.Name] == 0 {
+	if !r.seen[p.Name] {
 		return
 	}
 	Log.Info(
@@ -165,5 +166,7 @@ func (r *Reconciler) deleted(name string) (err error) {
 // hubRestart restarts the hub.
 func (r *Reconciler) hubRestart() {
 	Log.Info("**** RESTARTING HUB *****")
-	_ = syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
+	_ = syscall.Kill(
+		syscall.Getpid(),
+		syscall.SIGTERM)
 }

--- a/internal/controller/client/pkg.go
+++ b/internal/controller/client/pkg.go
@@ -97,10 +97,9 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 	if err != nil {
 		return
 	}
-	r.history[idpClient.Name] = 1
+	// Ready condition.
 	idpClient.Status.Conditions = nil
 	idpClient.Status.ObservedGeneration = idpClient.Generation
-	// Ready condition.
 	idpClient.Status.Conditions = append(
 		idpClient.Status.Conditions,
 		r.ready(idpClient))
@@ -109,6 +108,8 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 	if err != nil {
 		return
 	}
+
+	r.history[idpClient.Name] = 1
 
 	return
 }

--- a/internal/controller/client/pkg.go
+++ b/internal/controller/client/pkg.go
@@ -1,13 +1,13 @@
-package controller
+package client
 
 import (
 	"context"
 	"strings"
+	"syscall"
 
 	"github.com/go-logr/logr"
 	logr2 "github.com/jortel/go-utils/logr"
 	crd "github.com/konveyor/tackle2-hub/internal/k8s/api/tackle/v1alpha1"
-	"github.com/konveyor/tackle2-hub/shared/settings"
 	"gorm.io/gorm"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,21 +22,19 @@ import (
 )
 
 const (
-	Name = "addon"
+	Name = "idpClient"
 )
 
-// Package logger.
-var log = logr2.WithName(Name)
+var Log = logr2.WithName(Name)
 
-// Settings defines applcation settings.
-var Settings = &settings.Settings
+type IdpClient = crd.IdpClient
 
 // Add the controller.
-func Add(mgr manager.Manager, db *gorm.DB) error {
+func Add(mgr manager.Manager, db *gorm.DB) (err error) {
 	reconciler := &Reconciler{
 		history: make(map[string]byte),
 		Client:  mgr.GetClient(),
-		Log:     log,
+		Log:     Log,
 		DB:      db,
 	}
 	cnt, err := controller.New(
@@ -46,22 +44,21 @@ func Add(mgr manager.Manager, db *gorm.DB) error {
 			Reconciler: reconciler,
 		})
 	if err != nil {
-		log.Error(err, "")
-		return err
+		Log.Error(err, "")
+		return
 	}
-	// Primary CR.
 	err = cnt.Watch(
-		&source.Kind{Type: &crd.Addon{}},
+		&source.Kind{Type: &IdpClient{}},
 		&handler.EnqueueRequestForObject{})
 	if err != nil {
-		log.Error(err, "")
-		return err
+		Log.Error(err, "")
+		return
 	}
 
-	return nil
+	return
 }
 
-// Reconciler reconciles addon CRs.
+// Reconciler reconciles idpClient CRs.
 // The history is used to ensure resources are reconciled
 // at least once at startup.
 type Reconciler struct {
@@ -78,38 +75,37 @@ type Reconciler struct {
 func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (result reconcile.Result, err error) {
 	r.Log = logr2.WithName(
 		names.SimpleNameGenerator.GenerateName(Name+"|"),
-		"addon",
+		"idpClient",
 		request)
 
 	// Fetch the CR.
-	addon := &crd.Addon{}
-	err = r.Get(context.TODO(), request.NamespacedName, addon)
+	idpClient := &IdpClient{}
+	err = r.Get(context.TODO(), request.NamespacedName, idpClient)
 	if err != nil {
 		if k8serr.IsNotFound(err) {
-			r.Log.Info("Addon deleted.", "name", request)
-			_ = r.addonDeleted(request.Name)
+			_ = r.deleted(request.Name)
 			err = nil
 		}
 		return
 	}
-	_, found := r.history[addon.Name]
-	if found && addon.Reconciled() {
+	_, found := r.history[idpClient.Name]
+	if found && idpClient.Reconciled() {
 		return
 	}
-	r.history[addon.Name] = 1
-	addon.Status.Conditions = nil
-	addon.Status.ObservedGeneration = addon.Generation
 	// Changed
-	migrated, err := r.addonChanged(addon)
-	if migrated || err != nil {
+	err = r.changed(idpClient)
+	if err != nil {
 		return
 	}
+	r.history[idpClient.Name] = 1
+	idpClient.Status.Conditions = nil
+	idpClient.Status.ObservedGeneration = idpClient.Generation
 	// Ready condition.
-	addon.Status.Conditions = append(
-		addon.Status.Conditions,
-		r.ready(addon))
+	idpClient.Status.Conditions = append(
+		idpClient.Status.Conditions,
+		r.ready(idpClient))
 	// Apply changes.
-	err = r.Status().Update(context.TODO(), addon)
+	err = r.Status().Update(context.TODO(), idpClient)
 	if err != nil {
 		return
 	}
@@ -118,13 +114,13 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 }
 
 // ready returns the ready condition.
-func (r *Reconciler) ready(addon *crd.Addon) (ready v1.Condition) {
+func (r *Reconciler) ready(idpClient *IdpClient) (ready v1.Condition) {
 	ready = crd.Ready
 	ready.LastTransitionTime = v1.Now()
-	ready.ObservedGeneration = addon.Status.ObservedGeneration
+	ready.ObservedGeneration = idpClient.Status.ObservedGeneration
 	err := make([]string, 0)
-	for i := range addon.Status.Conditions {
-		cnd := &addon.Status.Conditions[i]
+	for i := range idpClient.Status.Conditions {
+		cnd := &idpClient.Status.Conditions[i]
 		if cnd.Type == crd.ValidationError {
 			err = append(err, cnd.Message)
 		}
@@ -140,27 +136,33 @@ func (r *Reconciler) ready(addon *crd.Addon) (ready v1.Condition) {
 	return
 }
 
-// addonChanged an addon has been created/updated.
-func (r *Reconciler) addonChanged(addon *crd.Addon) (migrated bool, err error) {
-	migrated = addon.Migrate()
-	if migrated {
-		err = r.Update(context.TODO(), addon)
-		if err != nil {
-			return
-		}
+// changed an idpClient has been created/updated.
+// When detected, the hub is restarted.
+func (r *Reconciler) changed(p *IdpClient) (err error) {
+	if r.history[p.Name] == 0 {
+		return
 	}
-	if addon.Spec.Container.Image == "" {
-		cnd := crd.ImageNotDefined
-		cnd.LastTransitionTime = v1.Now()
-		cnd.ObservedGeneration = addon.Status.ObservedGeneration
-		addon.Status.Conditions = append(
-			addon.Status.Conditions,
-			cnd)
-	}
+	Log.Info(
+		"IdP client added/changed.",
+		"name",
+		p.Name)
+	r.hubRestart()
 	return
 }
 
-// addonDeleted an addon has been deleted.
-func (r *Reconciler) addonDeleted(name string) (err error) {
+// deleted an idpClient has been deleted.
+// When detected, the hub is restarted.
+func (r *Reconciler) deleted(name string) (err error) {
+	Log.Info(
+		"IdP client deleted.",
+		"name",
+		name)
+	r.hubRestart()
 	return
+}
+
+// hubRestart restarts the hub.
+func (r *Reconciler) hubRestart() {
+	Log.Info("**** RESTARTING HUB *****")
+	_ = syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
 }

--- a/internal/controller/idp/pkg.go
+++ b/internal/controller/idp/pkg.go
@@ -32,10 +32,10 @@ type IdentityProvider = crd.IdentityProvider
 // Add the controller.
 func Add(mgr manager.Manager, db *gorm.DB) (err error) {
 	reconciler := &Reconciler{
-		history: make(map[string]byte),
-		Client:  mgr.GetClient(),
-		Log:     Log,
-		DB:      db,
+		seen:   make(map[string]bool),
+		Client: mgr.GetClient(),
+		Log:    Log,
+		DB:     db,
 	}
 	cnt, err := controller.New(
 		Name,
@@ -59,14 +59,14 @@ func Add(mgr manager.Manager, db *gorm.DB) (err error) {
 }
 
 // Reconciler reconciles idp CRs.
-// The history is used to ensure resources are reconciled
-// at least once at startup.
+// The seen (map) is used to ensure resources are
+// reconciled at least once at startup.
 type Reconciler struct {
 	record.EventRecorder
 	k8s.Client
-	DB      *gorm.DB
-	Log     logr.Logger
-	history map[string]byte
+	DB   *gorm.DB
+	Log  logr.Logger
+	seen map[string]bool
 }
 
 // Reconcile a Addon CR.
@@ -88,7 +88,7 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 		}
 		return
 	}
-	_, found := r.history[idp.Name]
+	_, found := r.seen[idp.Name]
 	if found && idp.Reconciled() {
 		return
 	}
@@ -98,18 +98,19 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 		return
 	}
 	// Ready condition.
+	ready := r.ready(idp)
 	idp.Status.Conditions = nil
 	idp.Status.ObservedGeneration = idp.Generation
 	idp.Status.Conditions = append(
 		idp.Status.Conditions,
-		r.ready(idp))
+		ready)
 	// Apply changes.
 	err = r.Status().Update(context.TODO(), idp)
 	if err != nil {
 		return
 	}
 
-	r.history[idp.Name] = 1
+	r.seen[idp.Name] = true
 
 	return
 }
@@ -140,7 +141,7 @@ func (r *Reconciler) ready(idp *IdentityProvider) (ready v1.Condition) {
 // changed an idp has been created/updated.
 // When detected, the hub is restarted.
 func (r *Reconciler) changed(p *IdentityProvider) (err error) {
-	if r.history[p.Name] == 0 {
+	if !r.seen[p.Name] {
 		return
 	}
 	Log.Info(
@@ -165,5 +166,7 @@ func (r *Reconciler) deleted(name string) (err error) {
 // hubRestart restarts the hub.
 func (r *Reconciler) hubRestart() {
 	Log.Info("**** RESTARTING HUB *****")
-	_ = syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
+	_ = syscall.Kill(
+		syscall.Getpid(),
+		syscall.SIGTERM)
 }

--- a/internal/controller/idp/pkg.go
+++ b/internal/controller/idp/pkg.go
@@ -1,0 +1,168 @@
+package idp
+
+import (
+	"context"
+	"strings"
+	"syscall"
+
+	"github.com/go-logr/logr"
+	logr2 "github.com/jortel/go-utils/logr"
+	crd "github.com/konveyor/tackle2-hub/internal/k8s/api/tackle/v1alpha1"
+	"gorm.io/gorm"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/storage/names"
+	"k8s.io/client-go/tools/record"
+	k8s "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	Name = "idp"
+)
+
+var Log = logr2.WithName(Name)
+
+type IdentityProvider = crd.IdentityProvider
+
+// Add the controller.
+func Add(mgr manager.Manager, db *gorm.DB) (err error) {
+	reconciler := &Reconciler{
+		history: make(map[string]byte),
+		Client:  mgr.GetClient(),
+		Log:     Log,
+		DB:      db,
+	}
+	cnt, err := controller.New(
+		Name,
+		mgr,
+		controller.Options{
+			Reconciler: reconciler,
+		})
+	if err != nil {
+		Log.Error(err, "")
+		return
+	}
+	err = cnt.Watch(
+		&source.Kind{Type: &IdentityProvider{}},
+		&handler.EnqueueRequestForObject{})
+	if err != nil {
+		Log.Error(err, "")
+		return
+	}
+
+	return
+}
+
+// Reconciler reconciles idp CRs.
+// The history is used to ensure resources are reconciled
+// at least once at startup.
+type Reconciler struct {
+	record.EventRecorder
+	k8s.Client
+	DB      *gorm.DB
+	Log     logr.Logger
+	history map[string]byte
+}
+
+// Reconcile a Addon CR.
+// Note: Must not be a pointer receiver to ensure that the
+// logger and other state is not shared.
+func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (result reconcile.Result, err error) {
+	r.Log = logr2.WithName(
+		names.SimpleNameGenerator.GenerateName(Name+"|"),
+		"idp",
+		request)
+
+	// Fetch the CR.
+	idp := &IdentityProvider{}
+	err = r.Get(context.TODO(), request.NamespacedName, idp)
+	if err != nil {
+		if k8serr.IsNotFound(err) {
+			_ = r.deleted(request.Name)
+			err = nil
+		}
+		return
+	}
+	_, found := r.history[idp.Name]
+	if found && idp.Reconciled() {
+		return
+	}
+	// Changed
+	err = r.changed(idp)
+	if err != nil {
+		return
+	}
+	r.history[idp.Name] = 1
+	idp.Status.Conditions = nil
+	idp.Status.ObservedGeneration = idp.Generation
+	// Ready condition.
+	idp.Status.Conditions = append(
+		idp.Status.Conditions,
+		r.ready(idp))
+	// Apply changes.
+	err = r.Status().Update(context.TODO(), idp)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// ready returns the ready condition.
+func (r *Reconciler) ready(idp *IdentityProvider) (ready v1.Condition) {
+	ready = crd.Ready
+	ready.LastTransitionTime = v1.Now()
+	ready.ObservedGeneration = idp.Status.ObservedGeneration
+	err := make([]string, 0)
+	for i := range idp.Status.Conditions {
+		cnd := &idp.Status.Conditions[i]
+		if cnd.Type == crd.ValidationError {
+			err = append(err, cnd.Message)
+		}
+	}
+	if len(err) == 0 {
+		ready.Status = v1.ConditionTrue
+		ready.Reason = crd.Validated
+		ready.Message = strings.Join(err, ";")
+	} else {
+		ready.Status = v1.ConditionFalse
+		ready.Reason = crd.ValidationError
+	}
+	return
+}
+
+// changed an idp has been created/updated.
+// When detected, the hub is restarted.
+func (r *Reconciler) changed(p *IdentityProvider) (err error) {
+	if r.history[p.Name] == 0 {
+		return
+	}
+	Log.Info(
+		"IdP added/changed.",
+		"name",
+		p.Name)
+	r.hubRestart()
+	return
+}
+
+// deleted an idp has been deleted.
+// When detected, the hub is restarted.
+func (r *Reconciler) deleted(name string) (err error) {
+	Log.Info(
+		"Idp deleted.",
+		"name",
+		name)
+	r.hubRestart()
+	return
+}
+
+// hubRestart restarts the hub.
+func (r *Reconciler) hubRestart() {
+	Log.Info("**** RESTARTING HUB *****")
+	_ = syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
+}

--- a/internal/controller/idp/pkg.go
+++ b/internal/controller/idp/pkg.go
@@ -97,10 +97,9 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 	if err != nil {
 		return
 	}
-	r.history[idp.Name] = 1
+	// Ready condition.
 	idp.Status.Conditions = nil
 	idp.Status.ObservedGeneration = idp.Generation
-	// Ready condition.
 	idp.Status.Conditions = append(
 		idp.Status.Conditions,
 		r.ready(idp))
@@ -109,6 +108,8 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 	if err != nil {
 		return
 	}
+
+	r.history[idp.Name] = 1
 
 	return
 }

--- a/internal/controller/ldap/pkg.go
+++ b/internal/controller/ldap/pkg.go
@@ -32,10 +32,10 @@ type LdapProvider = crd.LdapProvider
 // Add the controller.
 func Add(mgr manager.Manager, db *gorm.DB) (err error) {
 	reconciler := &Reconciler{
-		history: make(map[string]byte),
-		Client:  mgr.GetClient(),
-		Log:     Log,
-		DB:      db,
+		seen:   make(map[string]bool),
+		Client: mgr.GetClient(),
+		Log:    Log,
+		DB:     db,
 	}
 	cnt, err := controller.New(
 		Name,
@@ -59,14 +59,14 @@ func Add(mgr manager.Manager, db *gorm.DB) (err error) {
 }
 
 // Reconciler reconciles ldap CRs.
-// The history is used to ensure resources are reconciled
-// at least once at startup.
+// The seen (map) is used to ensure resources are
+// reconciled at least once at startup.
 type Reconciler struct {
 	record.EventRecorder
 	k8s.Client
-	DB      *gorm.DB
-	Log     logr.Logger
-	history map[string]byte
+	DB   *gorm.DB
+	Log  logr.Logger
+	seen map[string]bool
 }
 
 // Reconcile a Addon CR.
@@ -77,7 +77,6 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 		names.SimpleNameGenerator.GenerateName(Name+"|"),
 		"ldap",
 		request)
-
 	// Fetch the CR.
 	p := &LdapProvider{}
 	err = r.Get(context.TODO(), request.NamespacedName, p)
@@ -88,7 +87,7 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 		}
 		return
 	}
-	_, found := r.history[p.Name]
+	_, found := r.seen[p.Name]
 	if found && p.Reconciled() {
 		return
 	}
@@ -98,18 +97,19 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 		return
 	}
 	// Ready condition.
+	ready := r.ready(p)
 	p.Status.Conditions = nil
 	p.Status.ObservedGeneration = p.Generation
 	p.Status.Conditions = append(
 		p.Status.Conditions,
-		r.ready(p))
+		ready)
 	// Apply changes.
 	err = r.Status().Update(context.TODO(), p)
 	if err != nil {
 		return
 	}
 
-	r.history[p.Name] = 1
+	r.seen[p.Name] = true
 
 	return
 }
@@ -140,7 +140,7 @@ func (r *Reconciler) ready(p *LdapProvider) (ready v1.Condition) {
 // changed an ldap has been added/updated.
 // When detected, the hub is restarted.
 func (r *Reconciler) changed(p *LdapProvider) (err error) {
-	if r.history[p.Name] == 0 {
+	if !r.seen[p.Name] {
 		return
 	}
 	Log.Info(
@@ -165,5 +165,7 @@ func (r *Reconciler) deleted(name string) (err error) {
 // hubRestart restarts the hub.
 func (r *Reconciler) hubRestart() {
 	Log.Info("**** RESTARTING HUB *****")
-	_ = syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
+	_ = syscall.Kill(
+		syscall.Getpid(),
+		syscall.SIGTERM)
 }

--- a/internal/controller/ldap/pkg.go
+++ b/internal/controller/ldap/pkg.go
@@ -97,10 +97,9 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 	if err != nil {
 		return
 	}
-	r.history[p.Name] = 1
+	// Ready condition.
 	p.Status.Conditions = nil
 	p.Status.ObservedGeneration = p.Generation
-	// Ready condition.
 	p.Status.Conditions = append(
 		p.Status.Conditions,
 		r.ready(p))
@@ -109,6 +108,8 @@ func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (r
 	if err != nil {
 		return
 	}
+
+	r.history[p.Name] = 1
 
 	return
 }

--- a/internal/controller/ldap/pkg.go
+++ b/internal/controller/ldap/pkg.go
@@ -1,0 +1,168 @@
+package ldap
+
+import (
+	"context"
+	"strings"
+	"syscall"
+
+	"github.com/go-logr/logr"
+	logr2 "github.com/jortel/go-utils/logr"
+	crd "github.com/konveyor/tackle2-hub/internal/k8s/api/tackle/v1alpha1"
+	"gorm.io/gorm"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/storage/names"
+	"k8s.io/client-go/tools/record"
+	k8s "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+const (
+	Name = "ldap"
+)
+
+var Log = logr2.WithName(Name)
+
+type LdapProvider = crd.LdapProvider
+
+// Add the controller.
+func Add(mgr manager.Manager, db *gorm.DB) (err error) {
+	reconciler := &Reconciler{
+		history: make(map[string]byte),
+		Client:  mgr.GetClient(),
+		Log:     Log,
+		DB:      db,
+	}
+	cnt, err := controller.New(
+		Name,
+		mgr,
+		controller.Options{
+			Reconciler: reconciler,
+		})
+	if err != nil {
+		Log.Error(err, "")
+		return
+	}
+	err = cnt.Watch(
+		&source.Kind{Type: &LdapProvider{}},
+		&handler.EnqueueRequestForObject{})
+	if err != nil {
+		Log.Error(err, "")
+		return
+	}
+
+	return
+}
+
+// Reconciler reconciles ldap CRs.
+// The history is used to ensure resources are reconciled
+// at least once at startup.
+type Reconciler struct {
+	record.EventRecorder
+	k8s.Client
+	DB      *gorm.DB
+	Log     logr.Logger
+	history map[string]byte
+}
+
+// Reconcile a Addon CR.
+// Note: Must not be a pointer receiver to ensure that the
+// logger and other state is not shared.
+func (r Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (result reconcile.Result, err error) {
+	r.Log = logr2.WithName(
+		names.SimpleNameGenerator.GenerateName(Name+"|"),
+		"ldap",
+		request)
+
+	// Fetch the CR.
+	p := &LdapProvider{}
+	err = r.Get(context.TODO(), request.NamespacedName, p)
+	if err != nil {
+		if k8serr.IsNotFound(err) {
+			_ = r.deleted(request.Name)
+			err = nil
+		}
+		return
+	}
+	_, found := r.history[p.Name]
+	if found && p.Reconciled() {
+		return
+	}
+	// Changed
+	err = r.changed(p)
+	if err != nil {
+		return
+	}
+	r.history[p.Name] = 1
+	p.Status.Conditions = nil
+	p.Status.ObservedGeneration = p.Generation
+	// Ready condition.
+	p.Status.Conditions = append(
+		p.Status.Conditions,
+		r.ready(p))
+	// Apply changes.
+	err = r.Status().Update(context.TODO(), p)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+// ready returns the ready condition.
+func (r *Reconciler) ready(p *LdapProvider) (ready v1.Condition) {
+	ready = crd.Ready
+	ready.LastTransitionTime = v1.Now()
+	ready.ObservedGeneration = p.Status.ObservedGeneration
+	err := make([]string, 0)
+	for i := range p.Status.Conditions {
+		cnd := &p.Status.Conditions[i]
+		if cnd.Type == crd.ValidationError {
+			err = append(err, cnd.Message)
+		}
+	}
+	if len(err) == 0 {
+		ready.Status = v1.ConditionTrue
+		ready.Reason = crd.Validated
+		ready.Message = strings.Join(err, ";")
+	} else {
+		ready.Status = v1.ConditionFalse
+		ready.Reason = crd.ValidationError
+	}
+	return
+}
+
+// changed an ldap has been added/updated.
+// When detected, the hub is restarted.
+func (r *Reconciler) changed(p *LdapProvider) (err error) {
+	if r.history[p.Name] == 0 {
+		return
+	}
+	Log.Info(
+		"LDAP Provider added/changed.",
+		"name",
+		p.Name)
+	r.hubRestart()
+	return
+}
+
+// deleted an ldap has been deleted.
+// When detected, the hub is restarted.
+func (r *Reconciler) deleted(name string) (err error) {
+	Log.Info(
+		"LDAP Provider deleted.",
+		"name",
+		name)
+	r.hubRestart()
+	return
+}
+
+// hubRestart restarts the hub.
+func (r *Reconciler) hubRestart() {
+	Log.Info("**** RESTARTING HUB *****")
+	_ = syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
+}

--- a/internal/controller/pkg.go
+++ b/internal/controller/pkg.go
@@ -1,0 +1,31 @@
+package controller
+
+import (
+	"github.com/konveyor/tackle2-hub/internal/controller/addon"
+	"github.com/konveyor/tackle2-hub/internal/controller/client"
+	"github.com/konveyor/tackle2-hub/internal/controller/idp"
+	"github.com/konveyor/tackle2-hub/internal/controller/ldap"
+	"gorm.io/gorm"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+// Add the controllers.
+func Add(mgr manager.Manager, db *gorm.DB) (err error) {
+	err = addon.Add(mgr, db)
+	if err != nil {
+		return
+	}
+	err = idp.Add(mgr, db)
+	if err != nil {
+		return
+	}
+	err = ldap.Add(mgr, db)
+	if err != nil {
+		return
+	}
+	err = client.Add(mgr, db)
+	if err != nil {
+		return
+	}
+	return
+}

--- a/internal/k8s/api/tackle/v1alpha1/client.go
+++ b/internal/k8s/api/tackle/v1alpha1/client.go
@@ -72,6 +72,22 @@ type IdpClient struct {
 	Status IdpClientStatus `json:"status,omitempty"`
 }
 
+// Reconciled returns true when the resource has been reconciled.
+func (r *IdpClient) Reconciled() (b bool) {
+	return r.Generation == r.Status.ObservedGeneration
+}
+
+// Ready returns true when resource has the ready condition.
+func (r *IdpClient) Ready() (ready bool) {
+	for _, cnd := range r.Status.Conditions {
+		if cnd.Type == Ready.Type && cnd.Status == meta.ConditionTrue {
+			ready = true
+			break
+		}
+	}
+	return
+}
+
 // IdpClientList contains a list of IdpClient.
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type IdpClientList struct {

--- a/internal/k8s/api/tackle/v1alpha1/identityprovider.go
+++ b/internal/k8s/api/tackle/v1alpha1/identityprovider.go
@@ -108,6 +108,22 @@ type IdentityProvider struct {
 	Status IdentityProviderStatus `json:"status,omitempty"`
 }
 
+// Reconciled returns true when the resource has been reconciled.
+func (r *IdentityProvider) Reconciled() (b bool) {
+	return r.Generation == r.Status.ObservedGeneration
+}
+
+// Ready returns true when resource has the ready condition.
+func (r *IdentityProvider) Ready() (ready bool) {
+	for _, cnd := range r.Status.Conditions {
+		if cnd.Type == Ready.Type && cnd.Status == meta.ConditionTrue {
+			ready = true
+			break
+		}
+	}
+	return
+}
+
 // IdentityProviderList is a list of IdentityProvider.
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type IdentityProviderList struct {

--- a/internal/k8s/api/tackle/v1alpha1/ldapprovider.go
+++ b/internal/k8s/api/tackle/v1alpha1/ldapprovider.go
@@ -87,6 +87,22 @@ type LdapProvider struct {
 	Status LdapProviderStatus `json:"status,omitempty"`
 }
 
+// Reconciled returns true when the resource has been reconciled.
+func (r *LdapProvider) Reconciled() (b bool) {
+	return r.Generation == r.Status.ObservedGeneration
+}
+
+// Ready returns true when resource has the ready condition.
+func (r *LdapProvider) Ready() (ready bool) {
+	for _, cnd := range r.Status.Conditions {
+		if cnd.Type == Ready.Type && cnd.Status == meta.ConditionTrue {
+			ready = true
+			break
+		}
+	}
+	return
+}
+
 // LdapProviderList is a list of LdapProvider.
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 type LdapProviderList struct {


### PR DESCRIPTION
closes #1085 

When changes to auth CRs are detected, the hub is restarted.  Using SIGTERM seems heavy-handed but no different than the operator doing a pod restart.

The addon controller moved into a new `addon` package.

As a follow up, we'll open another PR to catch SIGTERM and gracefully shutdown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added/registered Kubernetes controllers for Addon, Identity Provider, LDAP Provider, and Client, with consistent status management.
  * Added `Ready` and `Reconciled` helpers to the involved resources to standardize readiness and observed reconciliation state.

* **Bug Fixes**
  * Refined reconciliation flow to update status conditions deterministically and only mark resources as reconciled after successful observed updates.
  * Improved restart triggering and “already processed” gating to avoid premature restarts during initial reconciliation.

* **Chores**
  * Minor test formatting cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->