### PR TITLE
:sparkles: Refactor shared SCM for use outside of addons.

### DIFF
--- a/shared/addon/scm/pkg.go
+++ b/shared/addon/scm/pkg.go
@@ -2,7 +2,6 @@ package scm
 
 import (
 	"os"
-	"path/filepath"
 
 	"github.com/konveyor/tackle2-hub/shared/addon/adapter"
 	"github.com/konveyor/tackle2-hub/shared/api"
@@ -10,12 +9,11 @@ import (
 )
 
 var (
-	Dir   = ""
 	addon = adapter.Addon
 )
 
 func init() {
-	Dir, _ = os.Getwd()
+	scm.Dir, _ = os.Getwd()
 }
 
 type SCM = scm.SCM
@@ -28,88 +26,10 @@ type Subversion = scm.Subversion
 
 // New SCM repository factory.
 func New(destDir string, repository api.Repository, identity *api.Identity) (r SCM, err error) {
-	remote := Remote{
-		Kind:   repository.Kind,
-		URL:    repository.URL,
-		Branch: repository.Branch,
-		Path:   repository.Path,
-	}
-	if identity != nil {
-		remote.Identity = &Identity{
-			ID:       identity.ID,
-			Name:     identity.Name,
-			User:     identity.User,
-			Password: identity.Password,
-			Key:      identity.Key,
-		}
-	}
-	switch remote.Kind {
-	case "subversion":
-		remote.Insecure, err = addon.Setting.Bool("svn.insecure.enabled")
-		if err != nil {
-			return
-		}
-		svn := &Subversion{}
-		svn.Remote = remote
-		svn.Path = destDir
-		svn.Home = filepath.Join(Dir, ".svn", svn.Id())
-		svn.Proxies, err = proxyMap()
-		if err != nil {
-			return
-		}
-		r = svn
-	default:
-		remote.Insecure, err = addon.Setting.Bool("git.insecure.enabled")
-		if err != nil {
-			return
-		}
-		git := &Git{}
-		git.Remote = remote
-		git.Path = destDir
-		git.Home = filepath.Join(Dir, ".git", git.Id())
-		git.Proxies, err = proxyMap()
-		if err != nil {
-			return
-		}
-		r = git
-	}
-	err = r.Validate()
-	return
-}
-
-// proxyMap returns a map of proxies.
-func proxyMap() (pm ProxyMap, err error) {
-	pm = make(ProxyMap)
-	list, err := addon.Proxy.List()
-	if err != nil {
-		return
-	}
-	for _, p := range list {
-		if !p.Enabled {
-			continue
-		}
-		proxy := Proxy{
-			ID:       p.ID,
-			Kind:     p.Kind,
-			Host:     p.Host,
-			Port:     p.Port,
-			Excluded: p.Excluded,
-		}
-		if p.Identity != nil {
-			var identity *api.Identity
-			identity, err = addon.Identity.Get(p.Identity.ID)
-			if err != nil {
-				return
-			}
-			proxy.Identity = &Identity{
-				ID:       identity.ID,
-				Name:     identity.Name,
-				User:     identity.User,
-				Password: identity.Password,
-				Key:      identity.Key,
-			}
-		}
-		pm[p.Kind] = proxy
-	}
+	r, err = scm.New(
+		destDir,
+		repository,
+		identity,
+		addon.Client())
 	return
 }

--- a/shared/scm/base.go
+++ b/shared/scm/base.go
@@ -10,12 +10,6 @@ import (
 	"github.com/konveyor/tackle2-hub/shared/nas"
 )
 
-var Home = ""
-
-func init() {
-	Home, _ = os.Getwd()
-}
-
 // Base SCM.
 type Base struct {
 	Home    string

--- a/shared/scm/pkg.go
+++ b/shared/scm/pkg.go
@@ -7,13 +7,22 @@ package scm
 import (
 	"fmt"
 	"hash/fnv"
+	"os"
+	"path/filepath"
 
 	"github.com/jortel/go-utils/logr"
+	"github.com/konveyor/tackle2-hub/shared/api"
+	"github.com/konveyor/tackle2-hub/shared/binding"
 )
 
 var (
 	Log = logr.New("SCM", 0)
+	Dir = ""
 )
+
+func init() {
+	Dir, _ = os.Getwd()
+}
 
 // SCM interface.
 type SCM interface {
@@ -67,5 +76,98 @@ func (r *Remote) Digest() (d string) {
 	_, _ = h.Write([]byte(r.URL))
 	n := h.Sum64()
 	d = fmt.Sprintf("%x", n)
+	return
+}
+
+// New SCM repository factory.
+func New(
+	destDir string,
+	repository api.Repository,
+	identity *api.Identity,
+	client *binding.RichClient) (r SCM, err error) {
+	//
+	remote := Remote{
+		Kind:   repository.Kind,
+		URL:    repository.URL,
+		Branch: repository.Branch,
+		Path:   repository.Path,
+	}
+	if identity != nil {
+		remote.Identity = &Identity{
+			ID:       identity.ID,
+			Name:     identity.Name,
+			User:     identity.User,
+			Password: identity.Password,
+			Key:      identity.Key,
+		}
+	}
+	switch remote.Kind {
+	case "subversion":
+		remote.Insecure, err = client.Setting.Bool("svn.insecure.enabled")
+		if err != nil {
+			return
+		}
+		svn := &Subversion{}
+		svn.Remote = remote
+		svn.Path = destDir
+		svn.Home = filepath.Join(Dir, ".svn", svn.Id())
+		svn.Proxies, err = proxyMap(client)
+		if err != nil {
+			return
+		}
+		r = svn
+	default:
+		remote.Insecure, err = client.Setting.Bool("git.insecure.enabled")
+		if err != nil {
+			return
+		}
+		git := &Git{}
+		git.Remote = remote
+		git.Path = destDir
+		git.Home = filepath.Join(Dir, ".git", git.Id())
+		git.Proxies, err = proxyMap(client)
+		if err != nil {
+			return
+		}
+		r = git
+	}
+	err = r.Validate()
+	return
+}
+
+// proxyMap returns a map of proxies.
+func proxyMap(client *binding.RichClient) (pm ProxyMap, err error) {
+	pm = make(ProxyMap)
+	list, err := client.Proxy.List()
+	if err != nil {
+		return
+	}
+	for _, p := range list {
+		if !p.Enabled {
+			continue
+		}
+		proxy := Proxy{
+			ID:       p.ID,
+			Kind:     p.Kind,
+			Host:     p.Host,
+			Port:     p.Port,
+			Excluded: p.Excluded,
+		}
+		if p.Identity != nil {
+			var identity *api.Identity
+			identity, err = client.Identity.Get(p.Identity.ID)
+			if err != nil {
+				return
+			}
+			proxy.Identity = &Identity{
+				ID:       identity.ID,
+				Name:     identity.Name,
+				User:     identity.User,
+				Password: identity.Password,
+				Key:      identity.Key,
+			}
+		}
+		pm[p.Kind] = proxy
+	}
 	return
 }


### PR DESCRIPTION
Adds shared/scm New().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added unified SCM repository setup for Git and Subversion repositories.
  * SCM connections now support repository identities, proxy configuration, and per-type security settings.
  * Repository-specific working directories and home directories are configured automatically.

* **Bug Fixes**
  * Improved repository validation during setup.
  * Enabled clearer handling of proxy and client configuration errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->