### PR TITLE
:bug: Fix hard coded path.

### DIFF
--- a/shared/nas/dir.go
+++ b/shared/nas/dir.go
@@ -14,7 +14,7 @@ import (
 
 // CpDir copies (recursively) the directory.
 func CpDir(path, destination string) (err error) {
-	cmd := command.New("/usr/bin/cp")
+	cmd := command.New("cp")
 	cmd.Options.Add("-r", path, destination)
 	err = cmd.Run()
 	return
@@ -22,7 +22,7 @@ func CpDir(path, destination string) (err error) {
 
 // RmDir deletes the directory.
 func RmDir(path string) (err error) {
-	cmd := command.New("/usr/bin/rm")
+	cmd := command.New("rm")
 	cmd.Options.Add("-rf", path)
 	err = cmd.Run()
 	return


### PR DESCRIPTION
closes #1118 

Note: Using `rm` command instead of os.RemoveAll() because it's 12x faster.  Especially on network FS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory copy and removal operations by allowing the system to locate the required commands dynamically.
  * Preserved existing command options and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->