### PR TITLE
:sparkles: Add special role scopes support in IdP access tokens.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ test-api:
 
 test-binding:
 	for pkg in $$(go list ./test/binding/...); do \
-	  HUB_BASE_URL="$(HUB_BASE_URL)" go test -count=1 -v -failfast "$$pkg" || exit 1; \
+	  HUB_BASE_URL="$(HUB_BASE_URL)" go test -count=1 -v -failfast -parallel=1 "$$pkg" || exit 1; \
 	done
 test-auth:
 	for pkg in $$(go list ./test/auth/...); do \

--- a/internal/auth/idp.go
+++ b/internal/auth/idp.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"sync"
 
@@ -18,6 +19,10 @@ import (
 	"github.com/zitadel/oidc/v3/pkg/op"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
+)
+
+var (
+	roleScopeRegex = regexp.MustCompile(`\$\{role:([^}]+)\}`)
 )
 
 //
@@ -389,9 +394,35 @@ func (f *FedIdpLogin) extractScopes() (scopes []string) {
 	if scopeClaim, found := f.accessTokenClaims[ClaimScope]; found {
 		str := f.asString(scopeClaim)
 		scopes = strings.Fields(str)
+		scopes = f.expandScopes(scopes)
 		scopes = ExpandScopes(scopes...)
 	}
+	return
+}
 
+// expandScopes expands role references in the scope list.
+// Role references use ${role:name} syntax and are replaced with the role's
+// permission scopes. Reduces the burden of scope management in IdPs.
+func (f *FedIdpLogin) expandScopes(in []string) (expanded []string) {
+	cache := f.handler.cache
+	for _, scope := range in {
+		match := roleScopeRegex.FindStringSubmatch(scope)
+		if len(match) < 2 {
+			expanded = append(expanded, scope)
+			continue
+		}
+		name := match[1]
+		role, err := cache.FindRoleByName(name)
+		if err != nil {
+			Log.Info(err.Error(),
+				"pattern",
+				scope)
+			continue
+		}
+		for _, p := range role.Permissions {
+			expanded = append(expanded, p.Scope)
+		}
+	}
 	return
 }
 

--- a/internal/auth/idp.go
+++ b/internal/auth/idp.go
@@ -22,7 +22,7 @@ import (
 )
 
 var (
-	roleScopeRegex = regexp.MustCompile(`\$\{role:([^}]+)\}`)
+	roleScopeRegex = regexp.MustCompile(`^\+role\.([^.\s]+)$`)
 )
 
 //
@@ -401,7 +401,7 @@ func (f *FedIdpLogin) extractScopes() (scopes []string) {
 }
 
 // expandScopes expands role references in the scope list.
