### PR TITLE
:sparkles: Select idp and ldap when multiples.

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -189,6 +189,7 @@ golang.org/x/telemetry v0.0.0-20260109210033-bd525da824e2 h1:O1cMQHRfwNpDfDJerqR
 golang.org/x/telemetry v0.0.0-20260109210033-bd525da824e2/go.mod h1:b7fPSJ0pKZ3ccUh8gnTONJxhn3c/PS6tyzQvyqw4iA8=
 golang.org/x/telemetry v0.0.0-20260311193753-579e4da9a98c h1:6a8FdnNk6bTXBjR4AGKFgUKuo+7GnR3FX5L7CbveeZc=
 golang.org/x/telemetry v0.0.0-20260311193753-579e4da9a98c/go.mod h1:TpUTTEp9frx7rTdLpC9gFG9kdI7zVLFTFFlqaH2Cncw=
+golang.org/x/telemetry v0.0.0-20260625142307-59b4966ccb57 h1:nwGZBCt+FnXUrGsj5vjzAsEmkcaFvd82BbOjECiFYZc=
 golang.org/x/telemetry v0.0.0-20260625142307-59b4966ccb57/go.mod h1:3AWMyWHS+caVoiEXpiq6+tzKA40J4vQT3MYr80ZtQpc=
 golang.org/x/term v0.39.0/go.mod h1:yxzUCTP/U+FzoxfdKmLaA0RV1WgE0VY7hXBwKtY/4ww=
 golang.org/x/text v0.33.0/go.mod h1:LuMebE6+rBincTi9+xWTY8TztLzKHc/9C1uBCG27+q8=

--- a/internal/auth/domain.go
+++ b/internal/auth/domain.go
@@ -549,22 +549,39 @@ func (d *Tenant) getIdp() (err error) {
 		err = liberr.Wrap(err)
 		return
 	}
-	for _, m := range list.Items {
-		m2 := IdentityProvider{}
-		err = m2.with(&m)
+	if len(list.Items) == 0 {
+		return
+	}
+	if len(list.Items) > 1 {
+		sort.Slice(
+			list.Items,
+			func(i, j int) bool {
+				ti := list.Items[i].CreationTimestamp
+				tj := list.Items[j].CreationTimestamp
+				return ti.After(tj.Time)
+			})
+		Log.Info(
+			"WARNING: multiple IdentityProvider found."+
+				" The newest one will be used.",
+			"count",
+			len(list.Items),
+			"selected",
+			list.Items[0].Name)
+	}
+	m := &list.Items[0]
+	m2 := IdentityProvider{}
+	err = m2.with(m)
+	if err != nil {
+		return
+	}
+	ref := m.Spec.ClientSecret
+	if ref != nil {
+		m2.ClientSecret, err = d.getSecret(ref, "clientSecret")
 		if err != nil {
 			return
 		}
-		ref := m.Spec.ClientSecret
-		if ref != nil {
-			m2.ClientSecret, err = d.getSecret(ref, "clientSecret")
-			if err != nil {
-				return
-			}
-		}
-		d.Idp = m2
-		break
 	}
+	d.Idp = m2
 	return
 }
 
@@ -577,22 +594,39 @@ func (d *Tenant) getLdap() (err error) {
 		err = liberr.Wrap(err)
 		return
 	}
-	for _, m := range list.Items {
-		m2 := LdapProvider{}
-		err = m2.with(&m)
+	if len(list.Items) == 0 {
+		return
+	}
+	if len(list.Items) > 1 {
+		sort.Slice(
+			list.Items,
+			func(i, j int) bool {
+				ti := list.Items[i].CreationTimestamp
+				tj := list.Items[j].CreationTimestamp
+				return ti.After(tj.Time)
+			})
+		Log.Info(
+			"WARNING: multiple LdapProvider found."+
+				" The newest one will be used.",
+			"count",
+			len(list.Items),
+			"selected",
+			list.Items[0].Name)
+	}
+	m := &list.Items[0]
+	m2 := LdapProvider{}
+	err = m2.with(m)
+	if err != nil {
+		return
+	}
+	ref := m.Spec.Password
+	if ref != nil {
+		m2.Password, err = d.getSecret(ref, "password")
 		if err != nil {
 			return
 		}
-		ref := m.Spec.Password
-		if ref != nil {
-			m2.Password, err = d.getSecret(ref, "password")
-			if err != nil {
-				return
-			}
-		}
-		d.Ldap = m2
-		break
 	}
+	d.Ldap = m2
 	return
 }
 

--- a/internal/auth/domain.go
+++ b/internal/auth/domain.go
@@ -558,7 +558,7 @@ func (d *Tenant) getIdp() (err error) {
 			func(i, j int) bool {
 				ti := list.Items[i].CreationTimestamp
 				tj := list.Items[j].CreationTimestamp
-				return ti.After(tj.Time)
+				return ti.Time.After(tj.Time)
 			})
 		Log.Info(
 			"WARNING: multiple IdentityProvider found."+
@@ -603,7 +603,7 @@ func (d *Tenant) getLdap() (err error) {
 			func(i, j int) bool {
 				ti := list.Items[i].CreationTimestamp
 				tj := list.Items[j].CreationTimestamp
-				return ti.After(tj.Time)
+				return ti.Time.After(tj.Time)
 			})
 		Log.Info(
 			"WARNING: multiple LdapProvider found."+

--- a/internal/auth/domain.go
+++ b/internal/auth/domain.go
@@ -550,6 +550,7 @@ func (d *Tenant) getIdp() (err error) {
 		return
 	}
 	if len(list.Items) == 0 {
+		d.Idp = IdentityProvider{}
 		return
 	}
 	if len(list.Items) > 1 {
@@ -595,6 +596,7 @@ func (d *Tenant) getLdap() (err error) {
 		return
 	}
 	if len(list.Items) == 0 {
+		d.Ldap = LdapProvider{}
 		return
 	}
 	if len(list.Items) > 1 {


### PR DESCRIPTION
When multiple resources exist, select the newest and log a warning.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when multiple identity providers or LDAP configurations are available.
  * The newest configuration is now selected consistently.
  * Added safeguards for cases where no configuration is present.
  * Referenced credentials are resolved correctly for the selected configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->