### PR TITLE
:bug: Fix roles created when SA with ID=0 refs posted.

### DIFF
--- a/internal/auth/cache/cache.go
+++ b/internal/auth/cache/cache.go
@@ -732,11 +732,12 @@ func (d *Data) addTokenScopes(m *Token) {
 func (d *Data) addUserScopes(m *User) {
 	scopes := []string{}
 	for _, r := range m.Roles {
-		r, found := d.roleById[r.ID]
+		id := r.ID
+		r, found := d.roleById[id]
 		if !found {
 			err := &NotFound{
 				Resource: "role",
-				Id:       strconv.Itoa(int(r.ID)),
+				Id:       strconv.Itoa(int(id)),
 			}
 			Log.Info(err.Error())
 			continue
@@ -752,11 +753,12 @@ func (d *Data) addUserScopes(m *User) {
 func (d *Data) addSaScopes(m *ServiceAccount) {
 	scopes := []string{}
 	for _, r := range m.Roles {
-		r, found := d.roleById[r.ID]
+		id := r.ID
+		r, found := d.roleById[id]
 		if !found {
 			err := &NotFound{
 				Resource: "role",
-				Id:       strconv.Itoa(int(r.ID)),
+				Id:       strconv.Itoa(int(id)),
 			}
 			Log.Info(err.Error())
 			continue

--- a/shared/api/analysis.go
+++ b/shared/api/analysis.go
@@ -176,9 +176,9 @@ type ApScope struct {
 
 // ApRules analysis rules.
 type ApRules struct {
-	Targets    []ApTargetRef `json:"targets"`
+	Targets    []ApTargetRef `json:"targets" binding:"dive"`
 	Labels     InExList      `json:"labels,omitempty" yaml:",omitempty"`
-	Files      []Ref         `json:"files,omitempty" yaml:",omitempty"`
+	Files      []Ref         `json:"files,omitempty" yaml:",omitempty" binding:"dive"`
 	Repository *Repository   `json:"repository,omitempty" yaml:",omitempty"`
 	Identity   *Ref          `json:"identity,omitempty" yaml:",omitempty"`
 }

--- a/shared/api/application.go
+++ b/shared/api/application.go
@@ -17,16 +17,16 @@ type Application struct {
 	Coordinates     *Document     `json:"coordinates"`
 	Review          *Ref          `json:"review"`
 	Comments        string        `json:"comments"`
-	Identities      []IdentityRef `json:"identities"`
-	Tags            []TagRef      `json:"tags"`
+	Identities      []IdentityRef `json:"identities" binding:"dive"`
+	Tags            []TagRef      `json:"tags" binding:"dive"`
 	BusinessService *Ref          `json:"businessService" yaml:"businessService"`
 	Owner           *Ref          `json:"owner"`
-	Contributors    []Ref         `json:"contributors"`
+	Contributors    []Ref         `json:"contributors" binding:"dive"`
 	MigrationWave   *Ref          `json:"migrationWave" yaml:"migrationWave"`
 	Platform        *Ref          `json:"platform"`
-	Archetypes      []Ref         `json:"archetypes"`
-	Assessments     []Ref         `json:"assessments"`
-	Manifests       []Ref         `json:"manifests"`
+	Archetypes      []Ref         `json:"archetypes" binding:"dive"`
+	Assessments     []Ref         `json:"assessments" binding:"dive"`
+	Manifests       []Ref         `json:"manifests" binding:"dive"`
 	Assessed        bool          `json:"assessed"`
 	Risk            string        `json:"risk"`
 	Confidence      int           `json:"confidence"`
@@ -90,7 +90,7 @@ type IdentityRef struct {
 // Stakeholders REST resource for updating application stakeholders.
 type Stakeholders struct {
 	Owner        *Ref  `json:"owner"`
-	Contributors []Ref `json:"contributors"`
+	Contributors []Ref `json:"contributors" binding:"dive"`
 }
 
 // TagCategory REST resource.
@@ -98,7 +98,7 @@ type TagCategory struct {
 	Resource `yaml:",inline"`
 	Name     string `json:"name" binding:"required"`
 	Color    string `json:"colour" yaml:"colour"`
-	Tags     []Ref  `json:"tags"`
+	Tags     []Ref  `json:"tags" binding:"dive"`
 	// Deprecated
 	Username string `json:"username,omitempty"` // Deprecated
 	Rank     uint   `json:"rank,omitempty"`     // Deprecated
@@ -116,12 +116,12 @@ type Stakeholder struct {
 	Resource         `yaml:",inline"`
 	Name             string `json:"name" binding:"required"`
 	Email            string `json:"email" binding:"required"`
-	Groups           []Ref  `json:"stakeholderGroups" yaml:"stakeholderGroups"`
-	BusinessServices []Ref  `json:"businessServices" yaml:"businessServices"`
+	Groups           []Ref  `json:"stakeholderGroups" yaml:"stakeholderGroups" binding:"dive"`
+	BusinessServices []Ref  `json:"businessServices" yaml:"businessServices" binding:"dive"`
 	JobFunction      *Ref   `json:"jobFunction" yaml:"jobFunction"`
-	Owns             []Ref  `json:"owns"`
-	Contributes      []Ref  `json:"contributes"`
-	MigrationWaves   []Ref  `json:"migrationWaves" yaml:"migrationWaves"`
+	Owns             []Ref  `json:"owns" binding:"dive"`
+	Contributes      []Ref  `json:"contributes" binding:"dive"`
+	MigrationWaves   []Ref  `json:"migrationWaves" yaml:"migrationWaves" binding:"dive"`
 }
 
 // StakeholderGroup REST resource.
@@ -129,15 +129,15 @@ type StakeholderGroup struct {
 	Resource       `yaml:",inline"`
 	Name           string `json:"name" binding:"required"`
 	Description    string `json:"description"`
-	Stakeholders   []Ref  `json:"stakeholders"`
-	MigrationWaves []Ref  `json:"migrationWaves" yaml:"migrationWaves"`
+	Stakeholders   []Ref  `json:"stakeholders" binding:"dive"`
+	MigrationWaves []Ref  `json:"migrationWaves" yaml:"migrationWaves" binding:"dive"`
 }
 
 // JobFunction REST resource.
 type JobFunction struct {
 	Resource     `yaml:",inline"`
 	Name         string `json:"name" binding:"required"`
-	Stakeholders []Ref  `json:"stakeholders"`
+	Stakeholders []Ref  `json:"stakeholders" binding:"dive"`
 }
 
 // BusinessService REST resource.
@@ -179,9 +179,9 @@ type MigrationWave struct {
 	Name              string    `json:"name"`
 	StartDate         time.Time `json:"startDate" yaml:"startDate" binding:"required"`
 	EndDate           time.Time `json:"endDate" yaml:"endDate" binding:"required,gtfield=StartDate"`
-	Applications      []Ref     `json:"applications"`
-	Stakeholders      []Ref     `json:"stakeholders"`
-	StakeholderGroups []Ref     `json:"stakeholderGroups" yaml:"stakeholderGroups"`
+	Applications      []Ref     `json:"applications" binding:"dive"`
+	Stakeholders      []Ref     `json:"stakeholders" binding:"dive"`
+	StakeholderGroups []Ref     `json:"stakeholderGroups" yaml:"stakeholderGroups" binding:"dive"`
 }
 
 // Import REST resource.

--- a/shared/api/archetype.go
+++ b/shared/api/archetype.go
@@ -4,7 +4,7 @@ package api
 type TargetProfile struct {
 	Resource        `yaml:",inline"`
 	Name            string `json:"name" binding:"required"`
-	Generators      []Ref  `json:"generators"`
+	Generators      []Ref  `json:"generators" binding:"dive"`
 	AnalysisProfile *Ref   `json:"analysisProfile,omitempty" yaml:"analysisProfile,omitempty"`
 }
 
@@ -14,12 +14,12 @@ type Archetype struct {
 	Name              string          `json:"name" yaml:"name"`
 	Description       string          `json:"description" yaml:"description"`
 	Comments          string          `json:"comments" yaml:"comments"`
-	Tags              []TagRef        `json:"tags" yaml:"tags"`
-	Criteria          []TagRef        `json:"criteria" yaml:"criteria"`
-	Stakeholders      []Ref           `json:"stakeholders" yaml:"stakeholders"`
-	StakeholderGroups []Ref           `json:"stakeholderGroups" yaml:"stakeholderGroups"`
-	Applications      []Ref           `json:"applications" yaml:"applications"`
-	Assessments       []Ref           `json:"assessments" yaml:"assessments"`
+	Tags              []TagRef        `json:"tags" yaml:"tags" binding:"dive"`
+	Criteria          []TagRef        `json:"criteria" yaml:"criteria" binding:"dive"`
+	Stakeholders      []Ref           `json:"stakeholders" yaml:"stakeholders" binding:"dive"`
+	StakeholderGroups []Ref           `json:"stakeholderGroups" yaml:"stakeholderGroups" binding:"dive"`
+	Applications      []Ref           `json:"applications" yaml:"applications" binding:"dive"`
+	Assessments       []Ref           `json:"assessments" yaml:"assessments" binding:"dive"`
 	Assessed          bool            `json:"assessed"`
 	Risk              string          `json:"risk"`
 	Confidence        int             `json:"confidence"`
@@ -37,5 +37,5 @@ type Generator struct {
 	Params      Map         `json:"params"`
 	Values      Map         `json:"values"`
 	Identity    *Ref        `json:"identity,omitempty" yaml:",omitempty"`
-	Profiles    []Ref       `json:"profiles"`
+	Profiles    []Ref       `json:"profiles" binding:"dive"`
 }

--- a/shared/api/archetype.go
+++ b/shared/api/archetype.go
@@ -24,7 +24,7 @@ type Archetype struct {
 	Risk              string          `json:"risk"`
 	Confidence        int             `json:"confidence"`
 	Review            *Ref            `json:"review"`
-	Profiles          []TargetProfile `json:"profiles" yaml:",omitempty"`
+	Profiles          []TargetProfile `json:"profiles" yaml:",omitempty" binding:"dive"`
 }
 
 // Generator REST resource.

--- a/shared/api/assessment.go
+++ b/shared/api/assessment.go
@@ -7,8 +7,8 @@ type Assessment struct {
 	Archetype         *Ref         `json:"archetype,omitempty" yaml:",omitempty" binding:"excluded_with=Application"`
 	Questionnaire     Ref          `json:"questionnaire" binding:"required"`
 	Sections          []Section    `json:"sections" binding:"dive"`
-	Stakeholders      []Ref        `json:"stakeholders"`
-	StakeholderGroups []Ref        `json:"stakeholderGroups" yaml:"stakeholderGroups"`
+	Stakeholders      []Ref        `json:"stakeholders" binding:"dive"`
+	StakeholderGroups []Ref        `json:"stakeholderGroups" yaml:"stakeholderGroups" binding:"dive"`
 	Risk              string       `json:"risk"`
 	Confidence        int          `json:"confidence"`
 	Status            string       `json:"status"`

--- a/shared/api/core.go
+++ b/shared/api/core.go
@@ -152,7 +152,7 @@ type IdpIdentity struct {
 	Name     string   `json:"name"`
 	Email    string   `json:"email"`
 	Scopes   []string `json:"scopes"`
-	Tokens   []Ref    `json:"tokens"`
+	Tokens   []Ref    `json:"tokens" binding:"dive"`
 }
 
 // IdpClient REST resource.
@@ -164,7 +164,7 @@ type IdpClient struct {
 	Grants          []string `json:"grants" binding:"required"`
 	RedirectURIs    []string `json:"redirectURIs,omitempty"`
 	Scopes          []string `json:"scopes" binding:"required"`
-	Tokens          []Ref    `json:"tokens"`
+	Tokens          []Ref    `json:"tokens" binding:"dive"`
 }
 
 // User REST resource.
@@ -175,8 +175,8 @@ type User struct {
 	Name     string `json:"name"`
 	Password string `json:"password" binding:"required,max=72"`
 	Email    string `json:"email" binding:"required"`
-	Roles    []Ref  `json:"roles"`
-	Tokens   []Ref  `json:"tokens"`
+	Roles    []Ref  `json:"roles" binding:"dive"`
+	Tokens   []Ref  `json:"tokens" binding:"dive"`
 }
 
 // ServiceAccount REST resource.
@@ -185,8 +185,8 @@ type ServiceAccount struct {
 	Description string `json:"description,omitempty" yaml:",omitempty"`
 	Subject     string `json:"subject"`
 	Name        string `json:"name" binding:"required"`
-	Roles       []Ref  `json:"roles"`
-	Tokens      []Ref  `json:"tokens"`
+	Roles       []Ref  `json:"roles" binding:"dive"`
+	Tokens      []Ref  `json:"tokens" binding:"dive"`
 }
 
 // Role REST resource.
@@ -215,7 +215,7 @@ type Grant struct {
 	User        *Ref      `json:"user,omitempty" yaml:",omitempty"`
 	IdpIdentity *Ref      `json:"idpIdentity,omitempty" yaml:",omitempty"`
 	IdpClient   *Ref      `json:"idpClient,omitempty" yaml:",omitempty"`
-	Tokens      []Ref     `json:"tokens,omitempty" yaml:",omitempty"`
+	Tokens      []Ref     `json:"tokens,omitempty" yaml:",omitempty" binding:"dive"`
 }
 
 // Token REST resource.

--- a/shared/api/platform.go
+++ b/shared/api/platform.go
@@ -7,7 +7,7 @@ type Platform struct {
 	Name         string `json:"name"`
 	URL          string `json:"url"`
 	Identity     *Ref   `json:"identity,omitempty" yaml:",omitempty"`
-	Applications []Ref  `json:"applications,omitempty" yaml:",omitempty"`
+	Applications []Ref  `json:"applications,omitempty" yaml:",omitempty" binding:"dive"`
 }
 
 // Manifest REST resource.

--- a/shared/api/ruleset.go
+++ b/shared/api/ruleset.go
@@ -9,7 +9,7 @@ type RuleSet struct {
 	Rules       []Rule      `json:"rules"`
 	Repository  *Repository `json:"repository,omitempty"`
 	Identity    *Ref        `json:"identity,omitempty"`
-	DependsOn   []Ref       `json:"dependsOn" yaml:"dependsOn"`
+	DependsOn   []Ref       `json:"dependsOn" yaml:"dependsOn" binding:"dive"`
 }
 
 // Rule - REST Resource.

--- a/shared/api/task.go
+++ b/shared/api/task.go
@@ -63,7 +63,7 @@ type Task struct {
 	Errors      []TaskError  `json:"errors,omitempty" yaml:",omitempty"`
 	Activity    []string     `json:"activity,omitempty" yaml:",omitempty"`
 	Attached    []Attachment `json:"attached" yaml:",omitempty"`
-	Tokens      []Ref        `json:"tokens,omitempty" yaml:",omitempty"`
+	Tokens      []Ref        `json:"tokens,omitempty" yaml:",omitempty" binding:"dive"`
 }
 
 // TaskReport REST resource.

--- a/shared/binding/client/http.go
+++ b/shared/binding/client/http.go
@@ -818,6 +818,10 @@ func (r *Client) restError(response *http.Response) (err error) {
 		return
 	}
 	switch status {
+	case http.StatusBadRequest:
+		restError := &BadRequestError{}
+		restError.With(response)
+		err = restError
 	case http.StatusConflict:
 		restError := &Conflict{}
 		restError.With(response)

--- a/test/binding/identity_test.go
+++ b/test/binding/identity_test.go
@@ -233,7 +233,7 @@ func TestIdentityFind(t *testing.T) {
 	// Create application with first identity
 	application := &api.Application{
 		Name:       "Test App for Identity Find",
-		Identities: []api.IdentityRef{{ID: direct.ID}},
+		Identities: []api.IdentityRef{{ID: direct.ID, Role: "source"}},
 	}
 	err = client.Application.Create(application)
 	g.Expect(err).To(BeNil())

--- a/test/binding/serviceaccount_test.go
+++ b/test/binding/serviceaccount_test.go
@@ -115,6 +115,46 @@ func TestServiceAccount(t *testing.T) {
 	g.Expect(errors.Is(err, &api.NotFound{})).To(BeTrue())
 }
 
+// TestServiceAccountZeroRoleRef verifies that a service account referencing a
+// role with a zero-valued id (id=0) is rejected with 400 (Bad Request) by the
+// binding validation before reaching the database.
+func TestServiceAccountZeroRoleRef(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	// Get available scopes from the hub
+	scopes, err := client.Scope.List()
+	g.Expect(err).To(BeNil())
+	g.Expect(len(scopes)).Should(BeNumerically(">=", 1))
+
+	// Create a valid role to reference alongside the invalid one.
+	role := &api.Role{
+		Name: "sa-zero-role",
+		Scopes: []string{
+			scopes[0].Name,
+		},
+	}
+	err = client.Role.Create(role)
+	g.Expect(err).To(BeNil())
+	t.Cleanup(func() {
+		_ = client.Role.Delete(role.ID)
+	})
+
+	// CREATE: A zero-valued role ref (id=0) must be rejected.
+	sa := &api.ServiceAccount{
+		Name: "zero-role-sa",
+		Roles: []api.Ref{
+			{ID: role.ID},
+			{ID: 0},
+		},
+	}
+	err = client.ServiceAccount.Create(sa)
+	g.Expect(err).ToNot(BeNil())
+	g.Expect(errors.Is(err, &api.BadRequestError{})).To(BeTrue())
+
+	// The service account must not have been created.
+	g.Expect(sa.ID).To(BeZero())
+}
+
 func TestServiceAccountToken(t *testing.T) {
 	g := NewGomegaWithT(t)
 


### PR DESCRIPTION
closes #1124 

Fixes panic/500 in the cache when role not found.

This fixes a systemic issue where (Ref.ID required non-zero) in []Ref not validated.  The `dive` tag needs to be included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid nested references are now validated consistently across applications, assessments, archetypes, identities, roles, tasks, service accounts, grants, and related API resources.
  - Requests with invalid or zero-valued role references now return a clear bad-request error instead of being processed incorrectly.
  - Missing-role errors now identify the originally requested role more reliably.
  - HTTP 400 responses are surfaced as bad-request errors for more consistent client handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->