-// Role references use ${role:name} syntax and are replaced with the role's
+// Role references use +role.name syntax and are replaced with the role's
 // permission scopes. Reduces the burden of scope management in IdPs.
 func (f *FedIdpLogin) expandScopes(in []string) (expanded []string) {
 	cache := f.handler.cache

--- a/internal/auth/pkg_test.go
+++ b/internal/auth/pkg_test.go
@@ -4274,33 +4274,33 @@ func TestFedIdpRoleScopeExpansion(t *testing.T) {
 		accessTokenClaims: make(map[string]any),
 	}
 
-	// Test 1: Expand ${role:admin} to admin role's permissions
-	login.accessTokenClaims[ClaimScope] = "${role:admin} applications:delete"
+	// Test 1: Expand +role.admin to admin role's permissions
+	login.accessTokenClaims[ClaimScope] = "+role.admin applications:delete"
 	scopes := login.extractScopes()
 	g.Expect(scopes).To(ContainElement("applications:get"))
 	g.Expect(scopes).To(ContainElement("applications:post"))
 	g.Expect(scopes).To(ContainElement("applications:delete"))
-	g.Expect(scopes).NotTo(ContainElement("${role:admin}"))
+	g.Expect(scopes).NotTo(ContainElement("+role.admin"))
 
 	// Test 2: Mix of role reference and regular scopes
-	login.accessTokenClaims[ClaimScope] = "${role:viewer} applications:put"
+	login.accessTokenClaims[ClaimScope] = "+role.viewer applications:put"
 	scopes = login.extractScopes()
 	g.Expect(scopes).To(ContainElement("tags:get"))
 	g.Expect(scopes).To(ContainElement("applications:put"))
-	g.Expect(scopes).NotTo(ContainElement("${role:viewer}"))
+	g.Expect(scopes).NotTo(ContainElement("+role.viewer"))
 
 	// Test 3: Multiple role references
-	login.accessTokenClaims[ClaimScope] = "${role:admin} ${role:viewer}"
+	login.accessTokenClaims[ClaimScope] = "+role.admin +role.viewer"
 	scopes = login.extractScopes()
 	g.Expect(scopes).To(ContainElement("applications:get"))
 	g.Expect(scopes).To(ContainElement("applications:post"))
 	g.Expect(scopes).To(ContainElement("tags:get"))
 
 	// Test 4: Unknown role - should be logged and dropped
-	login.accessTokenClaims[ClaimScope] = "${role:unknown} tags:post"
+	login.accessTokenClaims[ClaimScope] = "+role.unknown tags:post"
 	scopes = login.extractScopes()
 	g.Expect(scopes).To(ContainElement("tags:post"))
-	g.Expect(scopes).NotTo(ContainElement("${role:unknown}"))
+	g.Expect(scopes).NotTo(ContainElement("+role.unknown"))
 	g.Expect(len(scopes)).To(Equal(1))
 
 	// Test 5: No role references - regular scopes unchanged
@@ -4322,7 +4322,7 @@ func TestFedIdpRoleScopeExpansion(t *testing.T) {
 	err = provider.cache.Refresh()
 	g.Expect(err).To(BeNil())
 
-	login.accessTokenClaims[ClaimScope] = "${role:empty} tags:delete"
+	login.accessTokenClaims[ClaimScope] = "+role.empty tags:delete"
 	scopes = login.extractScopes()
 	g.Expect(scopes).To(ContainElement("tags:delete"))
 	g.Expect(len(scopes)).To(Equal(1))

--- a/internal/auth/pkg_test.go
+++ b/internal/auth/pkg_test.go
@@ -4212,6 +4212,122 @@ func TestExternalIdpWildcardExpansion(t *testing.T) {
 	g.Expect(expanded).To(ContainElement("tags:delete"))
 }
 
+// TestFedIdpRoleScopeExpansion tests role reference expansion in federated IdP scopes.
+func TestFedIdpRoleScopeExpansion(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	db, err := setupTestDB()
+	g.Expect(err).To(BeNil())
+
+	// Create permissions
+	appGetPerm := &model.Permission{
+		Name:     "applications-get",
+		Resource: "applications",
+		Verb:     "get",
+		Scope:    "applications:get",
+	}
+	err = db.Create(appGetPerm).Error
+	g.Expect(err).To(BeNil())
+
+	appPostPerm := &model.Permission{
+		Name:     "applications-post",
+		Resource: "applications",
+		Verb:     "post",
+		Scope:    "applications:post",
+	}
+	err = db.Create(appPostPerm).Error
+	g.Expect(err).To(BeNil())
+
+	tagsGetPerm := &model.Permission{
+		Name:     "tags-get",
+		Resource: "tags",
+		Verb:     "get",
+		Scope:    "tags:get",
+	}
+	err = db.Create(tagsGetPerm).Error
+	g.Expect(err).To(BeNil())
+
+	// Create roles with permissions
+	adminRole := &model.Role{Name: "admin"}
+	err = db.Create(adminRole).Error
+	g.Expect(err).To(BeNil())
+	err = db.Model(adminRole).Association("Permissions").Append(appGetPerm, appPostPerm)
+	g.Expect(err).To(BeNil())
+
+	viewerRole := &model.Role{Name: "viewer"}
+	err = db.Create(viewerRole).Error
+	g.Expect(err).To(BeNil())
+	err = db.Model(viewerRole).Association("Permissions").Append(tagsGetPerm)
+	g.Expect(err).To(BeNil())
+
+	// Create provider and cache
+	provider, err := NewBuiltin(db)
+	g.Expect(err).To(BeNil())
+
+	// Create FedIdpHandler and FedIdpLogin
+	handler := &FedIdpHandler{
+		cache: provider.cache,
+	}
+
+	login := &FedIdpLogin{
+		handler:           handler,
+		accessTokenClaims: make(map[string]any),
+	}
+
+	// Test 1: Expand ${role:admin} to admin role's permissions
+	login.accessTokenClaims[ClaimScope] = "${role:admin} applications:delete"
+	scopes := login.extractScopes()
+	g.Expect(scopes).To(ContainElement("applications:get"))
+	g.Expect(scopes).To(ContainElement("applications:post"))
+	g.Expect(scopes).To(ContainElement("applications:delete"))
+	g.Expect(scopes).NotTo(ContainElement("${role:admin}"))
+
+	// Test 2: Mix of role reference and regular scopes
+	login.accessTokenClaims[ClaimScope] = "${role:viewer} applications:put"
+	scopes = login.extractScopes()
+	g.Expect(scopes).To(ContainElement("tags:get"))
+	g.Expect(scopes).To(ContainElement("applications:put"))
+	g.Expect(scopes).NotTo(ContainElement("${role:viewer}"))
+
+	// Test 3: Multiple role references
+	login.accessTokenClaims[ClaimScope] = "${role:admin} ${role:viewer}"
+	scopes = login.extractScopes()
+	g.Expect(scopes).To(ContainElement("applications:get"))
+	g.Expect(scopes).To(ContainElement("applications:post"))
+	g.Expect(scopes).To(ContainElement("tags:get"))
+
+	// Test 4: Unknown role - should be logged and dropped
+	login.accessTokenClaims[ClaimScope] = "${role:unknown} tags:post"
+	scopes = login.extractScopes()
+	g.Expect(scopes).To(ContainElement("tags:post"))
+	g.Expect(scopes).NotTo(ContainElement("${role:unknown}"))
+	g.Expect(len(scopes)).To(Equal(1))
+
+	// Test 5: No role references - regular scopes unchanged
+	login.accessTokenClaims[ClaimScope] = "applications:get tags:post"
+	scopes = login.extractScopes()
+	g.Expect(scopes).To(ContainElement("applications:get"))
+	g.Expect(scopes).To(ContainElement("tags:post"))
+	g.Expect(len(scopes)).To(Equal(2))
+
+	// Test 6: Empty scopes
+	login.accessTokenClaims[ClaimScope] = ""
+	scopes = login.extractScopes()
+	g.Expect(scopes).To(BeEmpty())
+
+	// Test 7: Role with no permissions
+	emptyRole := &model.Role{Name: "empty"}
+	err = db.Create(emptyRole).Error
+	g.Expect(err).To(BeNil())
+	err = provider.cache.Refresh()
+	g.Expect(err).To(BeNil())
+
+	login.accessTokenClaims[ClaimScope] = "${role:empty} tags:delete"
+	scopes = login.extractScopes()
+	g.Expect(scopes).To(ContainElement("tags:delete"))
+	g.Expect(len(scopes)).To(Equal(1))
+}
+
 // TestPermissionGenerationWithNounVerb tests that generatePermissions populates Noun and Verb.
 func TestPermissionGenerationWithNounVerb(t *testing.T) {
 	g := NewGomegaWithT(t)


### PR DESCRIPTION
To reduce the burden of scope management in external IdP, support scope (macros) that are expanded into known scopes.
i.e. access token scopes = "+role.migrator"
will be replace with migrator scopes.

closes #1087 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Federated login now expands role-based scope references found in access-token scope claims, deriving permissions from referenced roles.

* **Bug Fixes**
  * Valid non-role scopes are preserved while unknown role references are ignored.
  * Role-expanded scopes are normalized afterward to keep final access scopes consistent.

* **Tests**
  * Added coverage to verify role scope expansion behavior, including multiple references, missing permissions, and empty scope claims.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->