### PR TITLE
:bug: Set browser tab title from branding strings

### DIFF
--- a/internal/frontend/auth/content/src/index.html
+++ b/internal/frontend/auth/content/src/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Tackle Hub</title>
+  <title>Hub</title>
   <script id="login-config">
     window.__LOGIN_CONFIG__ = {{ . }};
   </script>

--- a/internal/frontend/auth/content/src/index.tsx
+++ b/internal/frontend/auth/content/src/index.tsx
@@ -40,7 +40,7 @@ const App = () => {
   }
 }
 
-document.title = brandingStrings.application.name ?? brandingStrings.application.title;
+document.title = brandingStrings.application?.name ?? brandingStrings.application?.title ?? "Hub";
 
 const container = document.getElementById("root");
 if (!container) {

--- a/internal/frontend/auth/content/src/index.tsx
+++ b/internal/frontend/auth/content/src/index.tsx
@@ -6,6 +6,7 @@ import { DeviceVerifyPage } from "./DeviceVerifyPage";
 import { DeviceSuccessPage } from "./DeviceSuccessPage";
 import { SessionExpiredPage } from "./SessionExpiredPage";
 import type { LoginConfig } from "./types";
+import { brandingStrings } from "./branding";
 
 import "@patternfly/react-core/dist/styles/base.css";
 // TODO Add support for branding.styles.themeCss (or in rspack.config.ts)
@@ -38,6 +39,8 @@ const App = () => {
       return <UserLoginPage config={config} />;
   }
 }
+
+document.title = brandingStrings.application.name ?? brandingStrings.application.title;
 
 const container = document.getElementById("root");
 if (!container) {


### PR DESCRIPTION
## Summary

- The HTML `<title>` was hardcoded to "Tackle Hub" and never updated from the branding configuration
- Added `document.title = brandingStrings.application.name` in `index.tsx` so the browser tab title respects whichever branding directory is used at build time
- Changed the static HTML `<title>` to a generic "Hub" fallback (only visible momentarily before JS runs)

## Test plan

- [ ] Build the frontend with the default `branding/` directory — tab should show "Konveyor Hub"
- [ ] Build with custom branding with a different `application.name` — tab should reflect that name
- [ ] Verify the fallback works when `application.name` is not set — falls back to `application.title`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the application page title to use the configured application name, with a fallback title when needed.
  * Simplified the default document title from “Tackle Hub” to “Hub.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->