### PR TITLE
:sparkles: Add SCM Push.

### DIFF
--- a/shared/scm/git.go
+++ b/shared/scm/git.go
@@ -109,7 +109,16 @@ func (r *Git) Commit(files []string, msg string) (err error) {
 	if err != nil {
 		return err
 	}
-	err = r.push()
+	err = r.Push()
+	return
+}
+
+// Push changes to the remote.
+func (r *Git) Push() (err error) {
+	cmd := r.git()
+	cmd.Dir = r.Path
+	cmd.Options.Add("push", "origin", "HEAD")
+	err = cmd.Run()
 	return
 }
 
@@ -264,15 +273,6 @@ func (r *Git) addFiles(files []string) (err error) {
 	cmd := r.git()
 	cmd.Dir = r.Path
 	cmd.Options.Add("add", files...)
-	err = cmd.Run()
-	return
-}
-
-// push changes to remote.
-func (r *Git) push() (err error) {
-	cmd := r.git()
-	cmd.Dir = r.Path
-	cmd.Options.Add("push", "origin", "HEAD")
 	err = cmd.Run()
 	return
 }

--- a/shared/scm/git.go
+++ b/shared/scm/git.go
@@ -109,16 +109,17 @@ func (r *Git) Commit(files []string, msg string) (err error) {
 	if err != nil {
 		return err
 	}
-	err = r.Push()
+	err = r.push()
 	return
 }
 
 // Push changes to the remote.
 func (r *Git) Push() (err error) {
-	cmd := r.git()
-	cmd.Dir = r.Path
-	cmd.Options.Add("push", "origin", "HEAD")
-	err = cmd.Run()
+	err = r.initHome()
+	if err != nil {
+		return
+	}
+	err = r.push()
 	return
 }
 
@@ -273,6 +274,15 @@ func (r *Git) addFiles(files []string) (err error) {
 	cmd := r.git()
 	cmd.Dir = r.Path
 	cmd.Options.Add("add", files...)
+	err = cmd.Run()
+	return
+}
+
+// push changes to the remote.
+func (r *Git) push() (err error) {
+	cmd := r.git()
+	cmd.Dir = r.Path
+	cmd.Options.Add("push", "origin", "HEAD")
 	err = cmd.Run()
 	return
 }

--- a/shared/scm/pkg.go
+++ b/shared/scm/pkg.go
@@ -32,6 +32,7 @@ type SCM interface {
 	Update() (err error)
 	Branch(ref string) (err error)
 	Commit(files []string, msg string) (err error)
+	Push() (err error)
 	Head() (commit string, err error)
 	Clean() (err error)
 }

--- a/shared/scm/subversion.go
+++ b/shared/scm/subversion.go
@@ -116,6 +116,11 @@ func (r *Subversion) Commit(files []string, msg string) (err error) {
 	return
 }
 
+// Push changes to the remote.
+func (r *Subversion) Push() (err error) {
+	return
+}
+
 // Head returns the current revision.
 func (r *Subversion) Head() (commit string, err error) {
 	err = r.initHome()


### PR DESCRIPTION
Add SCM.Push() for use cases where the repository is being _used_ outside of the package.  The use cases is an AI agent committing but not pushing.  Then, all the commits need to be pushed.
This is an no-op for SVN (command) because commit() pushes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

* Source control integrations now support pushing committed changes to a remote repository.
* Git integrations can explicitly push changes and report any errors.
* Subversion integrations now recognize the push operation for improved compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->